### PR TITLE
refactor: EVM state correspondence

### DIFF
--- a/juvix/ERC20Resource.juvix
+++ b/juvix/ERC20Resource.juvix
@@ -97,10 +97,10 @@ mkErc20Resource
 {- HELPERS -}
 
 -- TODO FORMAT
-decodeWrapperResourceKindFromLabel (wrappedResource : Resource) : Kind :=
+decodeWrapperResourceKindFromLabel (wrappingResource : Resource) : Kind :=
   let
-    wrapperResourceKind := builtinAnomaDecode (Resource.label wrappedResource);
-  -- TODO remove -- (wrapperResourceKind, _) : Pair Kind Address := builtinAnomaDecode (Resource.label wrappedResource);
+    wrapperResourceKind := builtinAnomaDecode (Resource.label wrappingResource);
+  -- TODO remove -- (wrapperResourceKind, _) : Pair Kind Address := builtinAnomaDecode (Resource.label wrappingResource);
   in wrapperResourceKind;
 
 owner (resource : Resource) : ExternalIdentity :=

--- a/juvix/ERC20WrapperContractResource.juvix
+++ b/juvix/ERC20WrapperContractResource.juvix
@@ -56,7 +56,7 @@ erc20WrapperContractLogic (pub : Instance) (priv : Witness) : Bool :=
         | just self :=
           if
             {- initializing consumption -}
-            | Resource.ephemeral self := initializationLogic
+            | Resource.ephemeral self := false
             {- conventional consumption -}
             | else := true
       }
@@ -73,9 +73,6 @@ erc20WrapperContractLogic (pub : Instance) (priv : Witness) : Bool :=
       }
     | else := false;
 
---- Currently, the protocol adapter can create this resource directly and only once (with a fixed label, logic, value, quantity, and nonce).
---- TODO adapt eventually
-initializationLogic : Bool := false;
 
 creationLogic (self : Resource) (priv : Witness) : Bool :=
   case Witness.consumed priv, Witness.created priv of
@@ -83,14 +80,14 @@ creationLogic (self : Resource) (priv : Witness) : Bool :=
       let
         ((consumedWC, createdWC), consumedERC20, createdERC20) :=
           matchKinds self a b x y;
-        (wrappedResourceKindInSelf, inputWithSelector, output)
+        (wrappingResourceKindInSelf, inputWithSelector, output)
           : Pair Kind (Pair ByteArray ByteArray) :=
           builtinAnomaDecode (Resource.value self);
       in same-kind?
           [
             decodeWrappedResourceKindFromValue consumedWC;
             decodeWrappedResourceKindFromValue createdWC;
-            wrappedResourceKindInSelf;
+            wrappingResourceKindInSelf;
             kind consumedERC20;
             kind createdERC20;
           ]
@@ -161,7 +158,7 @@ checkTransferCompliance
 --- The wrapper logic and value  can be customized to correspond to other EVM state changes.
 mkERC20WrapperContractResource
   (logic : Logic)
-  (wrappedResourceKind : Kind)
+  (wrappingResourceKind : Kind)
   (ffiCall : FfiCall)
   (nonce : Nat)
   {ephemeral : Bool := false}
@@ -171,7 +168,7 @@ mkERC20WrapperContractResource
     label := builtinAnomaEncode (FfiCall.address ffiCall);
     value :=
       builtinAnomaEncode
-        (wrappedResourceKind, FfiCall.input ffiCall, FfiCall.output ffiCall);
+        (wrappingResourceKind, FfiCall.input ffiCall, FfiCall.output ffiCall);
     quantity := 1;
     ephemeral;
     nullifierKeyCommitment :=

--- a/juvix/Helpers.juvix
+++ b/juvix/Helpers.juvix
@@ -84,6 +84,6 @@ isAuthorizedBy
 -- TODO Move
 decodeWrappedResourceKindFromValue (wrapper : Resource) : Kind :=
   let
-    (wrappedResourceKind, _) : Pair Kind (Pair ByteArray ByteArray) :=
+    (wrappingResourceKind, _) : Pair Kind (Pair ByteArray ByteArray) :=
       builtinAnomaDecode (Resource.value wrapper);
-  in wrappedResourceKind;
+  in wrappingResourceKind;

--- a/juvix/Transaction/Wrap.juvix
+++ b/juvix/Transaction/Wrap.juvix
@@ -30,13 +30,13 @@ wrapErc20
         wrapper |> Resource.label |> builtinAnomaDecode |> FfiCall.address;
       wrapperResourceKind := kind wrapper;
 
-      wrappedResourceLabel := builtinAnomaEncode wrapperResourceKind;
-      wrappedResourceKind := kind' erc20ResourceLogic wrappedResourceLabel;
+      wrappingResourceLabel := builtinAnomaEncode wrapperResourceKind;
+      wrappingResourceKind := kind' erc20ResourceLogic wrappingResourceLabel;
 
       updatedWrapper :=
         mkERC20WrapperContractResource@{
           logic := Resource.logic wrapper;
-          wrappedResourceKind;
+          wrappingResourceKind;
           ffiCall :=
             mkFfiCall@{
               address := wrapperContract;

--- a/script/DeployERC20Wrapper.s.sol
+++ b/script/DeployERC20Wrapper.s.sol
@@ -16,13 +16,13 @@ contract DeployWrapper is BaseScript {
 
     function run() public broadcast {
         bytes32 wrapperLogicRef; // TODO
-        bytes32 wrappedKind; // TODO
+        bytes32 wrappingKind; // TODO
 
         ERC20Wrapper wrapper = new ERC20Wrapper{ salt: ZERO_SALT }({
             protocolAdapter: address(PROTOCOL_ADAPTER),
             erc20: ERC20,
             wrapperLogicRef: wrapperLogicRef,
-            wrappedKind: wrappedKind
+            wrappingKind: wrappingKind
         });
 
         PROTOCOL_ADAPTER.createWrapperContractResource({ untrustedWrapperContract: wrapper });

--- a/src/ERC20Wrapper.sol
+++ b/src/ERC20Wrapper.sol
@@ -18,9 +18,9 @@ contract ERC20Wrapper is Ownable, WrapperBase {
         address protocolAdapter,
         address erc20,
         bytes32 wrapperLogicRef,
-        bytes32 wrappedKind
+        bytes32 wrappingKind
     )
-        WrapperBase(protocolAdapter, wrapperLogicRef, wrappedKind)
+        WrapperBase(protocolAdapter, wrapperLogicRef, wrappingKind)
     {
         if (erc20 == address(0)) revert ZeroAddressNotAllowed();
         _ERC20_CONTRACT = erc20;

--- a/src/ERC20Wrapper.sol
+++ b/src/ERC20Wrapper.sol
@@ -27,7 +27,7 @@ contract ERC20Wrapper is Ownable, WrapperBase {
     }
 
     // TODO make generic proxy, allow native ETH transfers
-    function _ffiCall(bytes calldata input) internal override returns (bytes memory output) {
+    function _forwardCall(bytes calldata input) internal override returns (bytes memory output) {
         output = _ERC20_CONTRACT.functionCall(input);
     }
 

--- a/src/ProtocolAdapter.sol
+++ b/src/ProtocolAdapter.sol
@@ -105,9 +105,9 @@ contract ProtocolAdapter is
                 newRoot = _addCommitmentUnchecked(action.commitments[j]);
             }
 
-            m = action.ffiCalls.length;
+            m = action.wrapperResourceFFICallPairs.length;
             for (j = 0; j < m; ++j) {
-                _executeFFICall(action.ffiCalls[j]);
+                _executeFFICall(action.wrapperResourceFFICallPairs[j].ffiCall);
             }
         }
 
@@ -324,13 +324,14 @@ contract ProtocolAdapter is
     }
 
     function _verifyFFICalls(Action calldata action) internal view {
-        uint256 len = action.ffiCalls.length;
+        uint256 len = action.wrapperResourceFFICallPairs.length;
         for (uint256 j; j < len; ++j) {
-            FFICall calldata ffiCall = action.ffiCalls[j];
+            Resource calldata wrapperResource = action.wrapperResourceFFICallPairs[j].wrapperResource;
+            FFICall calldata ffiCall = action.wrapperResourceFFICallPairs[j].ffiCall;
 
             // Kind integrity check
             {
-                bytes32 passedKind = ffiCall.wrapperResource.kind();
+                bytes32 passedKind = wrapperResource.kind();
 
                 bytes32 fetchedKind = UntrustedWrapper(ffiCall.untrustedWrapperContract).wrapperResourceKind();
 
@@ -345,7 +346,7 @@ contract ProtocolAdapter is
                     keccak256(abi.encode(ffiCall.untrustedWrapperContract, ffiCall.input, ffiCall.output));
 
                 bytes32 actualAppDataHash =
-                    keccak256(action.tagAppDataPairs.lookup({ tag: ffiCall.wrapperResource.commitment() }).blob);
+                    keccak256(action.tagAppDataPairs.lookup({ tag: wrapperResource.commitment() }).blob);
 
                 if (actualAppDataHash != expectedAppDataHash) {
                     revert WrapperResourceAppDataMismatch({ actual: actualAppDataHash, expected: expectedAppDataHash });

--- a/src/ProtocolAdapter.sol
+++ b/src/ProtocolAdapter.sol
@@ -21,11 +21,10 @@ import { Delta } from "./proving/Delta.sol";
 import { LogicInstance, LogicProofs, TagLogicProofPair, LogicRefProofPair } from "./proving/Logic.sol";
 
 import { BlobStorage, DeletionCriterion, ExpirableBlob } from "./state/BlobStorage.sol";
-import { CommitmentAccumulator as CommitmentAccumulator } from "./state/CommitmentAccumulator.sol";
-// TODO import { CommitmentAccumulator } from "./state/CommitmentAccumulator.sol";
+import { CommitmentAccumulator } from "./state/CommitmentAccumulator.sol";
 import { NullifierSet } from "./state/NullifierSet.sol";
 
-import { Action, FFICall, KindFFICallPair, Resource, TagAppDataPair, Transaction } from "./Types.sol";
+import { Action, FFICall, Resource, TagAppDataPair, Transaction } from "./Types.sol";
 
 contract ProtocolAdapter is
     IProtocolAdapter,

--- a/src/ProtocolAdapter.sol
+++ b/src/ProtocolAdapter.sol
@@ -127,7 +127,7 @@ contract ProtocolAdapter is
     // TODO Consider DoS attacks https://detectors.auditbase.com/avoid-external-calls-in-unbounded-loops-solidity
     // slither-disable-next-line calls-loop
     function _executeFFICall(FFICall calldata ffiCall) internal {
-        bytes memory output = UntrustedWrapper(ffiCall.untrustedWrapperContract).ffiCall(ffiCall.input);
+        bytes memory output = UntrustedWrapper(ffiCall.untrustedWrapperContract).forwardCall(ffiCall.input);
 
         if (keccak256(output) != keccak256(ffiCall.output)) {
             revert FFICallOutputMismatch({ expected: ffiCall.output, actual: output });

--- a/src/Types.sol
+++ b/src/Types.sol
@@ -28,11 +28,15 @@ struct Action {
     TagLogicProofPair[] logicProofs;
     ComplianceUnit[] complianceUnits;
     TagAppDataPair[] tagAppDataPairs;
-    FFICall[] ffiCalls;
+    WrapperFFICallPair[] wrapperResourceFFICallPairs;
+}
+
+struct WrapperFFICallPair {
+    Resource wrapperResource;
+    FFICall ffiCall;
 }
 
 struct FFICall {
-    Resource wrapperResource;
     address untrustedWrapperContract;
     bytes input;
     bytes output;

--- a/src/Types.sol
+++ b/src/Types.sol
@@ -39,7 +39,6 @@ struct KindFFICallPair {
 
 struct FFICall {
     address untrustedWrapperContract;
-    //bytes4 functionSelector; // TODO add?
     bytes input;
     bytes output;
 }

--- a/src/Types.sol
+++ b/src/Types.sol
@@ -28,10 +28,10 @@ struct Action {
     TagLogicProofPair[] logicProofs;
     ComplianceUnit[] complianceUnits;
     TagAppDataPair[] tagAppDataPairs;
-    WrapperFFICallPair[] wrapperResourceFFICallPairs;
+    WrapperResourceFFICallPair[] wrapperResourceFFICallPairs;
 }
 
-struct WrapperFFICallPair {
+struct WrapperResourceFFICallPair {
     Resource wrapperResource;
     FFICall ffiCall;
 }

--- a/src/Types.sol
+++ b/src/Types.sol
@@ -28,16 +28,11 @@ struct Action {
     TagLogicProofPair[] logicProofs;
     ComplianceUnit[] complianceUnits;
     TagAppDataPair[] tagAppDataPairs;
-    KindFFICallPair[] kindFFICallPairs; // NOTE: This saves us from doing the subset check.
-        // FFICall[] ffiCalls;
-}
-
-struct KindFFICallPair {
-    bytes32 kind;
-    FFICall ffiCall;
+    FFICall[] ffiCalls;
 }
 
 struct FFICall {
+    Resource wrapperResource;
     address untrustedWrapperContract;
     bytes input;
     bytes output;

--- a/src/WrapperBase.sol
+++ b/src/WrapperBase.sol
@@ -19,15 +19,15 @@ abstract contract WrapperBase is IWrapper, Ownable {
     bytes32 internal immutable _WRAPPER_RESOURCE_KIND;
 
     /// @notice The EVM state wrapping resource kind.
-    bytes32 internal immutable _WRAPPED_RESOURCE_KIND;
+    bytes32 internal immutable _WRAPPING_RESOURCE_KIND;
 
-    constructor(address protocolAdapter, bytes32 wrapperLogicRef, bytes32 wrappedKind) Ownable(protocolAdapter) {
+    constructor(address protocolAdapter, bytes32 wrapperLogicRef, bytes32 wrappingKind) Ownable(protocolAdapter) {
         _WRAPPER_RESOURCE_LOGIC_REF = wrapperLogicRef;
         _WRAPPER_RESOURCE_LABEL_REF = sha256(abi.encode(address(this)));
         _WRAPPER_RESOURCE_KIND =
             ComputableComponents.kind({ logicRef: _WRAPPER_RESOURCE_LOGIC_REF, labelRef: _WRAPPER_RESOURCE_LABEL_REF });
 
-        _WRAPPED_RESOURCE_KIND = wrappedKind;
+        _WRAPPING_RESOURCE_KIND = wrappingKind;
     }
 
     function ffiCall(bytes calldata input) external onlyOwner returns (bytes memory output) {
@@ -50,8 +50,8 @@ abstract contract WrapperBase is IWrapper, Ownable {
     }
 
     /// @inheritdoc IWrapper
-    function wrappedResourceKind() external view returns (bytes32 wrappedKind) {
-        wrappedKind = _WRAPPED_RESOURCE_KIND;
+    function wrappingResourceKind() external view returns (bytes32 wrappingKind) {
+        wrappingKind = _WRAPPING_RESOURCE_KIND;
     }
 
     function _ffiCall(bytes calldata input) internal virtual returns (bytes memory output);

--- a/src/WrapperBase.sol
+++ b/src/WrapperBase.sol
@@ -30,8 +30,8 @@ abstract contract WrapperBase is IWrapper, Ownable {
         _WRAPPING_RESOURCE_KIND = wrappingKind;
     }
 
-    function ffiCall(bytes calldata input) external onlyOwner returns (bytes memory output) {
-        output = _ffiCall(input);
+    function forwardCall(bytes calldata input) external onlyOwner returns (bytes memory output) {
+        output = _forwardCall(input);
     }
 
     /// @inheritdoc IWrapper
@@ -54,5 +54,5 @@ abstract contract WrapperBase is IWrapper, Ownable {
         wrappingKind = _WRAPPING_RESOURCE_KIND;
     }
 
-    function _ffiCall(bytes calldata input) internal virtual returns (bytes memory output);
+    function _forwardCall(bytes calldata input) internal virtual returns (bytes memory output);
 }

--- a/src/interfaces/IWrapper.sol
+++ b/src/interfaces/IWrapper.sol
@@ -22,6 +22,6 @@ interface IWrapper {
     function wrapperResourceKind() external view returns (bytes32 wrapperKind);
 
     /// @notice Returns the kind of the resource this contract is wrapping EVM state in.
-    /// @return wrappedKind The wrapped resource kind.
-    function wrappedResourceKind() external view returns (bytes32 wrappedKind);
+    /// @return wrappingKind The wrapping resource kind.
+    function wrappingResourceKind() external view returns (bytes32 wrappingKind);
 }

--- a/src/interfaces/IWrapper.sol
+++ b/src/interfaces/IWrapper.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.27;
 interface IWrapper {
     // TODO add events
 
-    /// @notice Conducts an external call to read or write EVM state.
+    /// @notice Forwards an external call to read or write EVM state.
     /// @param input The `bytes` encoded calldata (including the `bytes4` function selector).
     /// @return output The `bytes` encoded output of the call.
-    function ffiCall(bytes memory input) external returns (bytes memory output);
+    function forwardCall(bytes memory input) external returns (bytes memory output);
 
     /// @notice Returns the binding reference to the logic of the wrapper contract resource.
     /// @return wrapperLogicRef The binding logic reference.

--- a/src/libs/Reference.sol
+++ b/src/libs/Reference.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.27;
 
 library Reference {
     function toRef(address addr) internal pure returns (bytes32 ref) {
-        ref = sha256(abi.encode(addr)); //sha256(abi.encode(wrappedResourceKind, wrapperContract));
+        ref = sha256(abi.encode(addr));
     }
 
     function toRef(bytes calldata data) internal pure returns (bytes32 ref) {
-        ref = sha256(data); //sha256(abi.encode(wrappedResourceKind, wrapperContract));
+        ref = sha256(data);
     }
 
     function toRefCalldata(bytes memory data) internal pure returns (bytes32 ref) {
-        ref = sha256(data); //sha256(abi.encode(wrappedResourceKind, wrapperContract));
+        ref = sha256(data);
     }
 }

--- a/test/mocks/MockTypes.sol
+++ b/test/mocks/MockTypes.sol
@@ -13,7 +13,7 @@ import { Delta } from "../../src/proving/Delta.sol";
 import { LogicInstance, TagLogicProofPair, LogicRefProofPair } from "../../src/proving/Logic.sol";
 
 import { ExpirableBlob, DeletionCriterion } from "../../src/state/BlobStorage.sol";
-import { Action, FFICall, WrapperFFICallPair, Resource, Transaction } from "../../src/Types.sol";
+import { Action, WrapperFFICallPair, Resource, Transaction } from "../../src/Types.sol";
 
 import { MockDelta } from "../mocks/MockDelta.sol";
 import { MockRiscZeroProof } from "../mocks/MockRiscZeroProof.sol";

--- a/test/mocks/MockTypes.sol
+++ b/test/mocks/MockTypes.sol
@@ -13,7 +13,7 @@ import { Delta } from "../../src/proving/Delta.sol";
 import { LogicInstance, TagLogicProofPair, LogicRefProofPair } from "../../src/proving/Logic.sol";
 
 import { ExpirableBlob, DeletionCriterion } from "../../src/state/BlobStorage.sol";
-import { Action, WrapperFFICallPair, Resource, Transaction } from "../../src/Types.sol";
+import { Action, WrapperResourceFFICallPair, Resource, Transaction } from "../../src/Types.sol";
 
 import { MockDelta } from "../mocks/MockDelta.sol";
 import { MockRiscZeroProof } from "../mocks/MockRiscZeroProof.sol";
@@ -88,7 +88,7 @@ library MockTypes {
             ComplianceUnit[] memory complianceUnits =
                 mockComplianceUnits({ mockVerifier: mockVerifier, root: roots[0], commitments: cms, nullifiers: nfs });
 
-            WrapperFFICallPair[] memory emptyWrapperFfiCalls;
+            WrapperResourceFFICallPair[] memory emptyWrapperFfiCalls;
 
             actions[a] = Action({
                 commitments: cms,

--- a/test/mocks/MockTypes.sol
+++ b/test/mocks/MockTypes.sol
@@ -13,7 +13,7 @@ import { Delta } from "../../src/proving/Delta.sol";
 import { LogicInstance, TagLogicProofPair, LogicRefProofPair } from "../../src/proving/Logic.sol";
 
 import { ExpirableBlob, DeletionCriterion } from "../../src/state/BlobStorage.sol";
-import { Action, FFICall, Resource, Transaction } from "../../src/Types.sol";
+import { Action, FFICall, WrapperFFICallPair, Resource, Transaction } from "../../src/Types.sol";
 
 import { MockDelta } from "../mocks/MockDelta.sol";
 import { MockRiscZeroProof } from "../mocks/MockRiscZeroProof.sol";
@@ -88,7 +88,7 @@ library MockTypes {
             ComplianceUnit[] memory complianceUnits =
                 mockComplianceUnits({ mockVerifier: mockVerifier, root: roots[0], commitments: cms, nullifiers: nfs });
 
-            FFICall[] memory emptyFfiCalls;
+            WrapperFFICallPair[] memory emptyWrapperFfiCalls;
 
             actions[a] = Action({
                 commitments: cms,
@@ -96,7 +96,7 @@ library MockTypes {
                 logicProofs: rlProofs,
                 complianceUnits: complianceUnits,
                 tagAppDataPairs: appData,
-                ffiCalls: emptyFfiCalls
+                wrapperResourceFFICallPairs: emptyWrapperFfiCalls
             });
         }
 

--- a/test/mocks/MockTypes.sol
+++ b/test/mocks/MockTypes.sol
@@ -13,7 +13,7 @@ import { Delta } from "../../src/proving/Delta.sol";
 import { LogicInstance, TagLogicProofPair, LogicRefProofPair } from "../../src/proving/Logic.sol";
 
 import { ExpirableBlob, DeletionCriterion } from "../../src/state/BlobStorage.sol";
-import { Action, KindFFICallPair, Resource, Transaction } from "../../src/Types.sol";
+import { Action, FFICall, Resource, Transaction } from "../../src/Types.sol";
 
 import { MockDelta } from "../mocks/MockDelta.sol";
 import { MockRiscZeroProof } from "../mocks/MockRiscZeroProof.sol";
@@ -88,7 +88,7 @@ library MockTypes {
             ComplianceUnit[] memory complianceUnits =
                 mockComplianceUnits({ mockVerifier: mockVerifier, root: roots[0], commitments: cms, nullifiers: nfs });
 
-            KindFFICallPair[] memory emptyFfiCalls;
+            FFICall[] memory emptyFfiCalls;
 
             actions[a] = Action({
                 commitments: cms,
@@ -96,7 +96,7 @@ library MockTypes {
                 logicProofs: rlProofs,
                 complianceUnits: complianceUnits,
                 tagAppDataPairs: appData,
-                kindFFICallPairs: emptyFfiCalls
+                ffiCalls: emptyFfiCalls
             });
         }
 

--- a/test/state/NullifierSet.t.sol
+++ b/test/state/NullifierSet.t.sol
@@ -40,14 +40,14 @@ contract NullifierSetTest is Test {
         _nfSet.addNullifierUnchecked(_EXAMPLE_NF);
     }
 
-    function test_checkNullifierNonExistence_passes_on_non_existent_nullifier() public view {
-        _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
-    }
-
     function test_checkNullifierNonExistence_reverts_on_existent_nullifier() public {
         _nfSet.addNullifier(_EXAMPLE_NF);
 
         vm.expectRevert(abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF));
+        _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
+    }
+
+    function test_checkNullifierNonExistence_passes_on_non_existent_nullifier() public view {
         _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
     }
 }


### PR DESCRIPTION
This PR refactors the state correspondence design by
- renaming `wrappedResource` to `wrappingResource`
- requiring the `wrapperResource` object to be passed to the protocol adapter together with the `FFICall` data