### PR TITLE
feat(MerkleTree): use the non-commutative sha256 hash function and add direction bits to the Merkle proof

### DIFF
--- a/src/interfaces/ICommitmentAccumulator.sol
+++ b/src/interfaces/ICommitmentAccumulator.sol
@@ -32,9 +32,5 @@ interface ICommitmentAccumulator {
     /// @param commitment The commitment leaf to proof inclusion in the tree for.
     /// @return siblings The siblings constituting the path from the leaf to the root.
     /// @return directionBits The direction bits for the proof.
-    /// @return root The root associated with the Merkle proof.
-    function merkleProof(bytes32 commitment)
-        external
-        view
-        returns (bytes32[] memory siblings, uint256 directionBits, bytes32 root);
+    function merkleProof(bytes32 commitment) external view returns (bytes32[] memory siblings, uint256 directionBits);
 }

--- a/src/interfaces/ICommitmentAccumulator.sol
+++ b/src/interfaces/ICommitmentAccumulator.sol
@@ -14,14 +14,28 @@ interface ICommitmentAccumulator {
     /// @return isContained Whether the root exists or not.
     function containsRoot(bytes32 root) external view returns (bool isContained);
 
-    /// @notice Verifies a that a Merkle path (proof) and a commitment reproduces the given root.
+    /// @notice Verifies a that a Merkle path (proof) and a commitment leaf reproduces the given root.
     /// @param root The root to reproduce.
     /// @param commitment The commitment leaf to proof inclusion in the tree for.
-    /// @param root The siblings constituting the path from the leaf to the root.
-    function verifyMerkleProof(bytes32 root, bytes32 commitment, bytes32[] calldata path) external view;
+    /// @param path The siblings constituting the path from the leaf to the root.
+    /// @param directionBits The direction bits for the proof.
 
-    /// @notice Returns the Merkle proof and associated root for a commitment in the tree.
-    /// @return proof The Merkle proof.
+    function verifyMerkleProof(
+        bytes32 root,
+        bytes32 commitment,
+        bytes32[] calldata path,
+        uint256 directionBits
+    )
+        external
+        view;
+
+    /// @notice Returns the Merkle proof and associated root for a commitment leaf in the tree.
+    /// @param commitment The commitment leaf to proof inclusion in the tree for.
+    /// @return path The siblings constituting the path from the commitment leaf to the root.
+    /// @return directionBits The direction bits for the proof.
     /// @return root The root associated with the Merkle proof.
-    function merkleProof(bytes32 commitment) external view returns (bytes32[] memory proof, bytes32 root);
+    function merkleProof(bytes32 commitment)
+        external
+        view
+        returns (bytes32[] memory path, uint256 directionBits, bytes32 root);
 }

--- a/src/interfaces/ICommitmentAccumulator.sol
+++ b/src/interfaces/ICommitmentAccumulator.sol
@@ -17,13 +17,12 @@ interface ICommitmentAccumulator {
     /// @notice Verifies a that a Merkle path (proof) and a commitment leaf reproduces the given root.
     /// @param root The root to reproduce.
     /// @param commitment The commitment leaf to proof inclusion in the tree for.
-    /// @param path The siblings constituting the path from the leaf to the root.
-    /// @param directionBits The direction bits for the proof.
-
+    /// @param siblings The siblings constituting the path from the leaf to the root.
+    /// @param directionBits The direction bits indicating whether the siblings are left of right.
     function verifyMerkleProof(
         bytes32 root,
         bytes32 commitment,
-        bytes32[] calldata path,
+        bytes32[] calldata siblings,
         uint256 directionBits
     )
         external
@@ -31,11 +30,11 @@ interface ICommitmentAccumulator {
 
     /// @notice Returns the Merkle proof and associated root for a commitment leaf in the tree.
     /// @param commitment The commitment leaf to proof inclusion in the tree for.
-    /// @return path The siblings constituting the path from the commitment leaf to the root.
+    /// @return siblings The siblings constituting the path from the leaf to the root.
     /// @return directionBits The direction bits for the proof.
     /// @return root The root associated with the Merkle proof.
     function merkleProof(bytes32 commitment)
         external
         view
-        returns (bytes32[] memory path, uint256 directionBits, bytes32 root);
+        returns (bytes32[] memory siblings, uint256 directionBits, bytes32 root);
 }

--- a/src/libs/SHA256.sol
+++ b/src/libs/SHA256.sol
@@ -6,11 +6,7 @@ library SHA256 {
         ha = sha256(abi.encode(a));
     }
 
-    function hash(bytes32 a, bytes32 b) internal pure returns (bytes32 hab) {
+    function hash2(bytes32 a, bytes32 b) internal pure returns (bytes32 hab) {
         hab = sha256(abi.encode(a, b));
-    }
-
-    function commutativeHash(bytes32 a, bytes32 b) internal pure returns (bytes32 habOrBa) {
-        habOrBa = a < b ? hash(a, b) : hash(b, a);
     }
 }

--- a/src/libs/SHA256.sol
+++ b/src/libs/SHA256.sol
@@ -6,7 +6,7 @@ library SHA256 {
         ha = sha256(abi.encode(a));
     }
 
-    function hash2(bytes32 a, bytes32 b) internal pure returns (bytes32 hab) {
+    function hash(bytes32 a, bytes32 b) internal pure returns (bytes32 hab) {
         hab = sha256(abi.encode(a, b));
     }
 }

--- a/src/state/CommitmentAccumulator.sol
+++ b/src/state/CommitmentAccumulator.sol
@@ -2,16 +2,14 @@
 pragma solidity ^0.8.27;
 
 import { Arrays } from "@openzeppelin-contracts/utils/Arrays.sol";
-import { MerkleProof } from "@openzeppelin-contracts/utils/cryptography/MerkleProof.sol";
 import { EnumerableSet } from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
-import { SHA256 } from "../../src/libs/SHA256.sol";
 import { ICommitmentAccumulator } from "../interfaces/ICommitmentAccumulator.sol";
 import { MerkleTree } from "./MerkleTree.sol";
 
 contract CommitmentAccumulator is ICommitmentAccumulator {
     using MerkleTree for MerkleTree.Tree;
-    using MerkleProof for bytes32[];
+    using MerkleTree for bytes32[];
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using Arrays for bytes32[];
 
@@ -49,12 +47,26 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         isContained = _containsRoot(root);
     }
 
-    function verifyMerkleProof(bytes32 root, bytes32 commitment, bytes32[] calldata path) external view override {
-        _verifyMerkleProof({ root: root, commitment: commitment, path: path });
+    function verifyMerkleProof(
+        bytes32 root,
+        bytes32 commitment,
+        bytes32[] calldata path,
+        uint256 directionBits
+    )
+        external
+        view
+        override
+    {
+        _verifyMerkleProof({ root: root, commitment: commitment, path: path, directionBits: directionBits });
     }
 
-    function merkleProof(bytes32 commitment) external view override returns (bytes32[] memory proof, bytes32 root) {
-        (proof, root) = _merkleProof(commitment);
+    function merkleProof(bytes32 commitment)
+        external
+        view
+        override
+        returns (bytes32[] memory proof, uint256 directionBits, bytes32 root)
+    {
+        (proof, directionBits, root) = _merkleProof(commitment);
     }
 
     function _addCommitmentUnchecked(bytes32 commitment) internal returns (bytes32 newRoot) {
@@ -77,27 +89,39 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         emit RootAdded(root);
     }
 
-    function _verifyMerkleProof(bytes32 root, bytes32 commitment, bytes32[] calldata path) internal view {
+    function _verifyMerkleProof(
+        bytes32 root,
+        bytes32 commitment,
+        bytes32[] calldata path,
+        uint256 directionBits
+    )
+        internal
+        view
+    {
         // Check length.
-        uint256 pathLength = path.length;
-        uint256 treeDepth = _merkleTree.depth();
-        if (pathLength != treeDepth) {
-            revert InvalidPathLength({ expected: treeDepth, actual: pathLength });
+        if (path.length != _merkleTree.depth()) {
+            revert InvalidPathLength({ expected: _merkleTree.depth(), actual: path.length });
         }
 
         // Check root existence.
         if (!_roots.contains(root)) revert NonExistingRoot(root);
 
-        // Check that the leaf and path reproduce the root.
-        bytes32 computedRoot = path.processProof(commitment, SHA256.commutativeHash);
+        // Check that the commitment leaf and path reproduce the root.
+        bytes32 computedRoot = path.processProof(directionBits, commitment);
+
         if (root != computedRoot) {
             revert InvalidRoot({ expected: root, actual: computedRoot });
         }
     }
 
-    function _merkleProof(bytes32 commitment) internal view returns (bytes32[] memory proof, bytes32 root) {
+    function _merkleProof(bytes32 commitment)
+        internal
+        view
+        returns (bytes32[] memory proof, uint256 directionBits, bytes32 root)
+    {
         uint256 leafIndex = _findCommitmentIndex(commitment);
-        (proof, root) = (_merkleTree.merkleProof(leafIndex), _latestRoot());
+        (proof, directionBits) = (_merkleTree.merkleProof(leafIndex));
+        root = _latestRoot();
     }
 
     function _isContained(bytes32 commitment) internal view returns (bool isContained) {

--- a/src/state/CommitmentAccumulator.sol
+++ b/src/state/CommitmentAccumulator.sol
@@ -64,9 +64,9 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         external
         view
         override
-        returns (bytes32[] memory proof, uint256 directionBits, bytes32 root)
+        returns (bytes32[] memory proof, uint256 directionBits)
     {
-        (proof, directionBits, root) = _merkleProof(commitment);
+        (proof, directionBits) = _merkleProof(commitment);
     }
 
     function _addCommitmentUnchecked(bytes32 commitment) internal returns (bytes32 newRoot) {
@@ -114,14 +114,9 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         }
     }
 
-    function _merkleProof(bytes32 commitment)
-        internal
-        view
-        returns (bytes32[] memory proof, uint256 directionBits, bytes32 root)
-    {
+    function _merkleProof(bytes32 commitment) internal view returns (bytes32[] memory proof, uint256 directionBits) {
         uint256 leafIndex = _findCommitmentIndex(commitment);
         (proof, directionBits) = (_merkleTree.merkleProof(leafIndex));
-        root = _latestRoot();
     }
 
     function _isContained(bytes32 commitment) internal view returns (bool isContained) {

--- a/src/state/MerkleTree.sol
+++ b/src/state/MerkleTree.sol
@@ -5,6 +5,8 @@ import { Arrays } from "@openzeppelin-contracts/utils/Arrays.sol";
 
 import { SHA256 } from "../libs/SHA256.sol";
 
+/// @notice A Merkle tree implementation populating a tree of variable depth from left to right
+/// and providing on-chain Merkle proofs.
 /// @dev This is a modified version of the OpenZeppelin `MerkleTree` and `MerkleProof` implementation.
 /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.2.0/contracts/utils/structs/MerkleTree.sol
 /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.2.0/contracts/utils/cryptography/MerkleProof.sol
@@ -15,12 +17,18 @@ library MerkleTree {
         bytes32[] _zeros;
     }
 
+    /// @notice The hash representing the empty leaf that is not expected to be part of the tree.
     /// @dev Obtained from `sha256("EMPTY_LEAF")`.
     bytes32 internal constant _EMPTY_LEAF_HASH = 0x283d1bb3a401a7e0302d0ffb9102c8fc1f4730c2715a2bfd46a9d9209d5965e0;
 
     error TreeCapacityExceeded();
     error NonExistentLeafIndex(uint256 index);
 
+    /// @notice Sets up the tree with a capacity (i.e. number of leaves) of `2**treeDepth`
+    /// and computes the initial root of the empty tree.
+    /// @param self The tree data structure.
+    /// @param treeDepth The tree depth [0, 255].
+    /// @return initialRoot The initial root of the empty tree.
     function setup(Tree storage self, uint8 treeDepth) internal returns (bytes32 initialRoot) {
         Arrays.unsafeSetLength(self._zeros, treeDepth);
 
@@ -36,30 +44,38 @@ library MerkleTree {
         self._nextLeafIndex = 0;
     }
 
+    /// @notice Pushes a leaf to the tree.
+    /// @param self The tree data structure.
+    /// @param leaf The leaf to add.
+    /// @return index The index of the leaf.
+    /// @return newRoot The new root of the tree.
     function push(Tree storage self, bytes32 leaf) internal returns (uint256 index, bytes32 newRoot) {
-        // Cache read
+        // Cache the tree depth read.
         uint256 treeDepth = depth(self);
 
-        // Get leaf index.
+        // Get the next leaf index and increment it after assignment.
         // solhint-disable-next-line gas-increment-by-one
         index = self._nextLeafIndex++;
 
-        // Check if tree is full.
+        // Check if the tree is already full.
         if (index + 1 > 1 << treeDepth) revert TreeCapacityExceeded();
 
-        // Rebuild branch from leaf to root.
+        // Rebuild the branch from leaf to root.
         uint256 currentIndex = index;
         bytes32 currentLevelHash = leaf;
         for (uint256 i = 0; i < treeDepth; ++i) {
-            // Store the current node
+            // Store the node hash of depth `i`.
             self._nodes[i][currentIndex] = currentLevelHash;
 
-            // Reaching the parent node, is currentLevelHash the left child?
-            if (isLeftIndex(currentIndex)) {
-                // Left sibling
-                currentLevelHash = SHA256.hash(currentLevelHash, self._zeros[i]);
+            // Compute the next level hash for depth `i+i`.
+            // Check whether the `currentIndex` node is the left or right child of its parent.
+            if (isLeftChild(currentIndex)) {
+                // Compute the `currentLevelHash` using the right sibling,
+                // Because we fill the tree from left to right, this is the zero hash at depth `i`.
+                currentLevelHash = SHA256.hash(currentLevelHash, Arrays.unsafeAccess(self._zeros, i).value);
             } else {
-                // Right sibling
+                // Compute the `currentLevelHash` using the left sibling.
+                // Because we fill the tree from left to right, this is the previous node at depth `i`.
                 currentLevelHash = SHA256.hash(self._nodes[i][currentIndex - 1], currentLevelHash);
             }
 
@@ -68,56 +84,87 @@ library MerkleTree {
         newRoot = currentLevelHash;
     }
 
+    /// @notice Computes a Merkle proof consisting of the sibling at each depth and the associated direction bit
+    /// indicating whether the sibling is left (0) or right (1) at the respective depth.
+    /// @param self The tree data structure.
+    /// @param index The index of the leaf.
+    /// @return siblings The siblings of the leaf to proof inclusion for.
+    /// @return directionBits The direction bits indicating whether the siblings are left of right.
     function merkleProof(
         Tree storage self,
         uint256 index
     )
         internal
         view
-        returns (bytes32[] memory proof, uint256 directionBits)
+        returns (bytes32[] memory siblings, uint256 directionBits)
     {
         uint256 treeDepth = depth(self);
 
+        // Check whether the index exists or not.
         if (index + 1 > self._nextLeafIndex) revert NonExistentLeafIndex(index);
 
-        proof = new bytes32[](treeDepth);
+        siblings = new bytes32[](treeDepth);
         uint256 currentIndex = index;
+        bytes32 currentSibling;
 
-        bytes32 sibling;
-        bytes32 empty = 0;
-
-        directionBits = 0;
+        // Iterate over the different tree levels starting at the bottom at the leaf level.
         for (uint256 i = 0; i < treeDepth; ++i) {
-            if (isLeftIndex(currentIndex)) {
-                // Sibling is right
-                sibling = self._nodes[i][currentIndex + 1];
-                // Set the bit at position i to 1.
+            // Check if the current node the left or right child of its parent.
+            if (isLeftChild(currentIndex)) {
+                // Sibling is right.
+                currentSibling = self._nodes[i][currentIndex + 1];
+
+                // Set the direction bit at position `i` to 1.
                 directionBits |= (1 << i);
             } else {
-                // Sibling is left
-                sibling = self._nodes[i][currentIndex - 1];
-                // Leave the bit at position i as 0.
-            }
-            proof[i] = sibling == empty ? self._zeros[i] : sibling;
+                // Sibling is left.
+                currentSibling = self._nodes[i][currentIndex - 1];
 
+                // Leave the direction bit at position `i` as 0.
+            }
+
+            // Check if the sibling is an empty subtree.
+            if (currentSibling == bytes32(0)) {
+                // The subtree node doesn't exist, so we store the zero hash instead.
+                siblings[i] = Arrays.unsafeAccess(self._zeros, i).value;
+            } else {
+                // The subtree node exists, so we store it.
+                siblings[i] = currentSibling;
+            }
+
+            // Shift the number one bit to the right to drop the last binary digit.
             currentIndex >>= 1;
         }
     }
 
+    /// @notice Returns the tree depth.
+    /// @param self The tree data structure.
+    /// @return treeDepth The depth of the tree.
     function depth(Tree storage self) internal view returns (uint256 treeDepth) {
         treeDepth = self._zeros.length;
     }
 
-    function leafCount(Tree storage self) internal view returns (uint256 numberOfLeafs) {
-        numberOfLeafs = self._nextLeafIndex;
+    /// @notice Returns the number of leafs that have been added to the tree.
+    /// @param self The tree data structure.
+    /// @return count The number of leaves in the tree.
+    function leafCount(Tree storage self) internal view returns (uint256 count) {
+        count = self._nextLeafIndex;
     }
 
-    function isLeftIndex(uint256 index) internal pure returns (bool isLeft) {
+    /// @notice Checks whether a node is the left or right child according to its index.
+    /// @param index The index to check.
+    /// @return isLeft Whether this node is the left or right child.
+    function isLeftChild(uint256 index) internal pure returns (bool isLeft) {
         isLeft = index & 1 == 0;
     }
 
+    /// @notice Processes a Merkle proof consisting of siblings and direction bits and returns the resulting root.
+    /// @param siblings The siblings.
+    /// @param directionBits The direction bits indicating whether the siblings are left of right.
+    /// @param leaf The leaf.
+    /// @return root The resulting root obtained by processing the leaf, siblings, and direction bits.
     function processProof(
-        bytes32[] memory path,
+        bytes32[] memory siblings,
         uint256 directionBits,
         bytes32 leaf
     )
@@ -127,19 +174,23 @@ library MerkleTree {
     {
         bytes32 computedHash = leaf;
 
-        uint256 treeDepth = path.length;
+        uint256 treeDepth = siblings.length;
         for (uint256 i = 0; i < treeDepth; ++i) {
             if (isLeftSibling(directionBits, i)) {
                 // Left sibling
-                computedHash = SHA256.hash(path[i], computedHash);
+                computedHash = SHA256.hash(siblings[i], computedHash);
             } else {
                 // Right sibling
-                computedHash = SHA256.hash(computedHash, path[i]);
+                computedHash = SHA256.hash(computedHash, siblings[i]);
             }
         }
         root = computedHash;
     }
 
+    /// @notice Checks whether a direction bit encodes the left or right sibling.
+    /// @param directionBits The direction bits.
+    /// @param d The index of the bit to check.
+    /// @return isLeft Whether the sibling is left or right.
     function isLeftSibling(uint256 directionBits, uint256 d) internal pure returns (bool isLeft) {
         isLeft = (directionBits >> d) & 1 == 0;
     }

--- a/src/state/MerkleTree.sol
+++ b/src/state/MerkleTree.sol
@@ -28,7 +28,7 @@ library MerkleTree {
 
         for (uint256 i = 0; i < treeDepth; ++i) {
             Arrays.unsafeAccess(self._zeros, i).value = currentZero;
-            currentZero = SHA256.hash2(currentZero, currentZero);
+            currentZero = SHA256.hash(currentZero, currentZero);
         }
 
         initialRoot = currentZero;
@@ -57,10 +57,10 @@ library MerkleTree {
             // Reaching the parent node, is currentLevelHash the left child?
             if (isLeftIndex(currentIndex)) {
                 // Left sibling
-                currentLevelHash = SHA256.hash2(currentLevelHash, self._zeros[i]);
+                currentLevelHash = SHA256.hash(currentLevelHash, self._zeros[i]);
             } else {
                 // Right sibling
-                currentLevelHash = SHA256.hash2(self._nodes[i][currentIndex - 1], currentLevelHash);
+                currentLevelHash = SHA256.hash(self._nodes[i][currentIndex - 1], currentLevelHash);
             }
 
             currentIndex >>= 1;
@@ -131,10 +131,10 @@ library MerkleTree {
         for (uint256 i = 0; i < treeDepth; ++i) {
             if (isLeftSibling(directionBits, i)) {
                 // Left sibling
-                computedHash = SHA256.hash2(path[i], computedHash);
+                computedHash = SHA256.hash(path[i], computedHash);
             } else {
                 // Right sibling
-                computedHash = SHA256.hash2(computedHash, path[i]);
+                computedHash = SHA256.hash(computedHash, path[i]);
             }
         }
         root = computedHash;

--- a/src/state/MerkleTree.sol
+++ b/src/state/MerkleTree.sol
@@ -67,15 +67,15 @@ library MerkleTree {
             // Store the node hash of depth `i`.
             self._nodes[i][currentIndex] = currentLevelHash;
 
-            // Compute the next level hash for depth `i+i`.
+            // Compute the next level hash for depth `i+1`.
             // Check whether the `currentIndex` node is the left or right child of its parent.
             if (isLeftChild(currentIndex)) {
-                // Compute the `currentLevelHash` using the right sibling,
-                // Because we fill the tree from left to right, this is the zero hash at depth `i`.
+                // Compute the `currentLevelHash` using the right sibling.
+                // Because we fill the tree from left to right, the right child is empty and we must use the depth `i` zero hash.
                 currentLevelHash = SHA256.hash(currentLevelHash, Arrays.unsafeAccess(self._zeros, i).value);
             } else {
                 // Compute the `currentLevelHash` using the left sibling.
-                // Because we fill the tree from left to right, this is the previous node at depth `i`.
+                // Because we fill the tree from left to right, the left child is the previous node at depth `i`.
                 currentLevelHash = SHA256.hash(self._nodes[i][currentIndex - 1], currentLevelHash);
             }
 

--- a/src/state/MerkleTree.sol
+++ b/src/state/MerkleTree.sol
@@ -71,11 +71,13 @@ library MerkleTree {
             // Check whether the `currentIndex` node is the left or right child of its parent.
             if (isLeftChild(currentIndex)) {
                 // Compute the `currentLevelHash` using the right sibling.
-                // Because we fill the tree from left to right, the right child is empty and we must use the depth `i` zero hash.
+                // Because we fill the tree from left to right,
+                // the right child is empty and we must use the depth `i` zero hash.
                 currentLevelHash = SHA256.hash(currentLevelHash, Arrays.unsafeAccess(self._zeros, i).value);
             } else {
                 // Compute the `currentLevelHash` using the left sibling.
-                // Because we fill the tree from left to right, the left child is the previous node at depth `i`.
+                // Because we fill the tree from left to right,
+                // the left child is the previous node at depth `i`.
                 currentLevelHash = SHA256.hash(self._nodes[i][currentIndex - 1], currentLevelHash);
             }
 

--- a/src/state/MerkleTree.sol
+++ b/src/state/MerkleTree.sol
@@ -64,7 +64,7 @@ library MerkleTree {
         uint256 currentIndex = index;
         bytes32 currentLevelHash = leaf;
         for (uint256 i = 0; i < treeDepth; ++i) {
-            // Store the node hash of depth `i`.
+            // Store the current node hash at depth `i`.
             self._nodes[i][currentIndex] = currentLevelHash;
 
             // Compute the next level hash for depth `i+1`.

--- a/test/mocks/MockTree.sol
+++ b/test/mocks/MockTree.sol
@@ -36,9 +36,9 @@ contract MockTree {
                 _leaves[i][j] = MerkleTree._EMPTY_LEAF_HASH;
             }
 
-            _nodes[i][0] = SHA256.hash2(_leaves[i][0], _leaves[i][1]);
-            _nodes[i][1] = SHA256.hash2(_leaves[i][2], _leaves[i][3]);
-            _roots[i] = SHA256.hash2(_nodes[i][0], _nodes[i][1]);
+            _nodes[i][0] = SHA256.hash(_leaves[i][0], _leaves[i][1]);
+            _nodes[i][1] = SHA256.hash(_leaves[i][2], _leaves[i][3]);
+            _roots[i] = SHA256.hash(_nodes[i][0], _nodes[i][1]);
 
             _siblings[i][0] = new bytes32[](2);
             _siblings[i][0][0] = _leaves[i][1];

--- a/test/mocks/MockTree.sol
+++ b/test/mocks/MockTree.sol
@@ -13,6 +13,8 @@ contract MockTree {
 
     bytes32[4][5] internal _leaves;
     bytes32[][4][5] internal _siblings; // 2
+    uint256[4] internal _directionBits;
+
     bytes32[2][5] internal _nodes;
     bytes32[5] internal _roots;
 
@@ -34,25 +36,29 @@ contract MockTree {
                 _leaves[i][j] = MerkleTree._EMPTY_LEAF_HASH;
             }
 
-            _nodes[i][0] = SHA256.commutativeHash(_leaves[i][0], _leaves[i][1]);
-            _nodes[i][1] = SHA256.commutativeHash(_leaves[i][2], _leaves[i][3]);
-            _roots[i] = SHA256.commutativeHash(_nodes[i][0], _nodes[i][1]);
+            _nodes[i][0] = SHA256.hash2(_leaves[i][0], _leaves[i][1]);
+            _nodes[i][1] = SHA256.hash2(_leaves[i][2], _leaves[i][3]);
+            _roots[i] = SHA256.hash2(_nodes[i][0], _nodes[i][1]);
 
             _siblings[i][0] = new bytes32[](2);
             _siblings[i][0][0] = _leaves[i][1];
             _siblings[i][0][1] = _nodes[i][1];
+            _directionBits[0] = 3; // 11 = 3
 
             _siblings[i][1] = new bytes32[](2);
             _siblings[i][1][0] = _leaves[i][0];
             _siblings[i][1][1] = _nodes[i][1];
+            _directionBits[1] = 2; // 10 = 2
 
             _siblings[i][2] = new bytes32[](2);
             _siblings[i][2][0] = _leaves[i][3];
             _siblings[i][2][1] = _nodes[i][0];
+            _directionBits[2] = 1; // 01 = 1
 
             _siblings[i][3] = new bytes32[](2);
             _siblings[i][3][0] = _leaves[i][2];
             _siblings[i][3][1] = _nodes[i][0];
+            _directionBits[3] = 0; // 00 = 0
         }
     }
 }

--- a/test/state/CommitmentAccumulator.t.sol
+++ b/test/state/CommitmentAccumulator.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import {Test, console} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {SHA256} from "../../src/libs/SHA256.sol";
-import {CommitmentAccumulator} from "../../src/state/CommitmentAccumulator.sol";
-import {MerkleTree} from "../../src/state/MerkleTree.sol";
+import { SHA256 } from "../../src/libs/SHA256.sol";
+import { CommitmentAccumulator } from "../../src/state/CommitmentAccumulator.sol";
+import { MerkleTree } from "../../src/state/MerkleTree.sol";
 
-import {CommitmentAccumulatorMock} from "../mocks/CommitmentAccumulatorMock.sol";
-import {MockTree} from "../mocks/MockTree.sol";
+import { CommitmentAccumulatorMock } from "../mocks/CommitmentAccumulatorMock.sol";
+import { MockTree } from "../mocks/MockTree.sol";
 
 contract CommitmentAccumulatorTest is Test, MockTree {
     using MerkleTree for bytes32[];
@@ -170,7 +170,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
 
         (bytes32[] memory path, uint256 directionBits) = _cmAcc.merkleProof(cm);
 
-        _cmAcc.verifyMerkleProof({root: latestRoot, commitment: cm, path: path, directionBits: directionBits});
+        _cmAcc.verifyMerkleProof({ root: latestRoot, commitment: cm, path: path, directionBits: directionBits });
     }
 
     function test_verifyMerkleProof_reverts_on_non_existent_root() public {
@@ -210,7 +210,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         vm.expectRevert(
             abi.encodeWithSelector(CommitmentAccumulator.InvalidPathLength.selector, _TREE_DEPTH, wrongPath.length)
         );
-        _cmAcc.verifyMerkleProof({root: 0, commitment: 0, path: wrongPath, directionBits: 0});
+        _cmAcc.verifyMerkleProof({ root: 0, commitment: 0, path: wrongPath, directionBits: 0 });
     }
 
     function test_verifyMerkleProof_reverts_on_wrong_path() public {
@@ -221,9 +221,9 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         bytes32[] memory wrongPath = new bytes32[](_TREE_DEPTH);
 
         // Compute the expected, invalid root.
-        bytes32 invalidRoot = wrongPath.processProof({directionBits: 0, leaf: commitment});
+        bytes32 invalidRoot = wrongPath.processProof({ directionBits: 0, leaf: commitment });
 
         vm.expectRevert(abi.encodeWithSelector(CommitmentAccumulator.InvalidRoot.selector, newRoot, invalidRoot));
-        _cmAcc.verifyMerkleProof({root: newRoot, commitment: commitment, path: wrongPath, directionBits: 0});
+        _cmAcc.verifyMerkleProof({ root: newRoot, commitment: commitment, path: wrongPath, directionBits: 0 });
     }
 }

--- a/test/state/CommitmentAccumulator.t.sol
+++ b/test/state/CommitmentAccumulator.t.sol
@@ -111,7 +111,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
 
         // Test empty tree
         bytes32 root = _cmAcc.initialRoot();
-        bytes32 invalidRoot = SHA256.hash2(SHA256.hash2(nonExistentCommitment, _siblings[0][0][0]), _siblings[0][0][1]);
+        bytes32 invalidRoot = SHA256.hash(SHA256.hash(nonExistentCommitment, _siblings[0][0][0]), _siblings[0][0][1]);
 
         bytes32 computedRoot = MerkleTree.processProof({
             path: _siblings[0][0],
@@ -128,13 +128,13 @@ contract CommitmentAccumulatorTest is Test, MockTree {
             for (uint256 j = 0; j <= i; ++j) {
                 // Depth 0
                 invalidRoot = MerkleTree.isLeftSibling(_directionBits[j], 0)
-                    ? SHA256.hash2(_siblings[i + 1][j][0], nonExistentCommitment)
-                    : SHA256.hash2(nonExistentCommitment, _siblings[i + 1][j][0]);
+                    ? SHA256.hash(_siblings[i + 1][j][0], nonExistentCommitment)
+                    : SHA256.hash(nonExistentCommitment, _siblings[i + 1][j][0]);
 
                 // Depth 1
                 invalidRoot = MerkleTree.isLeftSibling(_directionBits[j], 1)
-                    ? SHA256.hash2(_siblings[i + 1][j][1], invalidRoot)
-                    : SHA256.hash2(invalidRoot, _siblings[i + 1][j][1]);
+                    ? SHA256.hash(_siblings[i + 1][j][1], invalidRoot)
+                    : SHA256.hash(invalidRoot, _siblings[i + 1][j][1]);
 
                 computedRoot = MerkleTree.processProof({
                     path: _siblings[i + 1][j],

--- a/test/state/CommitmentAccumulator.t.sol
+++ b/test/state/CommitmentAccumulator.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Test } from "forge-std/Test.sol";
+import {Test, console} from "forge-std/Test.sol";
 
-import { SHA256 } from "../../src/libs/SHA256.sol";
-import { CommitmentAccumulator } from "../../src/state/CommitmentAccumulator.sol";
-import { MerkleTree } from "../../src/state/MerkleTree.sol";
+import {SHA256} from "../../src/libs/SHA256.sol";
+import {CommitmentAccumulator} from "../../src/state/CommitmentAccumulator.sol";
+import {MerkleTree} from "../../src/state/MerkleTree.sol";
 
-import { CommitmentAccumulatorMock } from "../mocks/CommitmentAccumulatorMock.sol";
-import { MockTree } from "../mocks/MockTree.sol";
+import {CommitmentAccumulatorMock} from "../mocks/CommitmentAccumulatorMock.sol";
+import {MockTree} from "../mocks/MockTree.sol";
 
 contract CommitmentAccumulatorTest is Test, MockTree {
     using MerkleTree for bytes32[];
@@ -42,7 +42,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
             _cmAcc.addCommitment(_leaves[i + 1][i]);
 
             for (uint256 j = 0; j < i + 1; ++j) {
-                (bytes32[] memory path, uint256 directionBits,) = _cmAcc.merkleProof(_leaves[i + 1][j]);
+                (bytes32[] memory path, uint256 directionBits) = _cmAcc.merkleProof(_leaves[i + 1][j]);
 
                 assertEq(path, _siblings[i + 1][j]);
                 assertEq(directionBits, _directionBits[j]);
@@ -148,16 +148,32 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         }
     }
 
-    function test_checkPath_should_pass_on_valid_inputs() public {
-        bytes32 cm = sha256("SOMETHING");
-        _cmAcc.storeRoot(_cmAcc.addCommitment(cm));
+    function test_merkleProof_returns_proofs_that_match_the_latest_root() public {
+        for (uint256 i = 0; i < _N_LEAFS; ++i) {
+            bytes32 latestRoot = _cmAcc.addCommitment(_leaves[_N_ROOTS - 1][i]);
 
-        (bytes32[] memory path, uint256 directionBits, bytes32 latestRoot) = _cmAcc.merkleProof(cm);
+            // Check that all leaves of the current tree result in proofs reproducing the latest root.
+            for (uint256 j = 0; j <= i; ++j) {
+                bytes32 cm = _leaves[_N_ROOTS - 1][i];
 
-        _cmAcc.verifyMerkleProof({ root: latestRoot, commitment: cm, path: path, directionBits: directionBits });
+                (bytes32[] memory siblings, uint256 directionBits) = _cmAcc.merkleProof(cm);
+                bytes32 computedRoot = MerkleTree.processProof(siblings, directionBits, cm);
+
+                assertEq(computedRoot, latestRoot);
+            }
+        }
     }
 
-    function test_checkPath_reverts_on_non_existent_root() public {
+    function test_verifyMerkleProof_should_pass_on_valid_inputs() public {
+        bytes32 cm = sha256("SOMETHING");
+        bytes32 latestRoot = _cmAcc.addCommitment(cm);
+
+        (bytes32[] memory path, uint256 directionBits) = _cmAcc.merkleProof(cm);
+
+        _cmAcc.verifyMerkleProof({root: latestRoot, commitment: cm, path: path, directionBits: directionBits});
+    }
+
+    function test_verifyMerkleProof_reverts_on_non_existent_root() public {
         bytes32 nonExistingRoot = sha256("NON_EXISTENT_ROOT");
 
         vm.expectRevert(abi.encodeWithSelector(CommitmentAccumulator.NonExistingRoot.selector, nonExistingRoot));
@@ -169,7 +185,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         });
     }
 
-    function test_checkPath_reverts_on_non_existent_commitment() public {
+    function test_verifyMerkleProof_reverts_on_non_existent_commitment() public {
         bytes32 latestRoot = _cmAcc.latestRoot();
         assertEq(latestRoot, _roots[0]);
 
@@ -187,17 +203,17 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         });
     }
 
-    function test_checkPath_reverts_on_wrong_path_length() public {
+    function test_verifyMerkleProof_reverts_on_wrong_path_length() public {
         _cmAcc.storeRoot(_cmAcc.addCommitment(0));
         bytes32[] memory wrongPath = new bytes32[](3);
 
         vm.expectRevert(
             abi.encodeWithSelector(CommitmentAccumulator.InvalidPathLength.selector, _TREE_DEPTH, wrongPath.length)
         );
-        _cmAcc.verifyMerkleProof({ root: 0, commitment: 0, path: wrongPath, directionBits: 0 });
+        _cmAcc.verifyMerkleProof({root: 0, commitment: 0, path: wrongPath, directionBits: 0});
     }
 
-    function test_checkPath_reverts_on_wrong_path() public {
+    function test_verifyMerkleProof_reverts_on_wrong_path() public {
         bytes32 commitment = sha256("SOMETHING");
         bytes32 newRoot = _cmAcc.addCommitment(commitment);
         _cmAcc.storeRoot(newRoot);
@@ -205,9 +221,9 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         bytes32[] memory wrongPath = new bytes32[](_TREE_DEPTH);
 
         // Compute the expected, invalid root.
-        bytes32 invalidRoot = wrongPath.processProof({ directionBits: 0, leaf: commitment });
+        bytes32 invalidRoot = wrongPath.processProof({directionBits: 0, leaf: commitment});
 
         vm.expectRevert(abi.encodeWithSelector(CommitmentAccumulator.InvalidRoot.selector, newRoot, invalidRoot));
-        _cmAcc.verifyMerkleProof({ root: newRoot, commitment: commitment, path: wrongPath, directionBits: 0 });
+        _cmAcc.verifyMerkleProof({root: newRoot, commitment: commitment, path: wrongPath, directionBits: 0});
     }
 }

--- a/test/state/CommitmentAccumulator.t.sol
+++ b/test/state/CommitmentAccumulator.t.sol
@@ -114,7 +114,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         bytes32 invalidRoot = SHA256.hash(SHA256.hash(nonExistentCommitment, _siblings[0][0][0]), _siblings[0][0][1]);
 
         bytes32 computedRoot = MerkleTree.processProof({
-            path: _siblings[0][0],
+            siblings: _siblings[0][0],
             directionBits: _directionBits[0],
             leaf: nonExistentCommitment
         });
@@ -137,7 +137,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
                     : SHA256.hash(invalidRoot, _siblings[i + 1][j][1]);
 
                 computedRoot = MerkleTree.processProof({
-                    path: _siblings[i + 1][j],
+                    siblings: _siblings[i + 1][j],
                     directionBits: _directionBits[j],
                     leaf: nonExistentCommitment
                 });

--- a/test/state/CommitmentAccumulator.t.sol
+++ b/test/state/CommitmentAccumulator.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { MerkleProof } from "@openzeppelin-contracts/utils/cryptography/MerkleProof.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { SHA256 } from "../../src/libs/SHA256.sol";
 import { CommitmentAccumulator } from "../../src/state/CommitmentAccumulator.sol";
+import { MerkleTree } from "../../src/state/MerkleTree.sol";
 
 import { CommitmentAccumulatorMock } from "../mocks/CommitmentAccumulatorMock.sol";
 import { MockTree } from "../mocks/MockTree.sol";
 
 contract CommitmentAccumulatorTest is Test, MockTree {
-    using MerkleProof for bytes32[];
+    using MerkleTree for bytes32[];
 
     CommitmentAccumulatorMock internal _cmAcc;
 
@@ -37,13 +37,15 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         _cmAcc.merkleProof(emptyLeafHash);
     }
 
-    function test_merkleProof_should_return_correct_siblings() public {
+    function test_merkleProof_should_return_correct_siblings_and_direction_bits() public {
         for (uint256 i = 0; i < _N_LEAFS; ++i) {
             _cmAcc.addCommitment(_leaves[i + 1][i]);
 
-            for (uint256 j = 0; j < i; ++j) {
-                (bytes32[] memory proof,) = _cmAcc.merkleProof(_leaves[i + 1][j]);
-                assertEq(proof, _siblings[i + 1][j]);
+            for (uint256 j = 0; j < i + 1; ++j) {
+                (bytes32[] memory path, uint256 directionBits,) = _cmAcc.merkleProof(_leaves[i + 1][j]);
+
+                assertEq(path, _siblings[i + 1][j]);
+                assertEq(directionBits, _directionBits[j]);
             }
         }
     }
@@ -109,14 +111,12 @@ contract CommitmentAccumulatorTest is Test, MockTree {
 
         // Test empty tree
         bytes32 root = _cmAcc.initialRoot();
-        bytes32 invalidRoot = SHA256.commutativeHash(
-            SHA256.commutativeHash(nonExistentCommitment, _siblings[0][0][0]), _siblings[0][0][1]
-        );
+        bytes32 invalidRoot = SHA256.hash2(SHA256.hash2(nonExistentCommitment, _siblings[0][0][0]), _siblings[0][0][1]);
 
-        bytes32 computedRoot = MerkleProof.processProof({
-            proof: _siblings[0][0],
-            leaf: nonExistentCommitment,
-            hasher: SHA256.commutativeHash
+        bytes32 computedRoot = MerkleTree.processProof({
+            path: _siblings[0][0],
+            directionBits: _directionBits[0],
+            leaf: nonExistentCommitment
         });
         assertNotEq(computedRoot, root);
         assertEq(computedRoot, invalidRoot);
@@ -126,14 +126,20 @@ contract CommitmentAccumulatorTest is Test, MockTree {
             root = _cmAcc.addCommitment(_leaves[i + 1][i]);
 
             for (uint256 j = 0; j <= i; ++j) {
-                invalidRoot = SHA256.commutativeHash(
-                    SHA256.commutativeHash(nonExistentCommitment, _siblings[i + 1][j][0]), _siblings[i + 1][j][1]
-                );
+                // Depth 0
+                invalidRoot = MerkleTree.isLeftSibling(_directionBits[j], 0)
+                    ? SHA256.hash2(_siblings[i + 1][j][0], nonExistentCommitment)
+                    : SHA256.hash2(nonExistentCommitment, _siblings[i + 1][j][0]);
 
-                computedRoot = MerkleProof.processProof({
-                    proof: _siblings[i + 1][j],
-                    leaf: nonExistentCommitment,
-                    hasher: SHA256.commutativeHash
+                // Depth 1
+                invalidRoot = MerkleTree.isLeftSibling(_directionBits[j], 1)
+                    ? SHA256.hash2(_siblings[i + 1][j][1], invalidRoot)
+                    : SHA256.hash2(invalidRoot, _siblings[i + 1][j][1]);
+
+                computedRoot = MerkleTree.processProof({
+                    path: _siblings[i + 1][j],
+                    directionBits: _directionBits[j],
+                    leaf: nonExistentCommitment
                 });
 
                 assertNotEq(computedRoot, root);
@@ -146,16 +152,21 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         bytes32 cm = sha256("SOMETHING");
         _cmAcc.storeRoot(_cmAcc.addCommitment(cm));
 
-        (bytes32[] memory path, bytes32 latestRoot) = _cmAcc.merkleProof(cm);
+        (bytes32[] memory path, uint256 directionBits, bytes32 latestRoot) = _cmAcc.merkleProof(cm);
 
-        _cmAcc.verifyMerkleProof({ root: latestRoot, commitment: cm, path: path });
+        _cmAcc.verifyMerkleProof({ root: latestRoot, commitment: cm, path: path, directionBits: directionBits });
     }
 
     function test_checkPath_reverts_on_non_existent_root() public {
         bytes32 nonExistingRoot = sha256("NON_EXISTENT_ROOT");
 
         vm.expectRevert(abi.encodeWithSelector(CommitmentAccumulator.NonExistingRoot.selector, nonExistingRoot));
-        _cmAcc.verifyMerkleProof({ root: nonExistingRoot, commitment: 0, path: new bytes32[](_TREE_DEPTH) });
+        _cmAcc.verifyMerkleProof({
+            root: nonExistingRoot,
+            commitment: 0,
+            path: new bytes32[](_TREE_DEPTH),
+            directionBits: 0
+        });
     }
 
     function test_checkPath_reverts_on_non_existent_commitment() public {
@@ -165,12 +176,14 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         bytes32 nonExistingCommitment = _leaves[1][0];
         bytes32 nonExistingRoot = _roots[1];
         bytes32[] memory siblingsCorrespondingToNonExistingRoot = _siblings[1][0];
+        uint256 directionBitsCorrespondingToNonExistingRoot = _directionBits[0];
 
         vm.expectRevert(abi.encodeWithSelector(CommitmentAccumulator.InvalidRoot.selector, latestRoot, nonExistingRoot));
         _cmAcc.verifyMerkleProof({
             root: latestRoot,
             commitment: nonExistingCommitment,
-            path: siblingsCorrespondingToNonExistingRoot
+            path: siblingsCorrespondingToNonExistingRoot,
+            directionBits: directionBitsCorrespondingToNonExistingRoot
         });
     }
 
@@ -181,7 +194,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         vm.expectRevert(
             abi.encodeWithSelector(CommitmentAccumulator.InvalidPathLength.selector, _TREE_DEPTH, wrongPath.length)
         );
-        _cmAcc.verifyMerkleProof({ root: 0, commitment: 0, path: wrongPath });
+        _cmAcc.verifyMerkleProof({ root: 0, commitment: 0, path: wrongPath, directionBits: 0 });
     }
 
     function test_checkPath_reverts_on_wrong_path() public {
@@ -192,9 +205,9 @@ contract CommitmentAccumulatorTest is Test, MockTree {
         bytes32[] memory wrongPath = new bytes32[](_TREE_DEPTH);
 
         // Compute the expected, invalid root.
-        bytes32 invalidRoot = wrongPath.processProof(commitment, SHA256.commutativeHash);
+        bytes32 invalidRoot = wrongPath.processProof({ directionBits: 0, leaf: commitment });
 
         vm.expectRevert(abi.encodeWithSelector(CommitmentAccumulator.InvalidRoot.selector, newRoot, invalidRoot));
-        _cmAcc.verifyMerkleProof({ root: newRoot, commitment: commitment, path: wrongPath });
+        _cmAcc.verifyMerkleProof({ root: newRoot, commitment: commitment, path: wrongPath, directionBits: 0 });
     }
 }

--- a/test/state/CommitmentAccumulator.t.sol
+++ b/test/state/CommitmentAccumulator.t.sol
@@ -167,6 +167,7 @@ contract CommitmentAccumulatorTest is Test, MockTree {
     function test_verifyMerkleProof_should_pass_on_valid_inputs() public {
         bytes32 cm = sha256("SOMETHING");
         bytes32 latestRoot = _cmAcc.addCommitment(cm);
+        _cmAcc.storeRoot(latestRoot);
 
         (bytes32[] memory path, uint256 directionBits) = _cmAcc.merkleProof(cm);
 

--- a/test/state/MerkleTree.t.sol
+++ b/test/state/MerkleTree.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { MerkleTree } from "../../src/state/MerkleTree.sol";
-import { MockTree } from "../mocks/MockTree.sol";
+import {MerkleTree} from "../../src/state/MerkleTree.sol";
+import {MockTree} from "../mocks/MockTree.sol";
 
 contract MerkleTreeTest is Test, MockTree {
     using MerkleTree for MerkleTree.Tree;
+    using MerkleTree for bytes32[];
 
     MerkleTree.Tree internal _merkleTree;
 

--- a/test/state/MerkleTree.t.sol
+++ b/test/state/MerkleTree.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {MerkleTree} from "../../src/state/MerkleTree.sol";
-import {MockTree} from "../mocks/MockTree.sol";
+import { MerkleTree } from "../../src/state/MerkleTree.sol";
+import { MockTree } from "../mocks/MockTree.sol";
 
 contract MerkleTreeTest is Test, MockTree {
     using MerkleTree for MerkleTree.Tree;


### PR DESCRIPTION
This PR 
- replaces the commutative sha256 hash function used for the Merkle path computation and inclusion proof verification with the non-commutative version and direction bits
- adds [NatSpec](https://docs.soliditylang.org/en/latest/natspec-format.html) documentation to the `MerkleTree` library