### PR TITLE
refactor: add reverting contract to tests and change formatting

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -43,16 +43,6 @@ optimism = { key = "${API_KEY_OPTIMISTIC_ETHERSCAN}" }
 polygon = { key = "${API_KEY_POLYGONSCAN}" }
 sepolia = { key = "${API_KEY_ETHERSCAN}" }
 
-[fmt]
-bracket_spacing = true
-int_types = "long"
-line_length = 120
-multiline_func_header = "all"
-number_underscore = "thousands"
-quote_style = "double"
-tab_width = 4
-wrap_comments = false
-
 [rpc_endpoints]
 arbitrum = "https://arbitrum-mainnet.infura.io/v3/${API_KEY_INFURA}"
 avalanche = "https://avalanche-mainnet.infura.io/v3/${API_KEY_INFURA}"

--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Script } from "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
 abstract contract BaseScript is Script {
     modifier broadcast() {

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { IRiscZeroVerifier } from "@risc0-ethereum/IRiscZeroVerifier.sol";
+import {IRiscZeroVerifier} from "@risc0-ethereum/IRiscZeroVerifier.sol";
 
-import { ProtocolAdapter } from "../src/ProtocolAdapter.sol";
-import { BaseScript } from "./Base.s.sol";
+import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
+import {BaseScript} from "./Base.s.sol";
 
 contract Deploy is BaseScript {
     function run() public broadcast returns (address protocolAdapter) {
@@ -19,7 +19,7 @@ contract Deploy is BaseScript {
         uint8 treeDepth = uint8(vm.parseUint(vm.readLine(path)));
 
         protocolAdapter = address(
-            new ProtocolAdapter{ salt: sha256("ProtocolAdapter") }({
+            new ProtocolAdapter{salt: sha256("ProtocolAdapter")}({
                 riscZeroVerifier: trustedSepoliaVerifier,
                 logicCircuitID: logicCircuitID,
                 complianceCircuitID: complianceCircuitID,

--- a/script/DeployERC20Forwarder.sol
+++ b/script/DeployERC20Forwarder.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { ERC20Forwarder } from "../src/ERC20Forwarder.sol";
-import { ProtocolAdapter } from "../src/ProtocolAdapter.sol";
+import {ERC20Forwarder} from "../src/ERC20Forwarder.sol";
+import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 
-import { BaseScript } from "./Base.s.sol";
+import {BaseScript} from "./Base.s.sol";
 
 contract DeployERC20Wrapper is BaseScript {
     ProtocolAdapter internal constant _PROTOCOL_ADAPTER = ProtocolAdapter(address(0));
@@ -14,7 +14,7 @@ contract DeployERC20Wrapper is BaseScript {
     bytes32 internal constant _CALLDATA_CARRIER_LOGIC_REF = bytes32(0);
 
     function run() public broadcast {
-        new ERC20Forwarder{ salt: sha256("ERC20ForwarderExample") }({
+        new ERC20Forwarder{salt: sha256("ERC20ForwarderExample")}({
             protocolAdapter: address(_PROTOCOL_ADAPTER),
             erc20: _ERC20,
             calldataCarrierLogicRef: _CALLDATA_CARRIER_LOGIC_REF

--- a/src/ERC20Forwarder.sol
+++ b/src/ERC20Forwarder.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Ownable } from "@openzeppelin-contracts/access/Ownable.sol";
-import { Address } from "@openzeppelin-contracts/utils/Address.sol";
+import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
+import {Address} from "@openzeppelin-contracts/utils/Address.sol";
 //import { IERC20 } from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
-import { ForwarderBase } from "./ForwarderBase.sol";
+import {ForwarderBase} from "./ForwarderBase.sol";
 
 contract ERC20Forwarder is Ownable, ForwarderBase {
     using Address for address;
@@ -14,11 +14,7 @@ contract ERC20Forwarder is Ownable, ForwarderBase {
 
     error ZeroAddressNotAllowed();
 
-    constructor(
-        address protocolAdapter,
-        address erc20,
-        bytes32 calldataCarrierLogicRef
-    )
+    constructor(address protocolAdapter, address erc20, bytes32 calldataCarrierLogicRef)
         ForwarderBase(protocolAdapter, calldataCarrierLogicRef)
     {
         if (erc20 == address(0)) revert ZeroAddressNotAllowed();

--- a/src/ForwarderBase.sol
+++ b/src/ForwarderBase.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Ownable } from "@openzeppelin-contracts/access/Ownable.sol";
+import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
 
-import { IForwarder } from "./interfaces/IForwarder.sol";
-import { ComputableComponents } from "./libs/ComputableComponents.sol";
+import {IForwarder} from "./interfaces/IForwarder.sol";
+import {ComputableComponents} from "./libs/ComputableComponents.sol";
 
 /// A contract owning EVM state and executing EVM calls.
 abstract contract ForwarderBase is IForwarder, Ownable {
@@ -12,10 +12,8 @@ abstract contract ForwarderBase is IForwarder, Ownable {
     bytes32 internal immutable _CALLDATA_CARRIER_RESOURCE_KIND;
 
     constructor(address protocolAdapter, bytes32 calldataCarrierLogicRef) Ownable(protocolAdapter) {
-        _CALLDATA_CARRIER_RESOURCE_KIND = ComputableComponents.kind({
-            logicRef: calldataCarrierLogicRef,
-            labelRef: sha256(abi.encode(address(this)))
-        });
+        _CALLDATA_CARRIER_RESOURCE_KIND =
+            ComputableComponents.kind({logicRef: calldataCarrierLogicRef, labelRef: sha256(abi.encode(address(this)))});
     }
 
     /// @inheritdoc IForwarder

--- a/src/ProtocolAdapter.sol
+++ b/src/ProtocolAdapter.sol
@@ -1,29 +1,29 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { ReentrancyGuardTransient } from "@openzeppelin-contracts/utils/ReentrancyGuardTransient.sol";
-import { EnumerableSet } from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
-import { IRiscZeroVerifier as TrustedRiscZeroVerifier } from "@risc0-ethereum/IRiscZeroVerifier.sol";
+import {ReentrancyGuardTransient} from "@openzeppelin-contracts/utils/ReentrancyGuardTransient.sol";
+import {EnumerableSet} from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import {IRiscZeroVerifier as TrustedRiscZeroVerifier} from "@risc0-ethereum/IRiscZeroVerifier.sol";
 
-import { MockDelta } from "../test/mocks/MockDelta.sol"; // TODO remove
+import {MockDelta} from "../test/mocks/MockDelta.sol"; // TODO remove
 
-import { IForwarder } from "./interfaces/IForwarder.sol";
-import { IProtocolAdapter } from "./interfaces/IProtocolAdapter.sol";
+import {IForwarder} from "./interfaces/IForwarder.sol";
+import {IProtocolAdapter} from "./interfaces/IProtocolAdapter.sol";
 
-import { AppData } from "./libs/AppData.sol";
-import { ArrayLookup } from "./libs/ArrayLookup.sol";
-import { ComputableComponents } from "./libs/ComputableComponents.sol";
-import { Reference } from "./libs/Reference.sol";
+import {AppData} from "./libs/AppData.sol";
+import {ArrayLookup} from "./libs/ArrayLookup.sol";
+import {ComputableComponents} from "./libs/ComputableComponents.sol";
+import {Reference} from "./libs/Reference.sol";
 
-import { ComplianceUnit } from "./proving/Compliance.sol";
-import { Delta } from "./proving/Delta.sol";
-import { LogicInstance, LogicProofs, TagLogicProofPair, LogicRefProofPair } from "./proving/Logic.sol";
+import {ComplianceUnit} from "./proving/Compliance.sol";
+import {Delta} from "./proving/Delta.sol";
+import {LogicInstance, LogicProofs, TagLogicProofPair, LogicRefProofPair} from "./proving/Logic.sol";
 
-import { BlobStorage, DeletionCriterion, ExpirableBlob } from "./state/BlobStorage.sol";
-import { CommitmentAccumulator } from "./state/CommitmentAccumulator.sol";
-import { NullifierSet } from "./state/NullifierSet.sol";
+import {BlobStorage, DeletionCriterion, ExpirableBlob} from "./state/BlobStorage.sol";
+import {CommitmentAccumulator} from "./state/CommitmentAccumulator.sol";
+import {NullifierSet} from "./state/NullifierSet.sol";
 
-import { Action, ForwarderCalldata, Resource, TagAppDataPair, Transaction } from "./Types.sol";
+import {Action, ForwarderCalldata, Resource, TagAppDataPair, Transaction} from "./Types.sol";
 
 contract ProtocolAdapter is
     IProtocolAdapter,
@@ -63,9 +63,7 @@ contract ProtocolAdapter is
         bytes32 logicCircuitID,
         bytes32 complianceCircuitID,
         uint8 treeDepth
-    )
-        CommitmentAccumulator(treeDepth)
-    {
+    ) CommitmentAccumulator(treeDepth) {
         _TRUSTED_RISC_ZERO_VERIFIER = riscZeroVerifier;
         _LOGIC_CIRCUIT_ID = logicCircuitID;
         _COMPLIANCE_CIRCUIT_ID = complianceCircuitID;
@@ -76,7 +74,7 @@ contract ProtocolAdapter is
     function execute(Transaction calldata transaction) external override nonReentrant {
         _verify(transaction);
 
-        emit TransactionExecuted({ id: ++_txCount, transaction: transaction });
+        emit TransactionExecuted({id: ++_txCount, transaction: transaction});
 
         uint256 n = transaction.actions.length;
         uint256 m;
@@ -123,7 +121,7 @@ contract ProtocolAdapter is
         bytes memory output = IForwarder(call.untrustedForwarder).forwardCall(call.input);
 
         if (keccak256(output) != keccak256(call.output)) {
-            revert ForwarderCallOutputMismatch({ expected: call.output, actual: output });
+            revert ForwarderCallOutputMismatch({expected: call.output, actual: output});
         }
     }
 
@@ -184,7 +182,7 @@ contract ProtocolAdapter is
                 });
 
                 // Prepare delta proof
-                transactionDelta = Delta.add({ p1: transactionDelta, p2: unit.instance.unitDelta });
+                transactionDelta = Delta.add({p1: transactionDelta, p2: unit.instance.unitDelta});
             }
 
             // Logic Proofs
@@ -193,7 +191,7 @@ contract ProtocolAdapter is
                 isConsumed: true,
                 consumed: action.nullifiers,
                 created: action.commitments,
-                tagSpecificAppData: ExpirableBlob({ deletionCriterion: DeletionCriterion.Immediately, blob: bytes("") })
+                tagSpecificAppData: ExpirableBlob({deletionCriterion: DeletionCriterion.Immediately, blob: bytes("")})
             });
             LogicRefProofPair memory logicRefProofPair;
 
@@ -246,7 +244,7 @@ contract ProtocolAdapter is
         // TODO: THIS IS A TEMPORARY MOCK PROOF AND MUST BE REMOVED.
         // NOTE: The `transactionHash(tags)` and `transactionDelta` are not used here.
         _transactionHash(tags);
-        MockDelta.verify({ deltaProof: transaction.deltaProof });
+        MockDelta.verify({deltaProof: transaction.deltaProof});
         /*
         Delta.verify({
             transactionHash: _transactionHash(tags),
@@ -270,7 +268,7 @@ contract ProtocolAdapter is
                 bytes32 fetchedKind = IForwarder(call.untrustedForwarder).calldataCarrierResourceKind();
 
                 if (passedKind != fetchedKind) {
-                    revert CalldataCarrierKindMismatch({ expected: fetchedKind, actual: passedKind });
+                    revert CalldataCarrierKindMismatch({expected: fetchedKind, actual: passedKind});
                 }
             }
 
@@ -281,7 +279,7 @@ contract ProtocolAdapter is
                 bytes32 actualAppDataHash = keccak256(action.tagAppDataPairs.lookup(carrier.commitment()).blob);
 
                 if (actualAppDataHash != expectedAppDataHash) {
-                    revert CalldataCarrierAppDataMismatch({ actual: actualAppDataHash, expected: expectedAppDataHash });
+                    revert CalldataCarrierAppDataMismatch({actual: actualAppDataHash, expected: expectedAppDataHash});
                 }
             }
         }

--- a/src/Types.sol
+++ b/src/Types.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { TagAppDataPair } from "./libs/AppData.sol";
-import { ComplianceUnit } from "./proving/Compliance.sol";
-import { TagLogicProofPair } from "./proving/Logic.sol";
+import {TagAppDataPair} from "./libs/AppData.sol";
+import {ComplianceUnit} from "./proving/Compliance.sol";
+import {TagLogicProofPair} from "./proving/Logic.sol";
 
 struct Resource {
     bytes32 logicRef;

--- a/src/interfaces/ICommitmentAccumulator.sol
+++ b/src/interfaces/ICommitmentAccumulator.sol
@@ -19,12 +19,7 @@ interface ICommitmentAccumulator {
     /// @param commitment The commitment leaf to proof inclusion in the tree for.
     /// @param siblings The siblings constituting the path from the leaf to the root.
     /// @param directionBits The direction bits indicating whether the siblings are left of right.
-    function verifyMerkleProof(
-        bytes32 root,
-        bytes32 commitment,
-        bytes32[] calldata siblings,
-        uint256 directionBits
-    )
+    function verifyMerkleProof(bytes32 root, bytes32 commitment, bytes32[] calldata siblings, uint256 directionBits)
         external
         view;
 

--- a/src/interfaces/IProtocolAdapter.sol
+++ b/src/interfaces/IProtocolAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Transaction } from "../Types.sol";
+import {Transaction} from "../Types.sol";
 
 interface IProtocolAdapter {
     /// @notice Executes a transaction by adding the commitments and nullifiers to the commitment tree and nullifier

--- a/src/libs/AppData.sol
+++ b/src/libs/AppData.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { ExpirableBlob } from "../state/BlobStorage.sol";
+import {ExpirableBlob} from "../state/BlobStorage.sol";
 
 struct TagAppDataPair {
     bytes32 tag;
@@ -12,10 +12,7 @@ library AppData {
     error AppDataTagNotFound(bytes32 tag);
     error AppDataIndexOutBounds(uint256 index, uint256 max);
 
-    function lookupCalldata(
-        TagAppDataPair[] calldata map,
-        bytes32 tag
-    )
+    function lookupCalldata(TagAppDataPair[] calldata map, bytes32 tag)
         internal
         pure
         returns (ExpirableBlob memory appData)
@@ -42,7 +39,7 @@ library AppData {
     function at(TagAppDataPair[] calldata map, uint256 index) internal pure returns (ExpirableBlob memory appData) {
         uint256 lastIndex = map.length - 1;
         if (index > lastIndex) {
-            revert AppDataIndexOutBounds({ index: index, max: lastIndex });
+            revert AppDataIndexOutBounds({index: index, max: lastIndex});
         }
         appData = map[index].appData;
     }

--- a/src/libs/ComputableComponents.sol
+++ b/src/libs/ComputableComponents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Resource } from "../Types.sol";
+import {Resource} from "../Types.sol";
 
 library ComputableComponents {
     function commitment(Resource memory resource) internal pure returns (bytes32 cm) {

--- a/src/libs/EllipticCurveK256.sol
+++ b/src/libs/EllipticCurveK256.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { EllipticCurve } from "@elliptic-curve-solidity/contracts/EllipticCurve.sol";
+import {EllipticCurve} from "@elliptic-curve-solidity/contracts/EllipticCurve.sol";
 
 /// @notice The secp256k1 (K-256) elliptic curve taken from
 /// https://github.com/witnet/elliptic-curve-solidity/blob/0.2.1/examples/Secp256k1.sol
@@ -23,10 +23,10 @@ library EllipticCurveK256 {
 
     // TODO needed?
     function derivePubKey(uint256 privateKey) internal pure returns (uint256 qx, uint256 qy) {
-        (qx, qy) = EllipticCurve.ecMul({ _k: privateKey, _x: GX, _y: GY, _aa: AA, _pp: PP });
+        (qx, qy) = EllipticCurve.ecMul({_k: privateKey, _x: GX, _y: GY, _aa: AA, _pp: PP});
     }
 
     function ecAdd(uint256 x1, uint256 y1, uint256 x2, uint256 y2) internal pure returns (uint256 x3, uint256 y3) {
-        (x3, y3) = EllipticCurve.ecAdd({ _x1: x1, _y1: y1, _x2: x2, _y2: y2, _aa: AA, _pp: PP });
+        (x3, y3) = EllipticCurve.ecAdd({_x1: x1, _y1: y1, _x2: x2, _y2: y2, _aa: AA, _pp: PP});
     }
 }

--- a/src/proving/Delta.sol
+++ b/src/proving/Delta.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { ECDSA } from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
-import { EllipticCurveK256 } from "../libs/EllipticCurveK256.sol";
+import {ECDSA} from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import {EllipticCurveK256} from "../libs/EllipticCurveK256.sol";
 
 /// @notice A library for addition and verification of delta values.
 /// @dev This uses the Pedersen commitment scheme
@@ -12,7 +12,7 @@ library Delta {
     error DeltaMismatch(address expected, address actual);
 
     function zero() internal pure returns (uint256[2] memory p) {
-        (p[0], p[1]) = EllipticCurveK256.derivePubKey({ privateKey: 0 });
+        (p[0], p[1]) = EllipticCurveK256.derivePubKey({privateKey: 0});
     }
 
     function toBytes(uint256[2] memory delta) internal pure returns (bytes memory bytesDelta) {
@@ -31,23 +31,19 @@ library Delta {
         (p3[0], p3[1]) = EllipticCurveK256.ecAdd(p1[0], p1[1], p2[0], p2[1]);
     }
 
-    function verify(
-        bytes32 transactionHash,
-        uint256[2] memory transactionDelta,
-        bytes memory deltaProof
-    )
+    function verify(bytes32 transactionHash, uint256[2] memory transactionDelta, bytes memory deltaProof)
         internal
         pure
     {
         // Verify the delta proof using the ECDSA.recover API to obtain the address
-        address recovered = ECDSA.recover({ hash: transactionHash, signature: deltaProof });
+        address recovered = ECDSA.recover({hash: transactionHash, signature: deltaProof});
 
         // Convert the public key to an address
         address expected = toAccount(transactionDelta);
 
         // Compare it with the recovered address
         if (recovered != expected) {
-            revert DeltaMismatch({ expected: expected, actual: recovered });
+            revert DeltaMismatch({expected: expected, actual: recovered});
         }
     }
 }

--- a/src/proving/Logic.sol
+++ b/src/proving/Logic.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { ExpirableBlob } from "../state/BlobStorage.sol";
+import {ExpirableBlob} from "../state/BlobStorage.sol";
 
 struct LogicInstance {
     bytes32 tag;
@@ -25,10 +25,7 @@ library LogicProofs {
     error LogicProofTagNotFound(bytes32 tag);
     error LogicProofIndexOutBounds(uint256 index, uint256 max);
 
-    function lookup(
-        TagLogicProofPair[] calldata map,
-        bytes32 tag
-    )
+    function lookup(TagLogicProofPair[] calldata map, bytes32 tag)
         internal
         pure
         returns (LogicRefProofPair memory elem)
@@ -42,17 +39,14 @@ library LogicProofs {
         revert LogicProofTagNotFound(tag);
     }
 
-    function at(
-        TagLogicProofPair[] calldata map,
-        uint256 index
-    )
+    function at(TagLogicProofPair[] calldata map, uint256 index)
         internal
         pure
         returns (LogicRefProofPair memory elem)
     {
         uint256 lastIndex = map.length - 1;
         if (index > lastIndex) {
-            revert LogicProofIndexOutBounds({ index: index, max: lastIndex });
+            revert LogicProofIndexOutBounds({index: index, max: lastIndex});
         }
         elem = map[index].pair;
     }

--- a/src/state/BlobStorage.sol
+++ b/src/state/BlobStorage.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { IBlobStorage } from "../interfaces/IBlobStorage.sol";
+import {IBlobStorage} from "../interfaces/IBlobStorage.sol";
 
 enum DeletionCriterion {
     Immediately,
@@ -80,7 +80,7 @@ contract BlobStorage is IBlobStorage {
 
     function _checkIntegrity(bytes32 blobHash, bytes32 retrievedBlobHash) internal pure {
         if (blobHash != retrievedBlobHash) {
-            revert BlobHashMismatch({ expected: blobHash, actual: retrievedBlobHash });
+            revert BlobHashMismatch({expected: blobHash, actual: retrievedBlobHash});
         }
     }
 }

--- a/src/state/CommitmentAccumulator.sol
+++ b/src/state/CommitmentAccumulator.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Arrays } from "@openzeppelin-contracts/utils/Arrays.sol";
-import { EnumerableSet } from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import {Arrays} from "@openzeppelin-contracts/utils/Arrays.sol";
+import {EnumerableSet} from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
-import { ICommitmentAccumulator } from "../interfaces/ICommitmentAccumulator.sol";
-import { MerkleTree } from "./MerkleTree.sol";
+import {ICommitmentAccumulator} from "../interfaces/ICommitmentAccumulator.sol";
+import {MerkleTree} from "./MerkleTree.sol";
 
 contract CommitmentAccumulator is ICommitmentAccumulator {
     using MerkleTree for MerkleTree.Tree;
@@ -47,17 +47,12 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         isContained = _containsRoot(root);
     }
 
-    function verifyMerkleProof(
-        bytes32 root,
-        bytes32 commitment,
-        bytes32[] calldata path,
-        uint256 directionBits
-    )
+    function verifyMerkleProof(bytes32 root, bytes32 commitment, bytes32[] calldata path, uint256 directionBits)
         external
         view
         override
     {
-        _verifyMerkleProof({ root: root, commitment: commitment, path: path, directionBits: directionBits });
+        _verifyMerkleProof({root: root, commitment: commitment, path: path, directionBits: directionBits});
     }
 
     function merkleProof(bytes32 commitment)
@@ -74,7 +69,7 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         (index, newRoot) = _merkleTree.push(commitment);
         _indices[commitment] = index + _COMMITMENT_INDEX_OFFSET; // Add 1 to use 0 as a sentinel value
 
-        emit CommitmentAdded({ commitment: commitment, index: index });
+        emit CommitmentAdded({commitment: commitment, index: index});
     }
 
     // slither-disable-next-line dead-code
@@ -90,18 +85,13 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         emit RootAdded(root);
     }
 
-    function _verifyMerkleProof(
-        bytes32 root,
-        bytes32 commitment,
-        bytes32[] calldata path,
-        uint256 directionBits
-    )
+    function _verifyMerkleProof(bytes32 root, bytes32 commitment, bytes32[] calldata path, uint256 directionBits)
         internal
         view
     {
         // Check length.
         if (path.length != _merkleTree.depth()) {
-            revert InvalidPathLength({ expected: _merkleTree.depth(), actual: path.length });
+            revert InvalidPathLength({expected: _merkleTree.depth(), actual: path.length});
         }
 
         // Check root existence.
@@ -111,7 +101,7 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         bytes32 computedRoot = path.processProof(directionBits, commitment);
 
         if (root != computedRoot) {
-            revert InvalidRoot({ expected: root, actual: computedRoot });
+            revert InvalidRoot({expected: root, actual: computedRoot});
         }
     }
 
@@ -141,13 +131,13 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
 
         bytes32 retrieved = _commitmentAtIndex(index);
         if (retrieved != commitment) {
-            revert CommitmentMismatch({ expected: commitment, actual: retrieved });
+            revert CommitmentMismatch({expected: commitment, actual: retrieved});
         }
     }
 
     function _commitmentAtIndex(uint256 index) internal view returns (bytes32 commitment) {
         if (index + 1 > _merkleTree._nextLeafIndex) {
-            revert CommitmentIndexOutOfBounds({ current: index, limit: _merkleTree._nextLeafIndex });
+            revert CommitmentIndexOutOfBounds({current: index, limit: _merkleTree._nextLeafIndex});
         }
 
         commitment = _merkleTree._nodes[0][index];

--- a/src/state/MerkleTree.sol
+++ b/src/state/MerkleTree.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Arrays } from "@openzeppelin-contracts/utils/Arrays.sol";
+import {Arrays} from "@openzeppelin-contracts/utils/Arrays.sol";
 
-import { SHA256 } from "../libs/SHA256.sol";
+import {SHA256} from "../libs/SHA256.sol";
 
 /// @notice A Merkle tree implementation populating a tree of variable depth from left to right
 /// and providing on-chain Merkle proofs.
@@ -92,10 +92,7 @@ library MerkleTree {
     /// @param index The index of the leaf.
     /// @return siblings The siblings of the leaf to proof inclusion for.
     /// @return directionBits The direction bits indicating whether the siblings are left of right.
-    function merkleProof(
-        Tree storage self,
-        uint256 index
-    )
+    function merkleProof(Tree storage self, uint256 index)
         internal
         view
         returns (bytes32[] memory siblings, uint256 directionBits)
@@ -165,11 +162,7 @@ library MerkleTree {
     /// @param directionBits The direction bits indicating whether the siblings are left of right.
     /// @param leaf The leaf.
     /// @return root The resulting root obtained by processing the leaf, siblings, and direction bits.
-    function processProof(
-        bytes32[] memory siblings,
-        uint256 directionBits,
-        bytes32 leaf
-    )
+    function processProof(bytes32[] memory siblings, uint256 directionBits, bytes32 leaf)
         internal
         pure
         returns (bytes32 root)

--- a/src/state/NullifierSet.sol
+++ b/src/state/NullifierSet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { EnumerableSet } from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import {EnumerableSet} from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
 contract NullifierSet {
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -18,14 +18,14 @@ contract NullifierSet {
         if (!success) {
             revert PreExistingNullifier(nullifier);
         }
-        emit NullifierAdded({ nullifier: nullifier, index: _nullifierSet.length() - 1 });
+        emit NullifierAdded({nullifier: nullifier, index: _nullifierSet.length() - 1});
     }
 
     function _addNullifierUnchecked(bytes32 nullifier) internal {
         // slither-disable-next-line unused-return
         _nullifierSet.add(nullifier);
 
-        emit NullifierAdded({ nullifier: nullifier, index: _nullifierSet.length() - 1 });
+        emit NullifierAdded({nullifier: nullifier, index: _nullifierSet.length() - 1});
     }
 
     function _checkNullifierNonExistence(bytes32 nullifier) internal view {

--- a/test/Deployment.t.sol
+++ b/test/Deployment.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { Deploy } from "../script/Deploy.s.sol";
+import {Deploy} from "../script/Deploy.s.sol";
 
-import { ProtocolAdapter } from "../src/ProtocolAdapter.sol";
+import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 
 contract ProtocolAdapterTest is Test {
     ProtocolAdapter internal _pa;

--- a/test/Identities.t.sol
+++ b/test/Identities.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Test } from "forge-std/Test.sol";
-import { VmSafe } from "forge-std/Vm.sol";
+import {Test} from "forge-std/Test.sol";
+import {VmSafe} from "forge-std/Vm.sol";
 
-import { EllipticCurveK256 } from "../src/libs/EllipticCurveK256.sol";
-import { Universal } from "../src/libs/Identities.sol";
+import {EllipticCurveK256} from "../src/libs/EllipticCurveK256.sol";
+import {Universal} from "../src/libs/Identities.sol";
 
 contract UniversalIdentityTest is Test {
     bytes internal _publicKey;
@@ -13,7 +13,7 @@ contract UniversalIdentityTest is Test {
     address internal _account;
 
     function setUp() public {
-        (uint256 x, uint256 y) = EllipticCurveK256.derivePubKey({ privateKey: Universal.PRIVATE_KEY });
+        (uint256 x, uint256 y) = EllipticCurveK256.derivePubKey({privateKey: Universal.PRIVATE_KEY});
         _publicKey = abi.encode(bytes32(x), bytes32(y));
 
         _hashedKey = keccak256(_publicKey);

--- a/test/ProtocolAdapter.t.sol
+++ b/test/ProtocolAdapter.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { RiscZeroMockVerifier } from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
-import { Test } from "forge-std/Test.sol";
+import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { ProtocolAdapter } from "../src/ProtocolAdapter.sol";
-import { Resource, Transaction } from "../src/Types.sol";
+import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
+import {Resource, Transaction} from "../src/Types.sol";
 
-import { MockRiscZeroProof } from "./mocks/MockRiscZeroProof.sol";
-import { MockTypes } from "./mocks/MockTypes.sol";
+import {MockRiscZeroProof} from "./mocks/MockRiscZeroProof.sol";
+import {MockTypes} from "./mocks/MockTypes.sol";
 
 contract ProtocolAdapterTest is Test {
     uint8 internal constant _TREE_DEPTH = 2 ^ 32;
@@ -55,7 +55,7 @@ contract ProtocolAdapterTest is Test {
 
     function test_execute() public {
         (Resource[] memory consumed, Resource[] memory created) =
-            MockTypes.mockResources({ nConsumed: 1, ephConsumed: true, nCreated: 1, ephCreated: false, seed: 0 });
+            MockTypes.mockResources({nConsumed: 1, ephConsumed: true, nCreated: 1, ephCreated: false, seed: 0});
 
         Transaction memory txn = MockTypes.mockTransaction({
             mockVerifier: _mockVerifier,
@@ -80,7 +80,7 @@ contract ProtocolAdapterTest is Test {
 
     function test_verify() public view {
         (Resource[] memory consumed, Resource[] memory created) =
-            MockTypes.mockResources({ nConsumed: 1, ephConsumed: true, nCreated: 1, ephCreated: false, seed: 0 });
+            MockTypes.mockResources({nConsumed: 1, ephConsumed: true, nCreated: 1, ephCreated: false, seed: 0});
 
         Transaction memory txn = MockTypes.mockTransaction({
             mockVerifier: _mockVerifier,

--- a/test/mocks/BlobStorageMock.sol
+++ b/test/mocks/BlobStorageMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { BlobStorage, DeletionCriterion } from "../../src/state/BlobStorage.sol";
+import {BlobStorage, DeletionCriterion} from "../../src/state/BlobStorage.sol";
 
 contract BlobStorageMock is BlobStorage {
     function storeBlob(bytes calldata blob, DeletionCriterion deletionCriterion) external returns (bytes32 blobHash) {

--- a/test/mocks/CommitmentAccumulatorMock.sol
+++ b/test/mocks/CommitmentAccumulatorMock.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { EnumerableSet } from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import {EnumerableSet} from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
-import { CommitmentAccumulator } from "../../src/state/CommitmentAccumulator.sol";
-import { MerkleTree } from "../../src/state/MerkleTree.sol";
+import {CommitmentAccumulator} from "../../src/state/CommitmentAccumulator.sol";
+import {MerkleTree} from "../../src/state/MerkleTree.sol";
 
 contract CommitmentAccumulatorMock is CommitmentAccumulator {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using MerkleTree for MerkleTree.Tree;
 
-    constructor(uint8 treeDepth) CommitmentAccumulator(treeDepth) { }
+    constructor(uint8 treeDepth) CommitmentAccumulator(treeDepth) {}
 
     function addCommitment(bytes32 commitment) external returns (bytes32 newRoot) {
         newRoot = _addCommitment(commitment);

--- a/test/mocks/MockDelta.sol
+++ b/test/mocks/MockDelta.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Universal } from "../../src/libs/Identities.sol";
-import { Delta } from "../../src/proving/Delta.sol";
+import {Universal} from "../../src/libs/Identities.sol";
+import {Delta} from "../../src/proving/Delta.sol";
 
 library MockDelta {
     using Delta for uint256[2];
@@ -47,6 +47,6 @@ library MockDelta {
         // for the mock verification to work
         if (keccak256(deltaProof) != keccak256(PROOF)) revert WrongUsage();
 
-        Delta.verify({ transactionHash: MESSAGE_HASH, transactionDelta: transactionDelta(), deltaProof: deltaProof });
+        Delta.verify({transactionHash: MESSAGE_HASH, transactionDelta: transactionDelta(), deltaProof: deltaProof});
     }
 }

--- a/test/mocks/MockDelta.t.sol
+++ b/test/mocks/MockDelta.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { ECDSA } from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
-import { Test } from "forge-std/Test.sol";
+import {ECDSA} from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { Delta } from "../../src/proving/Delta.sol";
-import { MockDelta } from "./MockDelta.sol";
+import {Delta} from "../../src/proving/Delta.sol";
+import {MockDelta} from "./MockDelta.sol";
 
 contract MockDeltaTest is Test {
     function test_signatureIntegrity() public pure {
@@ -16,7 +16,7 @@ contract MockDeltaTest is Test {
     }
 
     function test_signatureRecovery() public pure {
-        address recovered = ECDSA.recover({ hash: MockDelta.MESSAGE_HASH, signature: MockDelta.PROOF });
+        address recovered = ECDSA.recover({hash: MockDelta.MESSAGE_HASH, signature: MockDelta.PROOF});
         assertEq(recovered, MockDelta.SIGNER_ACCOUNT);
     }
 

--- a/test/mocks/MockRiscZeroProof.t.sol
+++ b/test/mocks/MockRiscZeroProof.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Bytes } from "@openzeppelin-contracts/utils/Bytes.sol";
-import { Receipt as RiscZeroReceipt, VerificationFailed } from "@risc0-ethereum/IRiscZeroVerifier.sol";
-import { RiscZeroMockVerifier, SelectorMismatch } from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
+import {Bytes} from "@openzeppelin-contracts/utils/Bytes.sol";
+import {Receipt as RiscZeroReceipt, VerificationFailed} from "@risc0-ethereum/IRiscZeroVerifier.sol";
+import {RiscZeroMockVerifier, SelectorMismatch} from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { MockRiscZeroProof } from "./MockRiscZeroProof.sol";
+import {MockRiscZeroProof} from "./MockRiscZeroProof.sol";
 
 contract MockRiscZeroProofTest is Test {
     using Bytes for bytes;
@@ -37,7 +37,7 @@ contract MockRiscZeroProofTest is Test {
     function test_wrongSeal() public {
         bytes memory wrongSeal = abi.encode(MockRiscZeroProof.VERIFIER_SELECTOR, "WRONG_DATA");
 
-        vm.expectRevert(VerificationFailed.selector);
+        vm.expectRevert(VerificationFailed.selector, address(_MOCK_VERIFIER));
         _MOCK_VERIFIER.verify({
             seal: wrongSeal,
             imageId: MockRiscZeroProof.IMAGE_ID_1,
@@ -49,7 +49,8 @@ contract MockRiscZeroProofTest is Test {
         bytes4 wrongSelector = bytes4(0);
 
         vm.expectRevert(
-            abi.encodeWithSelector(SelectorMismatch.selector, wrongSelector, MockRiscZeroProof.VERIFIER_SELECTOR)
+            abi.encodeWithSelector(SelectorMismatch.selector, wrongSelector, MockRiscZeroProof.VERIFIER_SELECTOR),
+            address(_MOCK_VERIFIER)
         );
         _MOCK_VERIFIER.verify({
             seal: abi.encode(wrongSelector),
@@ -61,8 +62,8 @@ contract MockRiscZeroProofTest is Test {
     function test_wrongJournalDigest() public {
         bytes32 wrongDigest = bytes32(0);
 
-        vm.expectRevert(VerificationFailed.selector);
-        _MOCK_VERIFIER.verify({ seal: _proof.seal, imageId: MockRiscZeroProof.IMAGE_ID_1, journalDigest: wrongDigest });
+        vm.expectRevert(VerificationFailed.selector, address(_MOCK_VERIFIER));
+        _MOCK_VERIFIER.verify({seal: _proof.seal, imageId: MockRiscZeroProof.IMAGE_ID_1, journalDigest: wrongDigest});
     }
     /// @notice It should verify correct _proofs.
 

--- a/test/mocks/MockTree.sol
+++ b/test/mocks/MockTree.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { SHA256 } from "../../src/libs/SHA256.sol";
+import {SHA256} from "../../src/libs/SHA256.sol";
 
-import { MerkleTree } from "../../src/state/MerkleTree.sol";
+import {MerkleTree} from "../../src/state/MerkleTree.sol";
 
 contract MockTree {
     uint8 internal constant _TREE_DEPTH = 2;

--- a/test/mocks/MockTypes.sol
+++ b/test/mocks/MockTypes.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Receipt as RiscZeroReceipt } from "@risc0-ethereum/IRiscZeroVerifier.sol";
-import { RiscZeroMockVerifier } from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
+import {Receipt as RiscZeroReceipt} from "@risc0-ethereum/IRiscZeroVerifier.sol";
+import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
 
-import { AppData, TagAppDataPair } from "../../src/libs/AppData.sol";
-import { ComputableComponents } from "../../src/libs/ComputableComponents.sol";
-import { Universal } from "../../src/libs/Identities.sol";
+import {AppData, TagAppDataPair} from "../../src/libs/AppData.sol";
+import {ComputableComponents} from "../../src/libs/ComputableComponents.sol";
+import {Universal} from "../../src/libs/Identities.sol";
 
-import { ComplianceUnit, ComplianceInstance, ConsumedRefs, CreatedRefs } from "../../src/proving/Compliance.sol";
-import { Delta } from "../../src/proving/Delta.sol";
-import { LogicInstance, TagLogicProofPair, LogicRefProofPair } from "../../src/proving/Logic.sol";
+import {ComplianceUnit, ComplianceInstance, ConsumedRefs, CreatedRefs} from "../../src/proving/Compliance.sol";
+import {Delta} from "../../src/proving/Delta.sol";
+import {LogicInstance, TagLogicProofPair, LogicRefProofPair} from "../../src/proving/Logic.sol";
 
-import { ExpirableBlob, DeletionCriterion } from "../../src/state/BlobStorage.sol";
-import { Action, ResourceForwarderCalldataPair, Resource, Transaction } from "../../src/Types.sol";
+import {ExpirableBlob, DeletionCriterion} from "../../src/state/BlobStorage.sol";
+import {Action, ResourceForwarderCalldataPair, Resource, Transaction} from "../../src/Types.sol";
 
-import { MockDelta } from "../mocks/MockDelta.sol";
-import { MockRiscZeroProof } from "../mocks/MockRiscZeroProof.sol";
+import {MockDelta} from "../mocks/MockDelta.sol";
+import {MockRiscZeroProof} from "../mocks/MockRiscZeroProof.sol";
 
 library MockTypes {
     using ComputableComponents for Resource;
@@ -34,15 +34,11 @@ library MockTypes {
         bytes32 root,
         Resource[] memory consumed,
         Resource[] memory created
-    )
-        internal
-        view
-        returns (Transaction memory transaction)
-    {
+    ) internal view returns (Transaction memory transaction) {
         bytes32[] memory roots = new bytes32[](1);
         roots[0] = root;
 
-        (consumed, created) = padResources({ consumed: consumed, created: created });
+        (consumed, created) = padResources({consumed: consumed, created: created});
 
         if (consumed.length != created.length) revert SevereError();
 
@@ -81,12 +77,12 @@ library MockTypes {
                 }
             }
 
-            TagAppDataPair[] memory appData = mockAppData({ nullifiers: nfs, commitments: cms });
+            TagAppDataPair[] memory appData = mockAppData({nullifiers: nfs, commitments: cms});
             TagLogicProofPair[] memory rlProofs =
-                _mockLogicProofs({ mockVerifier: mockVerifier, nullifiers: nfs, commitments: cms, appData: appData });
+                _mockLogicProofs({mockVerifier: mockVerifier, nullifiers: nfs, commitments: cms, appData: appData});
 
             ComplianceUnit[] memory complianceUnits =
-                mockComplianceUnits({ mockVerifier: mockVerifier, root: roots[0], commitments: cms, nullifiers: nfs });
+                mockComplianceUnits({mockVerifier: mockVerifier, root: roots[0], commitments: cms, nullifiers: nfs});
 
             ResourceForwarderCalldataPair[] memory emptyCalls;
 
@@ -102,7 +98,7 @@ library MockTypes {
 
         bytes memory deltaProof = MockDelta.PROOF;
 
-        transaction = Transaction({ roots: roots, actions: actions, deltaProof: deltaProof });
+        transaction = Transaction({roots: roots, actions: actions, deltaProof: deltaProof});
     }
 
     // solhint-disable-next-line function-max-lines
@@ -111,11 +107,7 @@ library MockTypes {
         bytes32[] memory nullifiers,
         bytes32[] memory commitments,
         TagAppDataPair[] memory appData
-    )
-        internal
-        view
-        returns (TagLogicProofPair[] memory logicProofs)
-    {
+    ) internal view returns (TagLogicProofPair[] memory logicProofs) {
         logicProofs = new TagLogicProofPair[](nullifiers.length + commitments.length);
 
         uint256 len = nullifiers.length;
@@ -139,7 +131,7 @@ library MockTypes {
 
             logicProofs[i] = TagLogicProofPair({
                 tag: tag,
-                pair: LogicRefProofPair({ logicRef: _ALWAYS_VALID_LOGIC_REF, proof: receipt.seal })
+                pair: LogicRefProofPair({logicRef: _ALWAYS_VALID_LOGIC_REF, proof: receipt.seal})
             });
         }
 
@@ -164,7 +156,7 @@ library MockTypes {
 
             logicProofs[nullifiers.length + i] = TagLogicProofPair({
                 tag: tag,
-                pair: LogicRefProofPair({ logicRef: _ALWAYS_VALID_LOGIC_REF, proof: receipt.seal })
+                pair: LogicRefProofPair({logicRef: _ALWAYS_VALID_LOGIC_REF, proof: receipt.seal})
             });
         }
     }
@@ -174,11 +166,7 @@ library MockTypes {
         bytes32 root,
         bytes32[] memory nullifiers,
         bytes32[] memory commitments
-    )
-        internal
-        view
-        returns (ComplianceUnit[] memory units)
-    {
+    ) internal view returns (ComplianceUnit[] memory units) {
         if (nullifiers.length != commitments.length) revert SevereError();
 
         bytes32 verifyingKey = MockRiscZeroProof.IMAGE_ID_2; // TODO
@@ -188,27 +176,21 @@ library MockTypes {
 
         for (uint256 i = 0; i < nUnits; ++i) {
             ComplianceInstance memory instance = ComplianceInstance({
-                consumed: ConsumedRefs({ nullifierRef: nullifiers[i], rootRef: root, logicRef: _ALWAYS_VALID_LOGIC_REF }),
-                created: CreatedRefs({ commitmentRef: commitments[i], logicRef: _ALWAYS_VALID_LOGIC_REF }),
+                consumed: ConsumedRefs({nullifierRef: nullifiers[i], rootRef: root, logicRef: _ALWAYS_VALID_LOGIC_REF}),
+                created: CreatedRefs({commitmentRef: commitments[i], logicRef: _ALWAYS_VALID_LOGIC_REF}),
                 unitDelta: Delta.zero() // TODO
-             });
+            });
 
             RiscZeroReceipt memory receipt = mockVerifier.mockProve({
                 imageId: MockRiscZeroProof.IMAGE_ID_2,
                 journalDigest: sha256(abi.encode(verifyingKey, instance))
             });
 
-            units[i] = ComplianceUnit({ proof: receipt.seal, instance: instance, verifyingKey: verifyingKey });
+            units[i] = ComplianceUnit({proof: receipt.seal, instance: instance, verifyingKey: verifyingKey});
         }
     }
 
-    function mockResources(
-        uint16 nConsumed,
-        bool ephConsumed,
-        uint16 nCreated,
-        bool ephCreated,
-        uint256 seed
-    )
+    function mockResources(uint16 nConsumed, bool ephConsumed, uint16 nCreated, bool ephCreated, uint256 seed)
         internal
         pure
         returns (Resource[] memory consumed, Resource[] memory created)
@@ -242,10 +224,7 @@ library MockTypes {
         }
     }
 
-    function mockAppData(
-        bytes32[] memory nullifiers,
-        bytes32[] memory commitments
-    )
+    function mockAppData(bytes32[] memory nullifiers, bytes32[] memory commitments)
         internal
         pure
         returns (TagAppDataPair[] memory appData)
@@ -256,14 +235,14 @@ library MockTypes {
             for (uint256 i = 0; i < len; ++i) {
                 appData[i] = TagAppDataPair({
                     tag: nullifiers[i],
-                    appData: ExpirableBlob({ deletionCriterion: DeletionCriterion.Immediately, blob: _MOCK_BLOB })
+                    appData: ExpirableBlob({deletionCriterion: DeletionCriterion.Immediately, blob: _MOCK_BLOB})
                 });
             }
             len = commitments.length;
             for (uint256 i = 0; i < len; ++i) {
                 appData[nullifiers.length + i] = TagAppDataPair({
                     tag: commitments[i],
-                    appData: ExpirableBlob({ deletionCriterion: DeletionCriterion.Immediately, blob: _MOCK_BLOB })
+                    appData: ExpirableBlob({deletionCriterion: DeletionCriterion.Immediately, blob: _MOCK_BLOB})
                 });
             }
         }
@@ -282,10 +261,7 @@ library MockTypes {
         });
     }
 
-    function padResources(
-        Resource[] memory consumed,
-        Resource[] memory created
-    )
+    function padResources(Resource[] memory consumed, Resource[] memory created)
         internal
         pure
         returns (Resource[] memory consumedPadded, Resource[] memory createdPadded)

--- a/test/mocks/NullifierSetMock.sol
+++ b/test/mocks/NullifierSetMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { NullifierSet } from "../../src/state/NullifierSet.sol";
+import {NullifierSet} from "../../src/state/NullifierSet.sol";
 
 contract NullifierSetMock is NullifierSet {
     function addNullifier(bytes32 nullifier) external {

--- a/test/proofs/ComplianceProof.t.sol
+++ b/test/proofs/ComplianceProof.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Receipt as RiscZeroReceipt } from "@risc0-ethereum/IRiscZeroVerifier.sol";
-import { RiscZeroVerifierRouter } from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
-import { RiscZeroMockVerifier } from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
+import {Receipt as RiscZeroReceipt} from "@risc0-ethereum/IRiscZeroVerifier.sol";
+import {RiscZeroVerifierRouter} from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
+import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { ExampleComplianceProof } from "../mocks/ExampleComplianceProof.sol";
+import {ExampleComplianceProof} from "../mocks/ExampleComplianceProof.sol";
 
 contract ComplianceProofTest is Test {
     RiscZeroVerifierRouter internal _sepoliaVerifierRouter;
@@ -18,7 +18,7 @@ contract ComplianceProofTest is Test {
 
     function setUp() public {
         _sepoliaVerifierRouter = RiscZeroVerifierRouter(0x925d8331ddc0a1F0d96E68CF073DFE1d92b69187);
-        _mockVerifier = new RiscZeroMockVerifier({ selector: bytes4(ExampleComplianceProof.SEAL) });
+        _mockVerifier = new RiscZeroMockVerifier({selector: bytes4(ExampleComplianceProof.SEAL)});
 
         _mockReceipt = _mockVerifier.mockProve({
             imageId: ExampleComplianceProof.COMPLIANCE_CIRCUIT_ID,

--- a/test/state/BlobStorage.t.sol
+++ b/test/state/BlobStorage.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { BlobStorage, DeletionCriterion } from "../../src/state/BlobStorage.sol";
+import {BlobStorage, DeletionCriterion} from "../../src/state/BlobStorage.sol";
 
-import { BlobStorageMock } from "../mocks/BlobStorageMock.sol";
+import {BlobStorageMock} from "../mocks/BlobStorageMock.sol";
 
 contract BlobStorageTest is Test {
     string internal constant _BLOB_CONTENT = "Blob";

--- a/test/state/MerkleTree.t.sol
+++ b/test/state/MerkleTree.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { MerkleTree } from "../../src/state/MerkleTree.sol";
-import { MockTree } from "../mocks/MockTree.sol";
+import {MerkleTree} from "../../src/state/MerkleTree.sol";
+import {MockTree} from "../mocks/MockTree.sol";
 
 contract MerkleTreeTest is Test, MockTree {
     using MerkleTree for MerkleTree.Tree;

--- a/test/state/NullifierSet.t.sol
+++ b/test/state/NullifierSet.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import { NullifierSet } from "../../src/state/NullifierSet.sol";
-import { NullifierSetMock } from "../mocks/NullifierSetMock.sol";
+import {NullifierSet} from "../../src/state/NullifierSet.sol";
+import {NullifierSetMock} from "../mocks/NullifierSetMock.sol";
 
 contract NullifierSetTest is Test {
     bytes32 internal constant _EXAMPLE_NF = bytes32(0);
@@ -23,14 +23,18 @@ contract NullifierSetTest is Test {
     function test_addNullifier_reverts_on_duplicate() public {
         _nfSet.addNullifier(_EXAMPLE_NF);
 
-        vm.expectRevert(abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF));
+        vm.expectRevert(
+            abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF), address(_nfSet)
+        );
         _nfSet.addNullifier(_EXAMPLE_NF);
     }
 
     function test_addNullifierUnchecked_adds_nullifier() public {
         _nfSet.addNullifierUnchecked(_EXAMPLE_NF);
 
-        vm.expectRevert(abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF));
+        vm.expectRevert(
+            abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF), address(_nfSet)
+        );
         _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
     }
 
@@ -43,7 +47,9 @@ contract NullifierSetTest is Test {
     function test_checkNullifierNonExistence_reverts_on_existent_nullifier() public {
         _nfSet.addNullifier(_EXAMPLE_NF);
 
-        vm.expectRevert(abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF));
+        vm.expectRevert(
+            abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF), address(_nfSet)
+        );
         _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
     }
 


### PR DESCRIPTION
This PR adds the reverting contract address to the `expectRevert` statement and fixes formatting discrepancies between src and test files