### PR TITLE
refactor: simplify forwarder by removing `Ownable`

### DIFF
--- a/src/ERC20Forwarder.sol
+++ b/src/ERC20Forwarder.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
 import {Address} from "@openzeppelin-contracts/utils/Address.sol";
 
 import {ForwarderBase} from "./ForwarderBase.sol";
 
-contract ERC20Forwarder is Ownable, ForwarderBase {
+contract ERC20Forwarder is ForwarderBase {
     using Address for address;
 
     address internal immutable _ERC20_CONTRACT;

--- a/src/ForwarderBase.sol
+++ b/src/ForwarderBase.sol
@@ -1,23 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import {Ownable} from "@openzeppelin-contracts/access/Ownable.sol";
-
 import {IForwarder} from "./interfaces/IForwarder.sol";
 import {ComputableComponents} from "./libs/ComputableComponents.sol";
 
 /// A contract owning EVM state and executing EVM calls.
-abstract contract ForwarderBase is IForwarder, Ownable {
+abstract contract ForwarderBase is IForwarder {
+    address internal immutable _PROTOCOL_ADAPTER;
+
     /// @notice The the calldata carrier resource kind.
     bytes32 internal immutable _CALLDATA_CARRIER_RESOURCE_KIND;
 
-    constructor(address protocolAdapter, bytes32 calldataCarrierLogicRef) Ownable(protocolAdapter) {
+    error UnauthorizedCaller(address caller);
+
+    constructor(address protocolAdapter, bytes32 calldataCarrierLogicRef) {
         _CALLDATA_CARRIER_RESOURCE_KIND =
             ComputableComponents.kind({logicRef: calldataCarrierLogicRef, labelRef: sha256(abi.encode(address(this)))});
+
+        _PROTOCOL_ADAPTER = protocolAdapter;
     }
 
     /// @inheritdoc IForwarder
-    function forwardCall(bytes calldata input) external onlyOwner returns (bytes memory output) {
+    function forwardCall(bytes calldata input) external returns (bytes memory output) {
+        if (msg.sender != _PROTOCOL_ADAPTER) {
+            revert UnauthorizedCaller(msg.sender);
+        }
         output = _forwardCall(input);
     }
 


### PR DESCRIPTION
This PR replaces the OZ `Ownable` by a custom implementation to simplify the contract and remove the `setOwner` functionality.