### PR TITLE
Fix Bug Allowing Transactions with Empty Compliance Units

### DIFF
--- a/contracts/test/Deployment.t.sol
+++ b/contracts/test/Deployment.t.sol
@@ -17,6 +17,6 @@ contract ProtocolAdapterTest is Test {
     }
 
     function test_run_deploys_deterministically() public view {
-        assertEq(address(_pa), 0xC5033726a1fb969743A6f5Baf1753D56c6e1692b);
+        assertEq(address(_pa), 0x7C1Ff2728f505C81F58c12175DE2B81b0C744b66);
     }
 }


### PR DESCRIPTION
Previously, it was possible to submit a transaction without compliance
units, trivial delta proof, and it would pass given that the resource
logics pass. That means, you could e.g. consume resources without ever
proving they existed before.

This commit changes that by checking that the number of tags in an
action in exactly twice the number of compliance units.

Coupled with the check ensuring no double-creation/consumption in the
same action it grants the desired property.