### PR TITLE
Compute Delta Instance By Starting With 0

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -209,19 +209,12 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                     }
 
                     // Compute transaction delta
-                    if (i == 0 && j == 0) {
-                        transactionDelta = [
+                    transactionDelta = transactionDelta.add(
+                        [
                             uint256(complianceVerifierInput.instance.unitDeltaX),
                             uint256(complianceVerifierInput.instance.unitDeltaY)
-                        ];
-                    } else {
-                        transactionDelta = transactionDelta.add(
-                            [
-                                uint256(complianceVerifierInput.instance.unitDeltaX),
-                                uint256(complianceVerifierInput.instance.unitDeltaY)
-                            ]
-                        );
-                    }
+                        ]
+                    );
                 }
             }
 


### PR DESCRIPTION
Previously the delta-computation for the instance started up at the first delta of the first compliance unit. Now, we just sum up starting from the zero of the curve.