### PR TITLE
Compute Action Tree Through Compliance Units

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -143,6 +143,8 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
             uint256 nCUs = action.complianceVerifierInputs.length;
             uint256 nResources = action.logicVerifierInputs.length;
 
+            bytes32[] memory actionTags = new bytes32[](nResources);
+
             // Check that the resource counts in the action and compliance units match
             if (nResources != nCUs * 2) {
                 revert ResourceCountMismatch({expected: nResources, actual: nCUs});
@@ -171,6 +173,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                         // Add the nullifier to the list of tags
                         // solhint-disable-next-line gas-increment-by-one
                         tags[resCounter++] = nf;
+                        actionTags[2 * j] = nf;
                     }
 
                     {
@@ -183,6 +186,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                         // Add the nullifier to the list of tags
                         // solhint-disable-next-line gas-increment-by-one
                         tags[resCounter++] = cm;
+                        actionTags[(2 * j) + 1] = cm;
                     }
 
                     // slither-disable-next-line calls-loop
@@ -226,10 +230,6 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
             // Logic Proofs
             {
-                bytes32[] memory actionTags = new bytes32[](nResources);
-                for (uint256 j = 0; j < nResources; ++j) {
-                    actionTags[j] = action.logicVerifierInputs[j].instance.tag;
-                }
                 bytes32 computedActionTreeRoot = MerkleTree.computeRoot(actionTags, _ACTION_TAG_TREE_DEPTH);
 
                 for (uint256 j = 0; j < nResources; ++j) {


### PR DESCRIPTION
Previously the computation of the Action tree happened by iterating over Action verifier inputs, yet canonically it happens in the order provided by the Compliance Units.

This also saves gas: on `test_verify_40` as much as 30k gas is saved.