### PR TITLE
fix: don't store roots for empty transactions

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -97,8 +97,10 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
             }
         }
 
-        // Store the latest root
-        _storeRoot(newRoot);
+        if (newRoot != 0) {
+            // Store the latest root
+            _storeRoot(newRoot);
+        }
     }
     // slither-disable-end reentrancy-no-eth
 


### PR DESCRIPTION
The zero root is an invalid root and should not be stored. Moreover, this would allow an empty transaction to be executed only once.