### PR TITLE
build: bump evm version

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -32,7 +32,7 @@ bytecode_hash = "none"
 
 solc = "0.8.30"
 auto_detect_solc = false
-evm_version = "cancun"
+evm_version = "prague"
 fuzz = { runs = 1_000 }
 gas_reports = [
     "ProtocolAdapter",


### PR DESCRIPTION
The Ethereum prague electra (a.k.a. pectra) hardfork has happened in May (https://ethereum.org/en/history/#pectra).
Changes from this update should be considered in code compilation and optimization.

Hence, we bump the evm version in forge.