### PR TITLE
ci: print calldata sizes

### DIFF
--- a/contracts/.solhint.other.json
+++ b/contracts/.solhint.other.json
@@ -3,7 +3,7 @@
   "rules": {
     "explicit-types": "error",
     "max-states-count": "error",
-    "no-console": "error",
+    "no-console": "off",
     "no-empty-blocks": "error",
     "no-global-import": "error",
     "no-unused-import": "error",
@@ -49,7 +49,7 @@
     "avoid-tx-origin": "error",
     "check-send-result": "error",
     "compiler-version": ["error", "^0.8.24"],
-    "func-visibility": ["error", { "ignoreConstructors": true }],
+    "func-visibility": ["error", {"ignoreConstructors": true}],
 
     "multiple-sends": "error",
     "no-complex-fallback": "error",

--- a/contracts/test/benchmark/Benchmark.t.sol
+++ b/contracts/test/benchmark/Benchmark.t.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {RiscZeroVerifierRouter} from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console} from "forge-std/Test.sol";
 
 import {ProtocolAdapter} from "../../src/ProtocolAdapter.sol";
 import {Transaction} from "../../src/Types.sol";
@@ -135,5 +136,32 @@ contract Benchmark is BenchmarkData {
 
     function test_verify_40() public view {
         _pa.verify(_txns[9]);
+    }
+
+    function test_print_calldata() public view {
+        for (uint256 i = 0; i < _txns.length; ++i) {
+            uint256 nCUs = 0;
+
+            uint256 nActions = _txns[i].actions.length;
+
+            for (uint256 j = 0; j < nActions; ++j) {
+                nCUs += _txns[i].actions[j].complianceVerifierInputs.length;
+            }
+
+            string memory output = string(
+                abi.encodePacked(
+                    "Actions: ",
+                    Strings.toString(nActions),
+                    ", ",
+                    "CUs: ",
+                    Strings.toString(nCUs),
+                    ", ",
+                    "Calldata (bytes): ",
+                    Strings.toString(abi.encode(_txns[i]).length)
+                )
+            );
+
+            console.log(output);
+        }
     }
 }


### PR DESCRIPTION
## Scope

Print the calldata sizes for our benchmark transactions to allow estimation of the 2D gas costs on L2's such as Arbitrum and Base.

- #68 


See the printout here: https://github.com/anoma/evm-protocol-adapter/pull/136/checks#step:10:108

```
Logs:
  Actions: 0, CUs: 0, Calldata (bytes): 160
  Actions: 1, CUs: 1, Calldata (bytes): 3136
  Actions: 5, CUs: 5, Calldata (bytes): 14656
  Actions: 10, CUs: 10, Calldata (bytes): 29056
  Actions: 15, CUs: 15, Calldata (bytes): 43456
  Actions: 20, CUs: 20, Calldata (bytes): 57856
  Actions: 25, CUs: 25, Calldata (bytes): 72256
  Actions: 30, CUs: 30, Calldata (bytes): 86656
  Actions: 35, CUs: 35, Calldata (bytes): 101056
  Actions: 40, CUs: 40, Calldata (bytes): 115456
  ```