### PR TITLE
feat: add tests for the `TransactionExecuted` and `ForwarderCallExecuted` events

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -40,7 +40,7 @@
     "constructor-syntax": "error",
     "gas-calldata-parameters": "warn",
     "gas-custom-errors": "warn",
-    "gas-increment-by-one": "warn",
+    "gas-increment-by-one": "off",
     "gas-indexed-events": "warn",
     "gas-length-in-loops": "warn",
     "gas-multitoken1155": "warn",

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -27,6 +27,7 @@ import {Action, ForwarderCalldata, Resource, Transaction} from "./Types.sol";
 /// @notice The protocol adapter contract verifying and executing resource machine transactions.
 /// @custom:security-contact security@anoma.foundation
 contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, CommitmentAccumulator, NullifierSet {
+    using MerkleTree for bytes32[];
     using TagLookup for bytes32[];
     using ComputableComponents for Resource;
     using RiscZeroUtils for Compliance.Instance;
@@ -37,7 +38,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
     RiscZeroVerifierRouter internal immutable _TRUSTED_RISC_ZERO_VERIFIER_ROUTER;
     uint8 internal immutable _ACTION_TAG_TREE_DEPTH;
 
-    uint256 private _txCount;
+    uint256 internal _txCount;
 
     error ForwarderCallOutputMismatch(bytes expected, bytes actual);
 
@@ -102,7 +103,8 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         }
 
         // slither-disable-next-line reentrancy-benign
-        emit TransactionExecuted({id: ++_txCount, transaction: transaction, newRoot: newRoot});
+        // solhint-disable-next-line gas-increment-by-one
+        emit TransactionExecuted({id: _txCount++, transaction: transaction, newRoot: newRoot});
     }
     // slither-disable-end reentrancy-no-eth
 
@@ -253,7 +255,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
             // Logic Proofs
             {
-                bytes32 computedActionTreeRoot = MerkleTree.computeRoot(actionTreeTags, _ACTION_TAG_TREE_DEPTH);
+                bytes32 computedActionTreeRoot = actionTreeTags.computeRoot(_ACTION_TAG_TREE_DEPTH);
 
                 for (uint256 j = 0; j < nResources; ++j) {
                     Logic.VerifierInput calldata input = action.logicVerifierInputs[j];
@@ -341,7 +343,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
                 // Lookup the first appData entry.
                 bytes32 actualAppDataHash =
-                    keccak256(abi.encode(action.logicVerifierInputs.lookup(carrier.commitment()).instance.appData[0]));
+                    keccak256(action.logicVerifierInputs.lookup(carrier.commitment()).instance.appData[0].blob);
 
                 if (actualAppDataHash != expectedAppDataHash) {
                     revert CalldataCarrierAppDataMismatch({actual: actualAppDataHash, expected: expectedAppDataHash});

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -103,7 +103,6 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         }
 
         // slither-disable-next-line reentrancy-benign
-        // solhint-disable-next-line gas-increment-by-one
         emit TransactionExecuted({id: _txCount++, transaction: transaction, newRoot: newRoot});
     }
     // slither-disable-end reentrancy-no-eth
@@ -192,7 +191,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                         _checkNullifierNonExistence(nf);
 
                         // Add the nullifier to the list of tags
-                        // solhint-disable-next-line gas-increment-by-one
+
                         tags[resCounter++] = nf;
                         actionTreeTags[2 * j] = nf;
                     }
@@ -205,7 +204,6 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                         _checkCommitmentNonExistence(cm);
 
                         // Add the nullifier to the list of tags
-                        // solhint-disable-next-line gas-increment-by-one
                         tags[resCounter++] = cm;
                         actionTreeTags[(2 * j) + 1] = cm;
                     }

--- a/contracts/src/libs/MerkleTree.sol
+++ b/contracts/src/libs/MerkleTree.sol
@@ -56,7 +56,6 @@ library MerkleTree {
         uint256 treeDepth = depth(self);
 
         // Get the next leaf index and increment it after assignment.
-        // solhint-disable-next-line gas-increment-by-one
         index = self._nextLeafIndex++;
 
         // Check if the tree is already full.

--- a/contracts/test/EmergencyMigratableForwarderBase.t.sol
+++ b/contracts/test/EmergencyMigratableForwarderBase.t.sol
@@ -9,7 +9,7 @@ import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 import {ForwarderBaseTest} from "./ForwarderBase.t.sol";
 import {EmergencyMigratableForwarderMock} from "./mocks/EmergencyMigratableForwarder.m.sol";
 import {ForwarderMock} from "./mocks/Forwarder.m.sol";
-import {ForwarderTarget} from "./mocks/ForwarderTarget.m.sol";
+import {ForwarderTarget, INPUT_VALUE, OUTPUT_VALUE, INPUT, EXPECTED_OUTPUT} from "./mocks/ForwarderTarget.m.sol";
 import {DeployRiscZeroContracts} from "./script/DeployRiscZeroContracts.s.sol";
 
 contract EmergencyMigratableForwarderBaseTest is ForwarderBaseTest {
@@ -89,7 +89,7 @@ contract EmergencyMigratableForwarderBaseTest is ForwarderBaseTest {
         _stopProtocolAdapter();
 
         vm.expectRevert(EmergencyMigratableForwarderBase.EmergencyCallerNotSet.selector);
-        _emrgFwd.forwardEmergencyCall({input: _INPUT});
+        _emrgFwd.forwardEmergencyCall({input: INPUT});
     }
 
     function test_forwardEmergencyCall_reverts_if_the_pa_is_stopped_but_the_caller_is_not_the_emergency_caller()
@@ -102,7 +102,7 @@ contract EmergencyMigratableForwarderBaseTest is ForwarderBaseTest {
         vm.expectRevert(
             abi.encodeWithSelector(ForwarderBase.UnauthorizedCaller.selector, _EMERGENCY_CALLER, _UNAUTHORIZED_CALLER)
         );
-        _emrgFwd.forwardEmergencyCall({input: _INPUT});
+        _emrgFwd.forwardEmergencyCall({input: INPUT});
     }
 
     function test_forwardEmergencyCall_forwards_calls_if_the_pa_is_stopped_and_the_caller_is_the_emergency_caller()
@@ -112,8 +112,8 @@ contract EmergencyMigratableForwarderBaseTest is ForwarderBaseTest {
         _setEmergencyCaller();
 
         vm.prank(_EMERGENCY_CALLER);
-        bytes memory output = _emrgFwd.forwardEmergencyCall({input: _INPUT});
-        assertEq(keccak256(output), keccak256(_EXPECTED_OUTPUT));
+        bytes memory output = _emrgFwd.forwardEmergencyCall({input: INPUT});
+        assertEq(keccak256(output), keccak256(EXPECTED_OUTPUT));
     }
 
     function test_forwardEmergencyCall_emits_the_EmergencyCallForwarded_event() public {
@@ -122,8 +122,8 @@ contract EmergencyMigratableForwarderBaseTest is ForwarderBaseTest {
 
         vm.prank(_EMERGENCY_CALLER);
         vm.expectEmit(address(_emrgFwd));
-        emit ForwarderMock.EmergencyCallForwarded(_INPUT, _EXPECTED_OUTPUT);
-        _emrgFwd.forwardEmergencyCall({input: _INPUT});
+        emit ForwarderMock.EmergencyCallForwarded(INPUT, EXPECTED_OUTPUT);
+        _emrgFwd.forwardEmergencyCall({input: INPUT});
     }
 
     function test_forwardEmergencyCall_calls_the_function_in_the_target_contract() public {
@@ -132,8 +132,8 @@ contract EmergencyMigratableForwarderBaseTest is ForwarderBaseTest {
         vm.prank(_EMERGENCY_CALLER);
 
         vm.expectEmit(address(_tgt));
-        emit ForwarderTarget.CallReceived(_INPUT_VALUE, _OUTPUT_VALUE);
-        _emrgFwd.forwardEmergencyCall({input: _INPUT});
+        emit ForwarderTarget.CallReceived(INPUT_VALUE, OUTPUT_VALUE);
+        _emrgFwd.forwardEmergencyCall({input: INPUT});
     }
 
     function test_emergencyCaller_returns_the_emergency_caller_after_it_has_been_set() public {

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -39,7 +39,11 @@ contract ProtocolAdapterTest is Test {
         _emergencyStop.estop();
 
         vm.expectRevert(ProtocolAdapter.RiscZeroVerifierStopped.selector);
-        new ProtocolAdapter({riscZeroVerifierRouter: _router, commitmentTreeDepth: 32, actionTagTreeDepth: 4});
+        new ProtocolAdapter({
+            riscZeroVerifierRouter: _router,
+            commitmentTreeDepth: Parameters.COMMITMENT_TREE_DEPTH,
+            actionTagTreeDepth: Parameters.ACTION_TAG_TREE_DEPTH
+        });
     }
 
     function test_verify_reverts_on_vulnerable_risc_zero_verifier() public {

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -88,8 +88,8 @@ contract ProtocolAdapterMockTest is Test {
                 appData: blobs
             });
 
-            ExampleGen.ActionResources[] memory resourceLists = new ExampleGen.ActionResources[](1);
-            resourceLists[0] = ExampleGen.ActionResources({consumed: consumed, created: created});
+            ExampleGen.ResourceLists[] memory resourceLists = new ExampleGen.ResourceLists[](1);
+            resourceLists[0] = ExampleGen.ResourceLists({consumed: consumed, created: created});
             txn = _mockVerifier.transaction(resourceLists, _TEST_COMMITMENT_TREE_DEPTH);
 
             ResourceForwarderCalldataPair[] memory pairs = new ResourceForwarderCalldataPair[](1);

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -258,4 +258,3 @@ contract ProtocolAdapterMockTest is Test {
         _mockPa.verify(txn);
     }
 }
-*/

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -7,19 +7,28 @@ import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.so
 
 import {Test} from "forge-std/Test.sol";
 
+import {IProtocolAdapter} from "../src/interfaces/IProtocolAdapter.sol";
+import {MerkleTree} from "../src/libs/MerkleTree.sol";
 import {TagLookup} from "../src/libs/TagLookup.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
+import {Logic} from "../src/proving/Logic.sol";
 import {CommitmentAccumulator} from "../src/state/CommitmentAccumulator.sol";
 import {NullifierSet} from "../src/state/NullifierSet.sol";
-import {Transaction} from "../src/Types.sol";
+import {Transaction, ResourceForwarderCalldataPair, ForwarderCalldata} from "../src/Types.sol";
 
 import {ExampleGen} from "./mocks/ExampleGen.sol";
+import {ForwarderMock} from "./mocks/Forwarder.m.sol";
+import {INPUT, EXPECTED_OUTPUT} from "./mocks/ForwarderTarget.m.sol";
 import {ProtocolAdapterMock} from "./mocks/ProtocolAdapter.m.sol";
 import {DeployRiscZeroContractsMock} from "./script/DeployRiscZeroContractsMock.s.sol";
 
 contract ProtocolAdapterMockTest is Test {
+    using MerkleTree for bytes32[];
     using ExampleGen for RiscZeroMockVerifier;
     using ExampleGen for Transaction;
+
+    uint8 internal constant _TEST_COMMITMENT_TREE_DEPTH = 8;
+    uint8 internal constant _TEST_ACTION_TAG_TREE_DEPTH = 4;
 
     RiscZeroVerifierRouter internal _router;
     RiscZeroMockVerifier internal _mockVerifier;
@@ -29,13 +38,84 @@ contract ProtocolAdapterMockTest is Test {
     function setUp() public {
         (_router, _emergencyStop, _mockVerifier) = new DeployRiscZeroContractsMock().run();
 
-        _mockPa = new ProtocolAdapterMock(_router, 32, 4);
+        _mockPa = new ProtocolAdapterMock(_router, _TEST_COMMITMENT_TREE_DEPTH, _TEST_ACTION_TAG_TREE_DEPTH);
+    }
+
+    function test_execute_emits_the_TransactionExecuted_event() public {
+        (Transaction memory txn,) = _mockVerifier.transaction({
+            nonce: 0,
+            configs: ExampleGen.generateActionConfigs({nActions: 1, nCUs: 1}),
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
+
+        bytes32[] memory cms = new bytes32[](1);
+        cms[0] = txn.actions[0].complianceVerifierInputs[0].instance.created.commitment;
+
+        bytes32 expectedRoot = cms.computeRoot(_TEST_COMMITMENT_TREE_DEPTH);
+
+        vm.expectEmit(address(_mockPa));
+        emit IProtocolAdapter.TransactionExecuted({id: 0, transaction: txn, newRoot: expectedRoot});
+        _mockPa.execute(txn);
+    }
+
+    function test_execute_emits_the_ForwarderCallExecuted_event() public {
+        uint256 nonce = 0;
+
+        bytes32 logicRef = bytes32(uint256(123));
+        ForwarderMock fwd = new ForwarderMock({protocolAdapter: address(_mockPa), calldataCarrierLogicRef: logicRef});
+
+        bytes32 labelRef = sha256(abi.encode(address(fwd)));
+
+        Transaction memory txn;
+        {
+            ForwarderCalldata memory call =
+                ForwarderCalldata({untrustedForwarder: address(fwd), input: INPUT, output: EXPECTED_OUTPUT});
+
+            Logic.ExpirableBlob[] memory blobs = new Logic.ExpirableBlob[](1);
+            blobs[0] = Logic.ExpirableBlob({
+                deletionCriterion: Logic.DeletionCriterion.Never,
+                blob: abi.encode(call.untrustedForwarder, call.input, call.output)
+            });
+
+            ExampleGen.ResourceAndAppData[] memory consumed = new ExampleGen.ResourceAndAppData[](1);
+            ExampleGen.ResourceAndAppData[] memory created = new ExampleGen.ResourceAndAppData[](1);
+            consumed[0] = ExampleGen.ResourceAndAppData({
+                resource: ExampleGen.mockResource({nonce: nonce++, logicRef: logicRef, labelRef: labelRef, quantity: 1}),
+                appData: blobs
+            });
+            created[0] = ExampleGen.ResourceAndAppData({
+                resource: ExampleGen.mockResource({nonce: nonce++, logicRef: logicRef, labelRef: labelRef, quantity: 1}),
+                appData: blobs
+            });
+
+            ExampleGen.ActionResources[] memory resourceLists = new ExampleGen.ActionResources[](1);
+            resourceLists[0] = ExampleGen.ActionResources({consumed: consumed, created: created});
+            txn = _mockVerifier.transaction(resourceLists, _TEST_COMMITMENT_TREE_DEPTH);
+
+            ResourceForwarderCalldataPair[] memory pairs = new ResourceForwarderCalldataPair[](1);
+            pairs[0] = ResourceForwarderCalldataPair({
+                carrier: created[0].resource,
+                call: ForwarderCalldata({untrustedForwarder: address(fwd), input: INPUT, output: EXPECTED_OUTPUT})
+            });
+
+            txn.actions[0].resourceCalldataPairs = pairs;
+        }
+
+        vm.expectEmit(address(_mockPa));
+        emit IProtocolAdapter.ForwarderCallExecuted({
+            untrustedForwarder: address(fwd),
+            input: INPUT,
+            output: EXPECTED_OUTPUT
+        });
+        _mockPa.execute(txn);
     }
 
     function test_execute_1_txn_with_1_action_and_0_cus() public {
-        ExampleGen.ActionConfig[] memory configs = ExampleGen.generateActionConfigs({nActions: 1, nCUs: 0});
-
-        (Transaction memory txn,) = _mockVerifier.transaction(0, configs);
+        (Transaction memory txn,) = _mockVerifier.transaction({
+            nonce: 0,
+            configs: ExampleGen.generateActionConfigs({nActions: 1, nCUs: 0}),
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
         _mockPa.execute(txn);
     }
 
@@ -44,7 +124,11 @@ contract ProtocolAdapterMockTest is Test {
         configs[0] = ExampleGen.ActionConfig({nCUs: 1});
         configs[1] = ExampleGen.ActionConfig({nCUs: 0});
 
-        (Transaction memory txn,) = _mockVerifier.transaction(0, configs);
+        (Transaction memory txn,) = _mockVerifier.transaction({
+            nonce: 0,
+            configs: ExampleGen.generateActionConfigs({nActions: 1, nCUs: 1}),
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
         _mockPa.execute(txn);
     }
 
@@ -54,7 +138,8 @@ contract ProtocolAdapterMockTest is Test {
             nCUs: uint8(bound(nCUs, 0, 2 ** (_mockPa.actionTreeDepth() - 1)))
         });
 
-        (Transaction memory txn,) = _mockVerifier.transaction(0, configs);
+        (Transaction memory txn,) =
+            _mockVerifier.transaction({nonce: 0, configs: configs, commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH});
         _mockPa.execute(txn);
     }
 
@@ -64,21 +149,31 @@ contract ProtocolAdapterMockTest is Test {
             nCUs: uint8(bound(nCUs, 0, 2 ** (_mockPa.actionTreeDepth() - 1)))
         });
 
-        (Transaction memory txn, uint256 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        (Transaction memory txn, uint256 updatedNonce) =
+            _mockVerifier.transaction({nonce: 0, configs: configs, commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH});
         _mockPa.execute(txn);
 
-        (txn,) = _mockVerifier.transaction(updatedNonce, configs);
+        (txn,) = _mockVerifier.transaction({
+            nonce: updatedNonce,
+            configs: configs,
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
         _mockPa.execute(txn);
     }
 
     function test_verify_reverts_on_pre_existing_nullifier() public {
         ExampleGen.ActionConfig[] memory configs = ExampleGen.generateActionConfigs({nActions: 1, nCUs: 1});
 
-        (Transaction memory tx1, uint256 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        (Transaction memory tx1, uint256 updatedNonce) =
+            _mockVerifier.transaction({nonce: 0, configs: configs, commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH});
         bytes32 preExistingNf = tx1.actions[0].complianceVerifierInputs[0].instance.consumed.nullifier;
         _mockPa.execute(tx1);
 
-        (Transaction memory tx2,) = _mockVerifier.transaction({nonce: updatedNonce, configs: configs});
+        (Transaction memory tx2,) = _mockVerifier.transaction({
+            nonce: updatedNonce,
+            configs: configs,
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
         tx2.actions[0].complianceVerifierInputs[0].instance.consumed.nullifier = preExistingNf;
         vm.expectRevert(
             abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, preExistingNf), address(_mockPa)
@@ -89,11 +184,16 @@ contract ProtocolAdapterMockTest is Test {
     function test_verify_reverts_on_pre_existing_commitment() public {
         ExampleGen.ActionConfig[] memory configs = ExampleGen.generateActionConfigs({nActions: 1, nCUs: 1});
 
-        (Transaction memory tx1, uint256 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        (Transaction memory tx1, uint256 updatedNonce) =
+            _mockVerifier.transaction({nonce: 0, configs: configs, commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH});
         bytes32 preExistingCm = tx1.actions[0].complianceVerifierInputs[0].instance.created.commitment;
         _mockPa.execute(tx1);
 
-        (Transaction memory tx2,) = _mockVerifier.transaction({nonce: updatedNonce, configs: configs});
+        (Transaction memory tx2,) = _mockVerifier.transaction({
+            nonce: updatedNonce,
+            configs: configs,
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
         tx2.actions[0].complianceVerifierInputs[0].instance.created.commitment = preExistingCm;
         vm.expectRevert(
             abi.encodeWithSelector(CommitmentAccumulator.PreExistingCommitment.selector, preExistingCm),
@@ -105,7 +205,8 @@ contract ProtocolAdapterMockTest is Test {
     function test_verify_reverts_on_duplicated_nullifier() public {
         ExampleGen.ActionConfig[] memory configs = ExampleGen.generateActionConfigs({nActions: 1, nCUs: 2});
 
-        (Transaction memory txn,) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        (Transaction memory txn,) =
+            _mockVerifier.transaction({nonce: 0, configs: configs, commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH});
         bytes32 duplicatedNf = txn.actions[0].complianceVerifierInputs[0].instance.consumed.nullifier;
         txn.actions[0].complianceVerifierInputs[1].instance.consumed.nullifier = duplicatedNf;
 
@@ -116,7 +217,8 @@ contract ProtocolAdapterMockTest is Test {
     function test_verify_reverts_on_duplicated_commitment() public {
         ExampleGen.ActionConfig[] memory configs = ExampleGen.generateActionConfigs({nActions: 1, nCUs: 2});
 
-        (Transaction memory txn,) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        (Transaction memory txn,) =
+            _mockVerifier.transaction({nonce: 0, configs: configs, commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH});
         bytes32 duplicatedCm = txn.actions[0].complianceVerifierInputs[0].instance.created.commitment;
         txn.actions[0].complianceVerifierInputs[1].instance.created.commitment = duplicatedCm;
 
@@ -125,8 +227,11 @@ contract ProtocolAdapterMockTest is Test {
     }
 
     function test_verify_reverts_on_wrong_isConsumed_value_in_consumed_resource_logic_proof() public {
-        (Transaction memory txn,) =
-            _mockVerifier.transaction({nonce: 0, configs: ExampleGen.generateActionConfigs({nActions: 2, nCUs: 2})});
+        (Transaction memory txn,) = _mockVerifier.transaction({
+            nonce: 0,
+            configs: ExampleGen.generateActionConfigs({nActions: 2, nCUs: 2}),
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
 
         bool expected = true;
         txn.actions[1].logicVerifierInputs[0].instance.isConsumed = !expected;
@@ -138,8 +243,11 @@ contract ProtocolAdapterMockTest is Test {
     }
 
     function test_verify_reverts_on_wrong_isConsumed_value_in_created_resource_logic_proof() public {
-        (Transaction memory txn,) =
-            _mockVerifier.transaction({nonce: 0, configs: ExampleGen.generateActionConfigs({nActions: 2, nCUs: 2})});
+        (Transaction memory txn,) = _mockVerifier.transaction({
+            nonce: 0,
+            configs: ExampleGen.generateActionConfigs({nActions: 2, nCUs: 2}),
+            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
+        });
 
         bool expected = false;
         txn.actions[1].logicVerifierInputs[1].instance.isConsumed = !expected;
@@ -150,3 +258,4 @@ contract ProtocolAdapterMockTest is Test {
         _mockPa.verify(txn);
     }
 }
+*/

--- a/contracts/test/mocks/ExampleGen.sol
+++ b/contracts/test/mocks/ExampleGen.sol
@@ -25,18 +25,12 @@ library ExampleGen {
         uint256 nCUs;
     }
 
-    struct ResourcePosition {
-        uint256 actId;
-        uint256 cuId;
-        bool isConsumed;
-    }
-
     struct ResourceAndAppData {
         Resource resource;
         Logic.ExpirableBlob[] appData;
     }
 
-    struct ActionResources {
+    struct ResourceLists {
         ResourceAndAppData[] consumed;
         ResourceAndAppData[] created;
     }
@@ -161,11 +155,12 @@ library ExampleGen {
         });
     }
 
-    function createAction(RiscZeroMockVerifier mockVerifier, uint256 nonce, uint256 nCUs, uint8 commitmentTreeDepth)
-        internal
-        view
-        returns (Action memory action, uint256 updatedNonce)
-    {
+    function createDefaultAction(
+        RiscZeroMockVerifier mockVerifier,
+        uint256 nonce,
+        uint256 nCUs,
+        uint8 commitmentTreeDepth
+    ) internal view returns (Action memory action, uint256 updatedNonce) {
         updatedNonce = nonce;
 
         ResourceAndAppData[] memory consumed = new ResourceAndAppData[](nCUs);
@@ -202,7 +197,7 @@ library ExampleGen {
 
     function transaction(
         RiscZeroMockVerifier mockVerifier,
-        ActionResources[] memory actionResources,
+        ResourceLists[] memory actionResources,
         uint8 commitmentTreeDepth
     ) internal view returns (Transaction memory txn) {
         Action[] memory actions = new Action[](actionResources.length);
@@ -235,7 +230,7 @@ library ExampleGen {
 
         Action[] memory actions = new Action[](configs.length);
         for (uint256 i = 0; i < configs.length; ++i) {
-            (actions[i], updatedNonce) = createAction({
+            (actions[i], updatedNonce) = createDefaultAction({
                 mockVerifier: mockVerifier,
                 nonce: updatedNonce,
                 nCUs: configs[i].nCUs,

--- a/contracts/test/mocks/ForwarderTarget.m.sol
+++ b/contracts/test/mocks/ForwarderTarget.m.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+uint256 constant INPUT_VALUE = 123;
+uint256 constant OUTPUT_VALUE = INPUT_VALUE + 1;
+bytes constant INPUT = abi.encodeCall(ForwarderTarget.increment, INPUT_VALUE);
+bytes constant EXPECTED_OUTPUT = abi.encode(OUTPUT_VALUE);
+
 contract ForwarderTarget {
     event CallReceived(uint256 input, uint256 output);
 


### PR DESCRIPTION
This PR also fixes a PA bug related to calldata encoding and starts the transaction ID counting with zero.