### PR TITLE
refactor: compliance test

### DIFF
--- a/contracts/test/proofs/ComplianceProof.t.sol
+++ b/contracts/test/proofs/ComplianceProof.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {RiscZeroVerifierEmergencyStop} from "@risc0-ethereum/RiscZeroVerifierEmergencyStop.sol";
 import {RiscZeroVerifierRouter} from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
 
 import {Test} from "forge-std/Test.sol";
@@ -8,23 +9,22 @@ import {Test} from "forge-std/Test.sol";
 import {RiscZeroUtils} from "../../src/libs/RiscZeroUtils.sol";
 import {Compliance} from "../../src/proving/Compliance.sol";
 import {TransactionExample} from "../examples/Transaction.e.sol";
+import {DeployRiscZeroContracts} from "../script/DeployRiscZeroContracts.s.sol";
 
 contract ComplianceProofTest is Test {
     using RiscZeroUtils for Compliance.Instance;
 
-    RiscZeroVerifierRouter internal _sepoliaVerifierRouter;
+    RiscZeroVerifierRouter internal _router;
+    RiscZeroVerifierEmergencyStop internal _emergencyStop;
 
     function setUp() public {
-        vm.selectFork(vm.createFork("sepolia"));
-
-        string memory path = "./script/constructor-args.txt";
-        _sepoliaVerifierRouter = RiscZeroVerifierRouter(vm.parseAddress(vm.readLine(path)));
+        (_router, _emergencyStop,) = new DeployRiscZeroContracts().run();
     }
 
-    function tes_verify_example_compliance_proof() public view {
+    function test_verify_example_compliance_proof() public view {
         Compliance.VerifierInput memory cu = TransactionExample.complianceVerifierInput();
 
-        _sepoliaVerifierRouter.verify({
+        _router.verify({
             seal: cu.proof,
             imageId: Compliance._VERIFYING_KEY,
             journalDigest: cu.instance.toJournalDigest()

--- a/contracts/test/proofs/LogicProof.t.sol
+++ b/contracts/test/proofs/LogicProof.t.sol
@@ -8,7 +8,6 @@ import {Test} from "forge-std/Test.sol";
 
 import {RiscZeroUtils} from "../../src/libs/RiscZeroUtils.sol";
 import {Logic} from "../../src/proving/Logic.sol";
-
 import {TransactionExample} from "../examples/Transaction.e.sol";
 import {DeployRiscZeroContracts} from "../script/DeployRiscZeroContracts.s.sol";
 


### PR DESCRIPTION
Note: The `test_verify_example_compliance_proof`  was not running due to a typo in the test name (`tes_verify_example_compliance_proof`).