### PR TITLE
Reduce storage used by Merkle trees.

### DIFF
--- a/contracts/src/interfaces/ICommitmentAccumulator.sol
+++ b/contracts/src/interfaces/ICommitmentAccumulator.sol
@@ -23,10 +23,4 @@ interface ICommitmentAccumulator {
     function verifyMerkleProof(bytes32 root, bytes32 commitment, bytes32[] calldata path, uint256 directionBits)
         external
         view;
-
-    /// @notice Returns the Merkle proof and associated root for a commitment leaf in the tree.
-    /// @param commitment The commitment leaf to proof inclusion in the tree for.
-    /// @return siblings The siblings constituting the path from the leaf to the root.
-    /// @return directionBits The direction bits for the proof.
-    function merkleProof(bytes32 commitment) external view returns (bytes32[] memory siblings, uint256 directionBits);
 }

--- a/contracts/src/libs/MerkleTree.sol
+++ b/contracts/src/libs/MerkleTree.sol
@@ -15,8 +15,8 @@ import {SHA256} from "../libs/SHA256.sol";
 /// @custom:security-contact security@anoma.foundation
 library MerkleTree {
     struct Tree {
-        uint256 _nextLeafIndex;
-        mapping(uint256 level => mapping(uint256 index => bytes32 node)) _nodes;
+        uint256 _leafCount;
+        mapping(uint256 level => bytes32 node) _parents;
         bytes32[] _zeros;
     }
 
@@ -32,137 +32,65 @@ library MerkleTree {
 
         self._zeros.push(SHA256.EMPTY_HASH);
 
-        self._nextLeafIndex = 0;
+        self._leafCount = 0;
     }
 
     /// @notice Pushes a leaf to the tree.
     /// @param self The tree data structure.
     /// @param leaf The leaf to add.
     /// @return index The index of the leaf.
-    /// @return newRoot The new root of the tree.
-    function push(Tree storage self, bytes32 leaf) internal returns (uint256 index, bytes32 newRoot) {
-        // Cache the tree depth read.
-        uint256 treeDepth = depth(self);
-
-        // Get the next leaf index and increment it after assignment.
-        index = self._nextLeafIndex++;
-
-        bytes32 currentLevelHash = leaf;
-
-        if (treeDepth == 0) {
-            self._nodes[0][0] = currentLevelHash;
-        } else {
-            uint256 currentIndex = index;
-
-            // Rebuild the branch from leaf to root.
-            for (uint256 i = 0; i < treeDepth; ++i) {
-                // Store the current node hash at depth `i`.
-                self._nodes[i][currentIndex] = currentLevelHash;
-
-                // Compute the next level hash for depth `i+1`.
-                // Check whether the `currentIndex` node is the left or right child of its parent.
-                if (isLeftChild(currentIndex)) {
-                    // Compute the `currentLevelHash` using the right sibling.
-                    // Because we fill the tree from left to right,
-                    // the right child is empty and we must use the depth `i` zero hash.
-                    currentLevelHash = SHA256.hash(currentLevelHash, Arrays.unsafeAccess(self._zeros, i).value);
-                } else {
-                    // Compute the `currentLevelHash` using the left sibling.
-                    // Because we fill the tree from left to right,
-                    // the left child is the previous node at depth `i`.
-                    currentLevelHash = SHA256.hash(self._nodes[i][currentIndex - 1], currentLevelHash);
-                }
-
-                currentIndex >>= 1;
-            }
-        }
-
-        // Expand the tree if the capacity is reached.
-        if (self._nextLeafIndex == capacity(self)) {
-            // Store the current hash in the current level at index 0.
-            self._nodes[treeDepth][0] = currentLevelHash;
-
-            // Compute the new current level hash of the expanded tree.
-
-            bytes32 currentZero = Arrays.unsafeAccess(self._zeros, treeDepth).value;
-
-            // Compute the new current level hash.
-            currentLevelHash = SHA256.hash(currentLevelHash, currentZero);
-
+    /// @return accumulatorNode The new root of the tree.
+    function push(Tree storage self, bytes32 leaf) internal returns (uint256 index, bytes32 accumulatorNode) {
+        // If the capacity of the current Merkle tree is exhausted, then expand it
+        if (self._leafCount != 0 && (self._leafCount & (self._leafCount - 1)) == 0) {
             // Compute the next zero for the next level.
+            bytes32 currentZero = Arrays.unsafeAccess(self._zeros, self._zeros.length - 1).value;
             bytes32 nextZero = SHA256.hash(currentZero, currentZero);
             self._zeros.push(nextZero);
         }
-
-        newRoot = currentLevelHash;
-    }
-
-    /// @notice Computes a Merkle proof consisting of the sibling at each depth and the associated direction bit
-    /// indicating whether the sibling is left (0) or right (1) at the respective depth.
-    /// @param self The tree data structure.
-    /// @param index The index of the leaf.
-    /// @return siblings The siblings of the leaf to proof inclusion for.
-    /// @return directionBits The direction bits indicating whether the siblings are left of right.
-    function merkleProof(Tree storage self, uint256 index)
-        internal
-        view
-        returns (bytes32[] memory siblings, uint256 directionBits)
-    {
-        uint256 treeDepth = depth(self);
-
-        // Check whether the index exists or not.
-        if (index + 1 > self._nextLeafIndex) revert NonExistentLeafIndex(index);
-
-        siblings = new bytes32[](treeDepth);
-        uint256 currentIndex = index;
-        bytes32 currentSibling;
-
-        // Iterate over the different tree levels starting at the bottom at the leaf level.
-        for (uint256 i = 0; i < treeDepth; ++i) {
-            // Check if the current node the left or right child of its parent.
-            if (isLeftChild(currentIndex)) {
-                // Sibling is right.
-                currentSibling = self._nodes[i][currentIndex + 1];
-
-                // Set the direction bit at position `i` to 1.
-                directionBits |= (1 << i);
-            } else {
-                // Sibling is left.
-                currentSibling = self._nodes[i][currentIndex - 1];
-
-                // Leave the direction bit at position `i` as 0.
-            }
-
-            // Check if the sibling is an empty subtree.
-            if (currentSibling == bytes32(0)) {
-                // The subtree node doesn't exist, so we store the zero hash instead.
-                siblings[i] = Arrays.unsafeAccess(self._zeros, i).value;
-            } else {
-                // The subtree node exists, so we store it.
-                siblings[i] = currentSibling;
-            }
-
-            // Shift the number one bit to the right to drop the last binary digit.
-            currentIndex >>= 1;
+        uint256 height = 0;
+        bytes32 replacementNode = leaf;
+        // Propagate a hash update up the Merkle tree until there's space
+        for (; self._parents[height] != 0; height++) {
+            // Compute the replacement of the parent node
+            replacementNode = SHA256.hash(self._parents[height], replacementNode);
+            // Delete the current level as it's now completed
+            delete self._parents[height];
         }
+        accumulatorNode = replacementNode;
+        // Record where we are going to insert the new node
+        uint256 insertHeight = height;
+        // Now let's compute the new root hash starting from the replacement node
+        for (; height < self._zeros.length - 1; height++) {
+            if (self._parents[height] == 0) {
+                // If no partial tree at current level, then right-pad the accumulator
+                accumulatorNode = SHA256.hash(accumulatorNode, self._zeros[height]);
+            } else {
+                // If there's a partial tree, then combine it with the accumulator
+                accumulatorNode = SHA256.hash(self._parents[height], accumulatorNode);
+            }
+        }
+        // Finish off the propagation with a final assignment
+        self._parents[insertHeight] = replacementNode;
+        index = self._leafCount++;
     }
 
     /// @notice Returns the tree depth.
     /// @param self The tree data structure.
-    /// @return treeDepth The depth of the tree.
-    function depth(Tree storage self) internal view returns (uint256 treeDepth) {
-        treeDepth = self._zeros.length - 1;
+    /// @return treeHeight The depth of the tree.
+    function height(Tree storage self) internal view returns (uint256 treeHeight) {
+        treeHeight = self._zeros.length - 1;
     }
 
     /// @notice Returns the number of leaves that have been added to the tree.
     /// @param self The tree data structure.
     /// @return count The number of leaves in the tree.
     function leafCount(Tree storage self) internal view returns (uint256 count) {
-        count = self._nextLeafIndex;
+        count = self._leafCount;
     }
 
     function capacity(Tree storage self) internal view returns (uint256 treeCapacity) {
-        treeCapacity = 1 << depth(self);
+        treeCapacity = 1 << height(self);
     }
 
     /// @notice Checks whether a node is the left or right child according to its index.

--- a/contracts/test/mocks/CommitmentAccumulator.m.sol
+++ b/contracts/test/mocks/CommitmentAccumulator.m.sol
@@ -36,20 +36,12 @@ contract CommitmentAccumulatorMock is CommitmentAccumulator {
         treeCapacity = _merkleTree.capacity();
     }
 
-    function depth() external view returns (uint256 treeDepth) {
-        treeDepth = _merkleTree.depth();
+    function height() external view returns (uint256 treeHeight) {
+        treeHeight = _merkleTree.height();
     }
 
     function emptyLeafHash() external view returns (bytes32 hash) {
         hash = _merkleTreeZero(0);
-    }
-
-    function findCommitmentIndex(bytes32 commitment) external view returns (uint256 index) {
-        index = _findCommitmentIndex(commitment);
-    }
-
-    function commitmentAtIndex(uint256 index) external view returns (bytes32 commitment) {
-        commitment = _commitmentAtIndex(index);
     }
 
     function _merkleTreeZero(uint256 level) internal view returns (bytes32 zeroHash) {

--- a/contracts/test/state/CommitmentAccumulator.t.sol
+++ b/contracts/test/state/CommitmentAccumulator.t.sol
@@ -35,42 +35,6 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
         }
     }
 
-    function test_merkleProof_reverts_for_empty_hash() public {
-        bytes32 emptyLeafHash = _cmAcc.emptyLeafHash();
-        vm.expectRevert(CommitmentAccumulator.EmptyCommitment.selector, address(_cmAcc));
-        _cmAcc.merkleProof(emptyLeafHash);
-    }
-
-    function test_merkleProof_should_return_correct_direction_bits() public {
-        for (uint256 i = 0; i < _N_LEAFS; ++i) {
-            _cmAcc.addCommitment(_a[i + 1][i]);
-
-            uint256 cap = _cmAcc.capacity();
-
-            for (uint256 j = 0; j < i + 1; ++j) {
-                (, uint256 directionBits) = _cmAcc.merkleProof(_a[i + 1][j]);
-
-                assertEq(directionBits, _directionBits[cap][j]);
-            }
-        }
-    }
-
-    function test_findCommitmentIndex_should_return_correct_indices() public {
-        for (uint256 i = 0; i < _N_LEAFS; ++i) {
-            _cmAcc.addCommitment(_a[i + 1][i]);
-
-            for (uint256 j = 0; j <= i; ++j) {
-                assertEq(j, _cmAcc.findCommitmentIndex(_a[i + 1][j]));
-            }
-        }
-    }
-
-    function test_findCommitmentIndex_reverts_on_empty_commitment() public {
-        bytes32 emptyLeafHash = _cmAcc.emptyLeafHash();
-        vm.expectRevert(CommitmentAccumulator.EmptyCommitment.selector, address(_cmAcc));
-        _cmAcc.findCommitmentIndex(emptyLeafHash);
-    }
-
     function test_addCommitment_should_add_commitments() public {
         uint256 prevCount = 0;
         uint256 newCount = 0;
@@ -92,27 +56,6 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
             abi.encodeWithSelector(CommitmentAccumulator.PreExistingCommitment.selector, cm), address(_cmAcc)
         );
         _cmAcc.addCommitment(cm);
-    }
-
-    function test_findCommitmentIndex_reverts_on_non_existent_commitment() public {
-        bytes32 nonExistentCommitment = sha256("NON_EXISTENT");
-        vm.expectRevert(
-            abi.encodeWithSelector(CommitmentAccumulator.NonExistingCommitment.selector, nonExistentCommitment),
-            address(_cmAcc)
-        );
-        _cmAcc.findCommitmentIndex(nonExistentCommitment);
-    }
-
-    function test_commitmentAtIndex_reverts_on_non_existent_index() public {
-        for (uint256 i = 0; i < _N_LEAFS; ++i) {
-            uint256 commitmentCount = _cmAcc.commitmentCount();
-
-            vm.expectRevert(
-                abi.encodeWithSelector(CommitmentAccumulator.CommitmentIndexOutOfBounds.selector, i, commitmentCount),
-                address(_cmAcc)
-            );
-            _cmAcc.commitmentAtIndex(i);
-        }
     }
 
     function test_should_produce_an_invalid_root_for_a_non_existent_leaf_in_the_empty_tree() public view {
@@ -143,32 +86,6 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
                 assertNotEq(computedRoot, root);
             }
         }
-    }
-
-    function test_merkleProof_returns_proofs_that_match_the_latest_root() public {
-        for (uint256 i = 0; i < _N_LEAFS; ++i) {
-            bytes32 latestRoot = _cmAcc.addCommitment(_a[_N_ROOTS - 1][i]);
-
-            // Check that all leaves of the current tree result in proofs reproducing the latest root.
-            for (uint256 j = 0; j <= i; ++j) {
-                bytes32 cm = _a[_N_ROOTS - 1][i];
-
-                (bytes32[] memory siblings, uint256 directionBits) = _cmAcc.merkleProof(cm);
-                bytes32 computedRoot = MerkleTree.processProof(siblings, directionBits, cm);
-
-                assertEq(computedRoot, latestRoot);
-            }
-        }
-    }
-
-    function test_verifyMerkleProof_should_pass_on_valid_inputs() public {
-        bytes32 cm = sha256("SOMETHING");
-        bytes32 latestRoot = _cmAcc.addCommitment(cm);
-        _cmAcc.storeRoot(latestRoot);
-
-        (bytes32[] memory path, uint256 directionBits) = _cmAcc.merkleProof(cm);
-
-        _cmAcc.verifyMerkleProof({root: latestRoot, commitment: cm, path: path, directionBits: directionBits});
     }
 
     function test_verifyMerkleProof_reverts_on_non_existent_root() public {
@@ -229,7 +146,7 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
         bytes32[] memory wrongPath = new bytes32[](3);
 
         vm.expectRevert(
-            abi.encodeWithSelector(CommitmentAccumulator.InvalidPathLength.selector, _cmAcc.depth(), wrongPath.length),
+            abi.encodeWithSelector(CommitmentAccumulator.InvalidPathLength.selector, _cmAcc.height(), wrongPath.length),
             address(_cmAcc)
         );
         _cmAcc.verifyMerkleProof({root: 0, commitment: 0, path: wrongPath, directionBits: 0});
@@ -240,7 +157,7 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
         bytes32 newRoot = _cmAcc.addCommitment(commitment);
         _cmAcc.storeRoot(newRoot);
 
-        bytes32[] memory wrongPath = new bytes32[](_cmAcc.depth());
+        bytes32[] memory wrongPath = new bytes32[](_cmAcc.height());
 
         // Compute the expected, invalid root.
         bytes32 invalidRoot = wrongPath.processProof({directionBits: 0, leaf: commitment});

--- a/contracts/test/state/MerkleTree.t.sol
+++ b/contracts/test/state/MerkleTree.t.sol
@@ -20,35 +20,35 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
     function test_push_expands_the_tree_depth_if_the_capacity_is_reached() public {
         assertEq(_merkleTree.setup(), _roots[0]);
         assertEq(_merkleTree.leafCount(), 0);
-        assertEq(_merkleTree.depth(), 0);
+        assertEq(_merkleTree.height(), 0);
 
         _merkleTree.push(_a[7][0]);
         assertEq(_merkleTree.leafCount(), 1);
-        assertEq(_merkleTree.depth(), 1);
+        assertEq(_merkleTree.height(), 0);
 
         _merkleTree.push(_a[7][1]);
         assertEq(_merkleTree.leafCount(), 2);
-        assertEq(_merkleTree.depth(), 2);
+        assertEq(_merkleTree.height(), 1);
 
         _merkleTree.push(_a[7][2]);
         assertEq(_merkleTree.leafCount(), 3);
-        assertEq(_merkleTree.depth(), 2);
+        assertEq(_merkleTree.height(), 2);
 
         _merkleTree.push(_a[7][3]);
         assertEq(_merkleTree.leafCount(), 4);
-        assertEq(_merkleTree.depth(), 3);
+        assertEq(_merkleTree.height(), 2);
 
         _merkleTree.push(_a[7][4]);
         assertEq(_merkleTree.leafCount(), 5);
-        assertEq(_merkleTree.depth(), 3);
+        assertEq(_merkleTree.height(), 3);
 
         _merkleTree.push(_a[7][5]);
         assertEq(_merkleTree.leafCount(), 6);
-        assertEq(_merkleTree.depth(), 3);
+        assertEq(_merkleTree.height(), 3);
 
         _merkleTree.push(_a[7][6]);
         assertEq(_merkleTree.leafCount(), 7);
-        assertEq(_merkleTree.depth(), 3);
+        assertEq(_merkleTree.height(), 3);
     }
 
     function test_setup_returns_the_expected_initial_root() public {


### PR DESCRIPTION
Optimized the variable depth Merkle tree implementation in https://github.com/anoma/evm-protocol-adapter/pull/160 with respect to space usage. Instead of using `O(n)` space to store the Merkle tree (where `n` is the number of leaves in the Merkle tree), this implementation uses `O(log(n))` space to store the Merkle tree. Additionally, this implementation only expands the capacity of the Merkle tree exactly when more space is required rather than in anticipation of future insertions.