### PR TITLE
Refactor `execute`, Remove `verify`

### DIFF
--- a/bindings/src/call.rs
+++ b/bindings/src/call.rs
@@ -128,17 +128,6 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "This test requires updatng the protocol adapter address in .env"]
-    async fn call_verify() {
-        let empty_tx = ProtocolAdapter::Transaction {
-            actions: vec![],
-            deltaProof: vec![].into(),
-        };
-        let result = protocol_adapter().verify(empty_tx).call().await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    #[ignore = "This test requires updatng the protocol adapter address in .env"]
     async fn call_execute() {
         let empty_tx = ProtocolAdapter::Transaction {
             actions: vec![],

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -170,7 +170,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
                 // Check consumed resource logic, verifier key correspondence,
                 // as well as possible external calls
-                _processResourceLogic({
+                _processResourceLogicContext({
                     input: action.logicVerifierInputs.lookup(nf),
                     logicRef: complianceVerifierInput.instance.consumed.logicRef,
                     actionTreeRoot: actionTreeRoot,
@@ -178,8 +178,8 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                     execute: execute
                 });
 
-                // Check created resources as well
-                _processResourceLogic({
+                // Check the related info for the created resource as well
+                _processResourceLogicContext({
                     input: action.logicVerifierInputs.lookup(cm),
                     logicRef: complianceVerifierInput.instance.created.logicRef,
                     actionTreeRoot: actionTreeRoot,
@@ -247,13 +247,14 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
     /// @param actionTreeRoot The root of the tree containing all action tags for the instance
     /// @param consumed Flag for indicating whether the resource is consumed
     /// @param execute Flag for indicating whether any forwarder calls will be performed
-    function _processResourceLogic(
+    function _processResourceLogicContext(
         Logic.VerifierInput calldata input,
         bytes32 logicRef,
         bytes32 actionTreeRoot,
         bool consumed,
         bool execute
     ) internal {
+        // Check verifier key correspondence
         if (logicRef != input.verifyingKey) {
             revert LogicRefMismatch({expected: input.verifyingKey, actual: logicRef});
         }
@@ -263,6 +264,8 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         if (input.appData.externalPayload.length != 0) {
             _processForwarderCall(input, consumed, execute);
         }
+
+        // Verify the logic proof againts the provided verifying key
         _verifyLogicProof({input: input, root: actionTreeRoot, consumed: consumed});
     }
 

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.30;
 
 import {ReentrancyGuardTransient} from "@openzeppelin-contracts/utils/ReentrancyGuardTransient.sol";
-import {EnumerableSet} from "@openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 import {RiscZeroVerifierEmergencyStop} from "@risc0-ethereum/RiscZeroVerifierEmergencyStop.sol";
 import {RiscZeroVerifierRouter} from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
 
@@ -35,7 +34,6 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
     using RiscZeroUtils for Logic.VerifierInput;
     using Logic for Logic.VerifierInput[];
     using Delta for uint256[2];
-    using EnumerableSet for EnumerableSet.Bytes32Set;
 
     RiscZeroVerifierRouter internal immutable _TRUSTED_RISC_ZERO_VERIFIER_ROUTER;
     uint8 internal immutable _ACTION_TAG_TREE_DEPTH;

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -136,6 +136,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                     consumed: false
                 });
 
+                // Populate the tags
                 tags[resCounter++] = nf;
                 tags[resCounter++] = cm;
 

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -114,7 +114,8 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
     /// @notice An internal function to verify a transaction.
     /// @param transaction The transaction to verify.
-    /// @param global Test whether t
+    /// @param global Test whether the processing is for execution or validation of the transaction
+    /// in the latter case the function is read-only
     function _processTransaction(Transaction calldata transaction, bool global) internal {
         bytes32 newRoot = 0;
         uint256[2] memory transactionDelta = [uint256(0), uint256(0)];
@@ -144,7 +145,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                 revert ResourceCountMismatch({expected: nResources, actual: nCUs});
             }
 
-            // Computer the root of the tree containing all tags of the action
+            // Compute the root of the tree containing all tags of the action
             bytes32 actionTreeRoot = _computeActionTreeRoot(action, nCUs);
 
             for (uint256 j = 0; j < nCUs; ++j) {

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -155,10 +155,15 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
             }
 
             // Check that the transaction is balanced
-            _verifyDeltaProof({proof: transaction.deltaProof, transactionDelta: transactionDelta, tags: tags});
+            if (nActions != 0) {
+                // Check the delta proof
+                _verifyDeltaProof({proof: transaction.deltaProof, transactionDelta: transactionDelta, tags: tags});
 
-            // Store the final root
-            _storeRoot(newRoot);
+                if (newRoot != bytes32(0)) {
+                    // Store the final root
+                    _storeRoot(newRoot);
+                }
+            }
 
             // Emit the event containing the transaction and new root
             emit TransactionExecuted({id: _txCount++, transaction: transaction, newRoot: newRoot});

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -125,6 +125,8 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
                     // Check consumed resource logic, verifier key correspondence,
                     // as well as possible external calls
+
+                    // slither-disable-next-line reentrancy-benign
                     _processResourceLogicContext({
                         input: action.logicVerifierInputs.lookup(nf),
                         logicRef: complianceVerifierInput.instance.consumed.logicRef,
@@ -133,6 +135,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                     });
 
                     // Check the related info for the created resource as well
+                    // slither-disable-next-line reentrancy-benign
                     _processResourceLogicContext({
                         input: action.logicVerifierInputs.lookup(cm),
                         logicRef: complianceVerifierInput.instance.created.logicRef,
@@ -167,6 +170,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
             emit TransactionExecuted({id: _txCount++, transaction: transaction, newRoot: newRoot});
         }
     }
+    // slither-disable-end reentrancy-no-eth
 
     /// @inheritdoc IProtocolAdapter
     function isEmergencyStopped() public view override returns (bool isStopped) {

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -44,7 +44,6 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
     error ForwarderCallOutputMismatch(bytes expected, bytes actual);
     error ResourceCountMismatch(uint256 expected, uint256 actual);
-    error RootMismatch(bytes32 expected, bytes32 actual);
     error LogicRefMismatch(bytes32 expected, bytes32 actual);
     error RiscZeroVerifierStopped();
 

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -102,7 +102,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                 revert ResourceCountMismatch({expected: nResources, actual: nCUs});
             }
 
-            // Compute the root of the tree containing all tags of the action
+            // Compute the action tree root
             bytes32 actionTreeRoot = _computeActionTreeRoot(action, nCUs);
 
             for (uint256 j = 0; j < nCUs; ++j) {

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -154,15 +154,13 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                 }
             }
 
-            // Check that the transaction is balanced
-            if (nActions != 0) {
+            // Check if the transaction induced a state change and the state root has changed
+            if (newRoot != bytes32(0)) {
                 // Check the delta proof
                 _verifyDeltaProof({proof: transaction.deltaProof, transactionDelta: transactionDelta, tags: tags});
 
-                if (newRoot != bytes32(0)) {
-                    // Store the final root
-                    _storeRoot(newRoot);
-                }
+                // Store the final root
+                _storeRoot(newRoot);
             }
 
             // Emit the event containing the transaction and new root

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -252,15 +252,11 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         _executeForwarderCall(call);
     }
 
-    /// @notice Given an action, computes the root of a tree containing all of its tags
-    /// @param action The action whose root we compute
-    /// @param nCUs The number of compliance units in the action
-    /// @return actionTreeRoot The root of the corresponding tree
-    function _computeActionTreeRoot(Action calldata action, uint256 nCUs)
-        internal
-        view
-        returns (bytes32 actionTreeRoot)
-    {
+    /// @notice Computes the action tree root of an action constituted by all its nullifiers and commitments.
+    /// @param action The action whose root we compute.
+    /// @param nCUs The number of compliance units in the action.
+    /// @return root The root of the corresponding tree.
+    function _computeActionTreeRoot(Action calldata action, uint256 nCUs) internal view returns (bytes32 root) {
         bytes32[] memory actionTreeTags = new bytes32[](nCUs * 2);
 
         // The order in which the tags are added to the tree are provided by the compliance units
@@ -274,7 +270,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         actionTreeRoot = actionTreeTags.computeRoot(_ACTION_TAG_TREE_DEPTH);
     }
 
-    /// @notice An internal function verifying a RISC0 compliance proof.
+    /// @notice Verifies a RISC0 compliance proof.
     /// @param input The verifier input of the compliance proof.
     /// @dev This function is virtual to allow for it to be overridden, e.g., to use mock proofs with a mock verifier.
     function _verifyComplianceProof(Compliance.VerifierInput calldata input) internal view virtual {
@@ -286,7 +282,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         });
     }
 
-    /// @notice An internal function verifying a RISC0 logic proof.
+    /// @notice Verifies a RISC0 logic proof.
     /// @param input The verifier input of the logic proof.
     /// @param root The root of the action tree containing all tags of an action.
     /// @param consumed Bool indicating whether the tag is a commitment or a nullifier.
@@ -300,7 +296,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         });
     }
 
-    /// @notice An internal function verifying a delta proof.
+    /// @notice Verifies a delta proof.
     /// @param proof The delta proof.
     /// @param transactionDelta The transaction delta.
     /// @param tags The tags being part of the transaction in the order of appearance in the compliance units.

--- a/contracts/src/interfaces/IProtocolAdapter.sol
+++ b/contracts/src/interfaces/IProtocolAdapter.sol
@@ -27,7 +27,7 @@ interface IProtocolAdapter {
 
     /// @notice Verifies a transaction by checking the delta, resource logic, and compliance proofs.
     /// @param transaction The transaction to verify.
-    function verify(Transaction calldata transaction) external view;
+    function verify(Transaction calldata transaction) external;
 
     /// @notice Returns the RISC Zero verifier selector associated with the protocol adapter.
     /// @return verifierSelector The RISC Zero verifier selector.

--- a/contracts/src/interfaces/IProtocolAdapter.sol
+++ b/contracts/src/interfaces/IProtocolAdapter.sol
@@ -25,10 +25,6 @@ interface IProtocolAdapter {
     /// @param transaction The transaction to execute.
     function execute(Transaction calldata transaction) external;
 
-    /// @notice Verifies a transaction by checking the delta, resource logic, and compliance proofs.
-    /// @param transaction The transaction to verify.
-    function verify(Transaction calldata transaction) external;
-
     /// @notice Returns the RISC Zero verifier selector associated with the protocol adapter.
     /// @return verifierSelector The RISC Zero verifier selector.
     function getRiscZeroVerifierSelector() external view returns (bytes4 verifierSelector);

--- a/contracts/src/state/NullifierSet.sol
+++ b/contracts/src/state/NullifierSet.sol
@@ -41,12 +41,4 @@ contract NullifierSet is INullifierSet {
             revert PreExistingNullifier(nullifier);
         }
     }
-
-    /// @notice Checks if a nullifier does not exists already and reverts otherwise.
-    /// @param nullifier The nullifier to check existence for.
-    function _checkNullifierNonExistence(bytes32 nullifier) internal view {
-        if (_nullifierSet.contains(nullifier)) {
-            revert PreExistingNullifier(nullifier);
-        }
-    }
 }

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -40,14 +40,6 @@ contract ProtocolAdapterTest is Test {
         });
     }
 
-    function test_verify_reverts_on_vulnerable_risc_zero_verifier() public {
-        vm.prank(_emergencyStop.owner());
-        _emergencyStop.estop();
-
-        vm.expectRevert(Pausable.EnforcedPause.selector, address(_emergencyStop));
-        _pa.verify(TransactionExample.transaction());
-    }
-
     function test_execute_reverts_on_vulnerable_risc_zero_verifier() public {
         vm.prank(_emergencyStop.owner());
         _emergencyStop.estop();
@@ -58,10 +50,6 @@ contract ProtocolAdapterTest is Test {
 
     function test_execute() public {
         _pa.execute(TransactionExample.transaction());
-    }
-
-    function test_verify() public {
-        _pa.verify(TransactionExample.transaction());
     }
 
     // solhint-disable-next-line no-empty-blocks

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -10,7 +10,6 @@ import {Test} from "forge-std/Test.sol";
 
 import {Parameters} from "../src/libs/Parameters.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
-import {Transaction, Action} from "../src/Types.sol";
 import {TransactionExample} from "./examples/Transaction.e.sol";
 import {DeployRiscZeroContracts} from "./script/DeployRiscZeroContracts.s.sol";
 
@@ -61,17 +60,7 @@ contract ProtocolAdapterTest is Test {
         _pa.execute(TransactionExample.transaction());
     }
 
-    function test_execute_empty_tx() public {
-        Transaction memory txn = Transaction({actions: new Action[](0), deltaProof: ""});
-        _pa.execute(txn);
-    }
-
-    function test_verify_empty_tx() public view {
-        Transaction memory txn = Transaction({actions: new Action[](0), deltaProof: ""});
-        _pa.verify(txn);
-    }
-
-    function test_verify() public view {
+    function test_verify() public {
         _pa.verify(TransactionExample.transaction());
     }
 

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -244,8 +244,8 @@ contract ProtocolAdapterMockTest is Test {
 
     function test_execute_2_txns_with_n_actions_and_n_cus(uint8 nActions, uint8 nCUs) public {
         TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            nActions: uint8(bound(nActions, 0, 5)),
-            nCUs: uint8(bound(nCUs, 0, 2 ** (_mockPa.actionTreeDepth() - 1)))
+            nActions: uint8(bound(nActions, 1, 5)),
+            nCUs: uint8(bound(nCUs, 1, 2 ** (_mockPa.actionTreeDepth() - 1)))
         });
 
         (Transaction memory txn, bytes32 updatedNonce) =

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -221,11 +221,8 @@ contract ProtocolAdapterMockTest is Test {
         configs[0] = TxGen.ActionConfig({nCUs: 1});
         configs[1] = TxGen.ActionConfig({nCUs: 0});
 
-        (Transaction memory txn,) = _mockVerifier.transaction({
-            nonce: 0,
-            configs: TxGen.generateActionConfigs({nActions: 1, nCUs: 1}),
-            commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH
-        });
+        (Transaction memory txn,) =
+            _mockVerifier.transaction({nonce: 0, configs: configs, commitmentTreeDepth: _TEST_COMMITMENT_TREE_DEPTH});
         _mockPa.execute(txn);
     }
 
@@ -242,8 +239,8 @@ contract ProtocolAdapterMockTest is Test {
 
     function test_execute_2_txns_with_n_actions_and_n_cus(uint8 nActions, uint8 nCUs) public {
         TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            nActions: uint8(bound(nActions, 1, 5)),
-            nCUs: uint8(bound(nCUs, 1, 2 ** (_mockPa.actionTreeDepth() - 1)))
+            nActions: uint8(bound(nActions, 0, 5)),
+            nCUs: uint8(bound(nCUs, 0, 2 ** (_mockPa.actionTreeDepth() - 1)))
         });
 
         (Transaction memory txn, bytes32 updatedNonce) =

--- a/contracts/test/TagLookup.t.sol
+++ b/contracts/test/TagLookup.t.sol
@@ -19,15 +19,6 @@ contract TagLookupTest is Test {
         _tags[3] = bytes32(uint256(3)); // Cm 1
     }
 
-    function test_checkNullifierNonExistence_reverts_if_the_nullifier_exists() public {
-        vm.expectRevert(abi.encodeWithSelector(TagLookup.NullifierDuplicated.selector, _tags[0]), address(this));
-        _tags.checkNullifierNonExistence(_tags[0]);
-    }
-
-    function test_checkNullifierNonExistence_passes_if_the_nullifier_does_not_exist() public view {
-        _tags.checkNullifierNonExistence(_tags[1]);
-    }
-
     function test_isNullifierContained_returns_true_for_existent_nullifier() public view {
         assertEq(_tags.isNullifierContained({nullifier: _tags[0]}), true);
         assertEq(_tags.isNullifierContained({nullifier: _tags[2]}), true);

--- a/contracts/test/benchmark/Benchmark.t.sol
+++ b/contracts/test/benchmark/Benchmark.t.sol
@@ -61,19 +61,19 @@ contract Benchmark is BenchmarkData {
         _pa.execute(_txns[3]);
     }
 
-    function test_verify_01() public view {
+    function test_verify_01() public {
         _pa.verify(_txns[0]);
     }
 
-    function test_verify_05() public view {
+    function test_verify_05() public {
         _pa.verify(_txns[1]);
     }
 
-    function test_verify_10() public view {
+    function test_verify_10() public {
         _pa.verify(_txns[2]);
     }
 
-    function test_verify_15() public view {
+    function test_verify_15() public {
         _pa.verify(_txns[3]);
     }
 

--- a/contracts/test/benchmark/Benchmark.t.sol
+++ b/contracts/test/benchmark/Benchmark.t.sol
@@ -61,22 +61,6 @@ contract Benchmark is BenchmarkData {
         _pa.execute(_txns[3]);
     }
 
-    function test_verify_01() public {
-        _pa.verify(_txns[0]);
-    }
-
-    function test_verify_05() public {
-        _pa.verify(_txns[1]);
-    }
-
-    function test_verify_10() public {
-        _pa.verify(_txns[2]);
-    }
-
-    function test_verify_15() public {
-        _pa.verify(_txns[3]);
-    }
-
     function test_print_calldata() public view {
         for (uint256 i = 0; i < _txns.length; ++i) {
             uint256 nCUs = 0;

--- a/contracts/test/mocks/NullifierSetMock.sol
+++ b/contracts/test/mocks/NullifierSetMock.sol
@@ -7,8 +7,4 @@ contract NullifierSetMock is NullifierSet {
     function addNullifier(bytes32 nullifier) external {
         _addNullifier(nullifier);
     }
-
-    function checkNullifierNonExistence(bytes32 nullifier) external view {
-        _checkNullifierNonExistence(nullifier);
-    }
 }

--- a/contracts/test/state/NullifierSet.t.sol
+++ b/contracts/test/state/NullifierSet.t.sol
@@ -15,7 +15,7 @@ contract NullifierSetTest is Test {
     }
 
     function test_addNullifier_adds_nullifier() public {
-        _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
+        assertEq(_nfSet.contains(_EXAMPLE_NF), false);
         _nfSet.addNullifier(_EXAMPLE_NF);
     }
 
@@ -26,15 +26,6 @@ contract NullifierSetTest is Test {
             abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF), address(_nfSet)
         );
         _nfSet.addNullifier(_EXAMPLE_NF);
-    }
-
-    function test_checkNullifierNonExistence_reverts_on_existent_nullifier() public {
-        _nfSet.addNullifier(_EXAMPLE_NF);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(NullifierSet.PreExistingNullifier.selector, _EXAMPLE_NF), address(_nfSet)
-        );
-        _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
     }
 
     function test_length_returns_the_length() public {
@@ -63,10 +54,6 @@ contract NullifierSetTest is Test {
     function test_contains_returns_true_if_the_nullifier_is_contained() public {
         _nfSet.addNullifier(_EXAMPLE_NF);
         assertEq(_nfSet.contains(_EXAMPLE_NF), true);
-    }
-
-    function test_checkNullifierNonExistence_passes_on_non_existent_nullifier() public view {
-        _nfSet.checkNullifierNonExistence(_EXAMPLE_NF);
     }
 
     function test_contains_returns_false_if_the_nullifier_is_not_contained() public view {


### PR DESCRIPTION
Refactors the core logic of the PA. Simplifies and decreases gas costs.

Removes `verify` to instead be provided by the SDK

Concerns #189, #190, #200, 