### PR TITLE
Add instructions for BONSAI_API_KEY required for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Change the directory to the `bindings` folder with `cd bindings` and run
 
 ### Usage
 
+Before running tests that require RISC Zero and BONSAI, make sure to set your BONSAI_API_KEY:
+
+```sh
+export BONSAI_API_KEY="your_api_key_here"
+```
+
 Print a test transaction with
 
 ```sh


### PR DESCRIPTION
The README was missing instructions for `BONSAI_API_KEY`. Without it, running `cargo test -- conversion::tests::print_tx` fails. This PR adds a brief note on setting the environment variable.