### PR TITLE
Allow ERC20 Forwarder Supporting All ERC20 Tokens

### DIFF
--- a/contracts/script/DeployERC20Forwarder.sol
+++ b/contracts/script/DeployERC20Forwarder.sol
@@ -10,8 +10,6 @@ contract DeployERC20Wrapper is Script {
 
     address internal constant _EMERGENCY_COMMITTEE = address(0);
 
-    address internal constant _ERC20 = address(0x1111111111111111111111111111111111111111);
-
     bytes32 internal constant _CALLDATA_CARRIER_LOGIC_REF = bytes32(0);
 
     function run() public {
@@ -19,8 +17,7 @@ contract DeployERC20Wrapper is Script {
         new ERC20Forwarder{salt: sha256("ERC20ForwarderExample")}({
             protocolAdapter: address(_PROTOCOL_ADAPTER),
             emergencyCommittee: _EMERGENCY_COMMITTEE,
-            calldataCarrierLogicRef: _CALLDATA_CARRIER_LOGIC_REF,
-            erc20: _ERC20
+            calldataCarrierLogicRef: _CALLDATA_CARRIER_LOGIC_REF
         });
         vm.stopBroadcast();
     }

--- a/contracts/src/forwarders/ERC20ForwarderInput.sol
+++ b/contracts/src/forwarders/ERC20ForwarderInput.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IERC20} from "@openzeppelin-contracts/token/ERC20/IERC20.sol";
 import {IPermit2, ISignatureTransfer} from "@permit2/src/interfaces/IPermit2.sol";
 import {Permit2Lib} from "@permit2/src/libraries/Permit2Lib.sol";
 import {PermitHash} from "@permit2/src/libraries/PermitHash.sol";
@@ -52,45 +53,54 @@ contract ERC20ForwarderInput {
     }
 
     /// @notice Encodes the input for the ERC-20 transfer call.
+    /// @param token The ERC-20 token.
     /// @param to The address receiving the tokens.
     /// @param value The value to send.
     /// @return input The encoded input.
-    function encodeTransfer(address to, uint256 value) public pure returns (bytes memory input) {
-        input = abi.encode(CallType.Transfer, to, value);
+    function encodeTransfer(IERC20 token, address to, uint256 value) public pure returns (bytes memory input) {
+        input = abi.encode(CallType.Transfer, token, to, value);
     }
 
     /// @notice Decodes the input for the ERC-20 transfer call.
     /// @param input The encoded input.
     /// @return callType The call type.
+    /// @return token The ERC-20 token.
     /// @return to The address receiving the tokens.
     /// @return value The value to send.
-    function decodeTransfer(bytes calldata input) public pure returns (CallType callType, address to, uint256 value) {
-        (callType, to, value) = abi.decode(input, (CallType, address, uint256));
+    function decodeTransfer(bytes calldata input)
+        public
+        pure
+        returns (CallType callType, IERC20 token, address to, uint256 value)
+    {
+        (callType, token, to, value) = abi.decode(input, (CallType, IERC20, address, uint256));
     }
 
     /// @notice Encodes the input for the ERC-20 `transferFrom` call.
+    /// @param token The ERC-20 token.
     /// @param from The address to withdraw the tokens from.
     /// @param value The value to send.
     /// @return input The encoded input.
-    function encodeTransferFrom(address from, uint256 value) public pure returns (bytes memory input) {
-        input = abi.encode(CallType.TransferFrom, from, value);
+    function encodeTransferFrom(IERC20 token, address from, uint256 value) public pure returns (bytes memory input) {
+        input = abi.encode(CallType.TransferFrom, token, from, value);
     }
 
     /// @notice Decodes the input for the ERC-20 `transferFrom` call.
 
     /// @param input The encoded input.
     /// @return callType The call type.
+    /// @return token The ERC-20 token.
     /// @return from The address to withdraw the tokens from.
     /// @return value The value to send.
     function decodeTransferFrom(bytes calldata input)
         public
         pure
-        returns (CallType callType, address from, uint256 value)
+        returns (CallType callType, IERC20 token, address from, uint256 value)
     {
-        (callType, from, value) = abi.decode(input, (CallType, address, uint256));
+        (callType, token, from, value) = abi.decode(input, (CallType, IERC20, address, uint256));
     }
 
     /// @notice Encodes the input for the Permit2 `permitWitnessTransferFrom` call.
+    /// @param token The ERC-20 token.
     /// @param from The address to withdraw the tokens from.
     /// @param value The value to send.
     /// @param permit The permit data constituted by the token address, token amount, nonce, and deadline.
@@ -98,18 +108,20 @@ contract ERC20ForwarderInput {
     /// @param signature The signature over the `PermitWitnessTransferFrom` message.
     /// @return input The encoded input.
     function encodePermitWitnessTransferFrom(
+        IERC20 token,
         address from,
         uint256 value,
         ISignatureTransfer.PermitTransferFrom memory permit,
         bytes32 witness,
         bytes memory signature
     ) public pure returns (bytes memory input) {
-        input = abi.encode(CallType.PermitWitnessTransferFrom, from, value, permit, witness, signature);
+        input = abi.encode(CallType.PermitWitnessTransferFrom, token, from, value, permit, witness, signature);
     }
 
     /// @notice Decodes the input for the Permit2 `permitWitnessTransferFrom` call.
     /// @param input The encoded input.
     /// @return callType The call type.
+    /// @return token The ERC-20 token.
     /// @return from The address to withdraw the tokens from.
     /// @return value The value to send.
     /// @return permit The permit data constituted by the token address, token amount, nonce, and deadline.
@@ -120,6 +132,7 @@ contract ERC20ForwarderInput {
         pure
         returns (
             CallType callType,
+            IERC20 token,
             address from,
             uint256 value,
             ISignatureTransfer.PermitTransferFrom memory permit,
@@ -127,8 +140,9 @@ contract ERC20ForwarderInput {
             bytes memory signature
         )
     {
-        (callType, from, value, permit, witness, signature) =
-            abi.decode(input, (CallType, address, uint256, ISignatureTransfer.PermitTransferFrom, bytes32, bytes));
+        (callType, token, from, value, permit, witness, signature) = abi.decode(
+            input, (CallType, IERC20, address, uint256, ISignatureTransfer.PermitTransferFrom, bytes32, bytes)
+        );
     }
 }
 // solhint-enable comprehensive-interface

--- a/contracts/test/DeployProtocolAdapter.sol
+++ b/contracts/test/DeployProtocolAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Test, console} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {DeployProtocolAdapter} from "../script/DeployProtocolAdapter.s.sol";
 

--- a/contracts/test/ERC20Forwarder.t.sol
+++ b/contracts/test/ERC20Forwarder.t.sol
@@ -72,8 +72,7 @@ contract ERC20ForwarderTest is Test {
             new ERC20Forwarder({
                 protocolAdapter: _pa,
                 emergencyCommittee: address(uint160(1)),
-                calldataCarrierLogicRef: bytes32(type(uint256).max),
-                erc20: address(_erc20)
+                calldataCarrierLogicRef: bytes32(type(uint256).max)
             })
         );
 
@@ -100,7 +99,7 @@ contract ERC20ForwarderTest is Test {
         uint256 startBalanceAlice = _erc20.balanceOf(_alice);
         uint256 startBalanceForwarder = _erc20.balanceOf(_fwd);
 
-        bytes memory input = ERC20Forwarder(_fwd).encodeTransfer({to: _alice, value: _TRANSFER_AMOUNT});
+        bytes memory input = ERC20Forwarder(_fwd).encodeTransfer({token: _erc20, to: _alice, value: _TRANSFER_AMOUNT});
 
         vm.prank(_pa);
         bytes memory output = ERC20Forwarder(_fwd).forwardCall({logicRef: _CALLDATA_CARRIER_LOGIC_REF, input: input});
@@ -112,18 +111,19 @@ contract ERC20ForwarderTest is Test {
 
     function test_forwardCall_Transfer_call_emits_the_Unwrapped_event() public {
         _erc20.mint({to: _fwd, value: _TRANSFER_AMOUNT});
-        bytes memory input = ERC20Forwarder(_fwd).encodeTransfer({to: _alice, value: _TRANSFER_AMOUNT});
+        bytes memory input = ERC20Forwarder(_fwd).encodeTransfer({token: _erc20, to: _alice, value: _TRANSFER_AMOUNT});
 
         vm.prank(_pa);
         vm.expectEmit(address(_fwd));
-        emit ERC20Forwarder.Unwrapped({to: _alice, value: _TRANSFER_AMOUNT});
+        emit ERC20Forwarder.Unwrapped({token: _erc20, to: _alice, value: _TRANSFER_AMOUNT});
         ERC20Forwarder(_fwd).forwardCall({logicRef: _CALLDATA_CARRIER_LOGIC_REF, input: input});
     }
 
     function test_forwardCall_TransferFrom_call_reverts_if_user_did_not_approve_the_forwarder() public {
         _erc20.mint({to: _alice, value: _TRANSFER_AMOUNT});
 
-        bytes memory input = ERC20Forwarder(_fwd).encodeTransferFrom({from: _alice, value: _TRANSFER_AMOUNT});
+        bytes memory input =
+            ERC20Forwarder(_fwd).encodeTransferFrom({token: _erc20, from: _alice, value: _TRANSFER_AMOUNT});
 
         uint256 allowance = _erc20.allowance({owner: _alice, spender: _fwd});
 
@@ -145,7 +145,8 @@ contract ERC20ForwarderTest is Test {
         vm.prank(_alice);
         _erc20.approve(_fwd, type(uint256).max);
 
-        bytes memory input = ERC20Forwarder(_fwd).encodeTransferFrom({from: _alice, value: _TRANSFER_AMOUNT});
+        bytes memory input =
+            ERC20Forwarder(_fwd).encodeTransferFrom({token: _erc20, from: _alice, value: _TRANSFER_AMOUNT});
 
         vm.prank(_pa);
         bytes memory output = ERC20Forwarder(_fwd).forwardCall({logicRef: _CALLDATA_CARRIER_LOGIC_REF, input: input});
@@ -160,11 +161,12 @@ contract ERC20ForwarderTest is Test {
         vm.prank(_alice);
         _erc20.approve(_fwd, type(uint256).max);
 
-        bytes memory input = ERC20Forwarder(_fwd).encodeTransferFrom({from: _alice, value: _TRANSFER_AMOUNT});
+        bytes memory input =
+            ERC20Forwarder(_fwd).encodeTransferFrom({token: _erc20, from: _alice, value: _TRANSFER_AMOUNT});
 
         vm.prank(_pa);
         vm.expectEmit(address(_fwd));
-        emit ERC20Forwarder.Wrapped({from: _alice, value: _TRANSFER_AMOUNT});
+        emit ERC20Forwarder.Wrapped({token: _erc20, from: _alice, value: _TRANSFER_AMOUNT});
         ERC20Forwarder(_fwd).forwardCall({logicRef: _CALLDATA_CARRIER_LOGIC_REF, input: input});
     }
 
@@ -172,6 +174,7 @@ contract ERC20ForwarderTest is Test {
         _erc20.mint({to: _alice, value: _TRANSFER_AMOUNT});
 
         bytes memory input = ERC20Forwarder(_fwd).encodePermitWitnessTransferFrom({
+            token: _erc20,
             from: _alice,
             value: _TRANSFER_AMOUNT,
             permit: _defaultPermit,
@@ -195,6 +198,7 @@ contract ERC20ForwarderTest is Test {
         _erc20.approve(address(_permit2), type(uint256).max);
 
         bytes memory input = ERC20Forwarder(_fwd).encodePermitWitnessTransferFrom({
+            token: _erc20,
             from: _alice,
             value: _TRANSFER_AMOUNT,
             permit: _defaultPermit,
@@ -221,6 +225,7 @@ contract ERC20ForwarderTest is Test {
         _erc20.approve(address(_permit2), type(uint256).max);
 
         bytes memory input = ERC20Forwarder(_fwd).encodePermitWitnessTransferFrom({
+            token: _erc20,
             from: _alice,
             value: _TRANSFER_AMOUNT,
             permit: _defaultPermit,
@@ -253,6 +258,7 @@ contract ERC20ForwarderTest is Test {
         permit.permitted.token = address(wrongERC20);
 
         bytes memory input = ERC20Forwarder(_fwd).encodePermitWitnessTransferFrom({
+            token: _erc20,
             from: _alice,
             value: _TRANSFER_AMOUNT,
             permit: permit,
@@ -281,6 +287,7 @@ contract ERC20ForwarderTest is Test {
         permit.permitted.amount = _TRANSFER_AMOUNT - 1;
 
         bytes memory input = ERC20Forwarder(_fwd).encodePermitWitnessTransferFrom({
+            token: _erc20,
             from: _alice,
             value: _TRANSFER_AMOUNT,
             permit: permit,
@@ -310,6 +317,7 @@ contract ERC20ForwarderTest is Test {
         _erc20.approve(address(_permit2), type(uint256).max);
 
         bytes memory input = ERC20Forwarder(_fwd).encodePermitWitnessTransferFrom({
+            token: _erc20,
             from: _alice,
             value: _TRANSFER_AMOUNT,
             permit: _defaultPermit,
@@ -337,6 +345,7 @@ contract ERC20ForwarderTest is Test {
         _erc20.approve(address(_permit2), type(uint256).max);
 
         bytes memory input = ERC20Forwarder(_fwd).encodePermitWitnessTransferFrom({
+            token: _erc20,
             from: _alice,
             value: _TRANSFER_AMOUNT,
             permit: _defaultPermit,
@@ -351,7 +360,7 @@ contract ERC20ForwarderTest is Test {
 
         vm.prank(_pa);
         vm.expectEmit(address(_fwd));
-        emit ERC20Forwarder.Wrapped({from: _alice, value: _TRANSFER_AMOUNT});
+        emit ERC20Forwarder.Wrapped({token: _erc20, from: _alice, value: _TRANSFER_AMOUNT});
         ERC20Forwarder(_fwd).forwardCall({logicRef: _CALLDATA_CARRIER_LOGIC_REF, input: input});
     }
 


### PR DESCRIPTION
Allows one forwarder contract to support all ERC20 token wrappings.