### PR TITLE
refactor: optimize events

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -41,7 +41,7 @@
     "gas-calldata-parameters": "warn",
     "gas-custom-errors": "warn",
     "gas-increment-by-one": "off",
-    "gas-indexed-events": "warn",
+    "gas-indexed-events": "off",
     "gas-length-in-loops": "warn",
     "gas-multitoken1155": "warn",
     "gas-named-return-values": "warn",

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -138,6 +138,8 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                     ]
                 });
             }
+
+            emit ActionExecuted({actionTreeRoot: actionTreeRoot, tagsCount: nResources});
         }
 
         // Check if the transaction induced a state change and the state root has changed

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -147,10 +147,9 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
 
             // Store the final root
             _storeRoot(newRoot);
-
-            // Emit the event containing the transaction and new root
-            emit TransactionExecuted({tags: tags, logicRefs: logicRefs, newRoot: newRoot});
         }
+
+        emit TransactionExecuted({tags: tags, logicRefs: logicRefs});
     }
     // slither-disable-end reentrancy-no-eth
 

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -60,7 +60,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
     // slither-disable-start reentrancy-no-eth
     /// @inheritdoc IProtocolAdapter
     function execute(Transaction calldata transaction) external override nonReentrant {
-        bytes32 newRoot = 0;
+        bytes32 updatedRoot = 0;
         uint256[2] memory transactionDelta = [uint256(0), uint256(0)];
 
         uint256 nActions = transaction.actions.length;
@@ -99,7 +99,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                 bytes32 cm = complianceVerifierInput.instance.created.commitment;
 
                 // Process the tags and provided root against global state
-                newRoot =
+                updatedRoot =
                     _processState({nf: nf, cm: cm, root: complianceVerifierInput.instance.consumed.commitmentTreeRoot});
 
                 // Verify the proof against a hardcoded compliance circuit
@@ -148,7 +148,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
             _verifyDeltaProof({proof: transaction.deltaProof, transactionDelta: transactionDelta, tags: tags});
 
             // Store the final root
-            _storeRoot(newRoot);
+            _storeRoot(updatedRoot);
         }
 
         emit TransactionExecuted({tags: tags, logicRefs: logicRefs});

--- a/contracts/src/forwarders/ERC20Forwarder.sol
+++ b/contracts/src/forwarders/ERC20Forwarder.sol
@@ -23,7 +23,6 @@ contract ERC20Forwarder is EmergencyMigratableForwarderBase {
     /// (see [Uniswap's announcement](https://blog.uniswap.org/permit2-and-universal-router)).
     IPermit2 internal constant _PERMIT2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
 
-    // solhint-disable gas-indexed-events
     /// @notice Emitted when ERC20 tokens get wrapped.
     /// @param token The ERC20 token address.
     /// @param from The address from which tokens were withdrawn.
@@ -35,7 +34,6 @@ contract ERC20Forwarder is EmergencyMigratableForwarderBase {
     /// @param to The address to which tokens were deposited.
     /// @param value The token amount being withdrawn from the ERC20 forwarder contract.
     event Unwrapped(address indexed token, address indexed to, uint256 value);
-    // solhint-enable gas-indexed-events
 
     error CallTypeInvalid();
     error TypeOverflow(uint256 limit, uint256 actual);

--- a/contracts/src/interfaces/ICommitmentAccumulator.sol
+++ b/contracts/src/interfaces/ICommitmentAccumulator.sol
@@ -6,6 +6,10 @@ pragma solidity ^0.8.30;
 /// @notice The interface of the commitment accumulator contract.
 /// @custom:security-contact security@anoma.foundation
 interface ICommitmentAccumulator {
+    /// @notice Emitted when a commitment tree root is stored in the set of historical roots.
+    /// @param root The root that was stored.
+    event CommitmentTreeRootStored(bytes32 root);
+
     /// @notice Returns the latest  commitment tree state root.
     /// @return root The latest commitment tree state root.
     function latestRoot() external view returns (bytes32 root);

--- a/contracts/src/interfaces/IProtocolAdapter.sol
+++ b/contracts/src/interfaces/IProtocolAdapter.sol
@@ -11,8 +11,8 @@ interface IProtocolAdapter {
     /// @notice Emitted when a transaction is executed.
     /// @param tags The tags of resources being consumed and created in this transaction in alternating order.
     /// @param logicRefs The logic references of resources being consumed and created in this transaction.
-    /// @param newRoot The new commitment tree root.
-    event TransactionExecuted(bytes32[] tags, bytes32[] logicRefs, bytes32 newRoot);
+    event TransactionExecuted(bytes32[] tags, bytes32[] logicRefs);
+
 
     /// @notice Emitted when a forwarder call is executed.
     /// @param untrustedForwarder The forwarder contract forwarding the call.

--- a/contracts/src/interfaces/IProtocolAdapter.sol
+++ b/contracts/src/interfaces/IProtocolAdapter.sol
@@ -13,6 +13,10 @@ interface IProtocolAdapter {
     /// @param logicRefs The logic references of resources being consumed and created in this transaction.
     event TransactionExecuted(bytes32[] tags, bytes32[] logicRefs);
 
+    /// @notice Emitted when an action is executed.
+    /// @param actionTreeRoot The action tree root.
+    /// @param tagsCount The number of tags in the action.
+    event ActionExecuted(bytes32 actionTreeRoot, uint256 tagsCount);
 
     /// @notice Emitted when a forwarder call is executed.
     /// @param untrustedForwarder The forwarder contract forwarding the call.

--- a/contracts/src/interfaces/IProtocolAdapter.sol
+++ b/contracts/src/interfaces/IProtocolAdapter.sol
@@ -9,16 +9,40 @@ import {Transaction} from "../Types.sol";
 /// @custom:security-contact security@anoma.foundation
 interface IProtocolAdapter {
     /// @notice Emitted when a transaction is executed.
-    /// @param id The transaction ID.
-    /// @param transaction The executed transaction.
+    /// @param tags The tags of resources being consumed and created in this transaction in alternating order.
+    /// @param logicRefs The logic references of resources being consumed and created in this transaction.
     /// @param newRoot The new commitment tree root.
-    event TransactionExecuted(uint256 indexed id, Transaction transaction, bytes32 newRoot);
+    event TransactionExecuted(bytes32[] tags, bytes32[] logicRefs, bytes32 newRoot);
 
     /// @notice Emitted when a forwarder call is executed.
     /// @param untrustedForwarder The forwarder contract forwarding the call.
     /// @param input The input data for the forwarded call.
     /// @param output The expected output data from the forwarded call.
     event ForwarderCallExecuted(address indexed untrustedForwarder, bytes input, bytes output);
+
+    /// @notice Emitted to store a resource payload blob persistently.
+    /// @param tag The tag of the resource this blob belongs to.
+    /// @param index The index of the blob in the payload array.
+    /// @param blob The blob.
+    event ResourcePayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
+
+    /// @notice Emitted to store a discovery payload blob persistently.
+    /// @param tag The tag of the resource this blob belongs to.
+    /// @param index The index of the blob in the payload array.
+    /// @param blob The blob.
+    event DiscoveryPayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
+
+    /// @notice Emitted to store a external payload blob persistently.
+    /// @param tag The tag of the resource this blob belongs to.
+    /// @param index The index of the blob in the payload array.
+    /// @param blob The blob.
+    event ExternalPayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
+
+    /// @notice Emitted to store an application payload blob persistently.
+    /// @param tag The tag of the resource this blob belongs to.
+    /// @param index The index of the blob in the payload array.
+    /// @param blob The blob.
+    event ApplicationPayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
 
     /// @notice Executes a transaction by adding the commitments and nullifiers to the commitment tree and nullifier
     /// set, respectively.

--- a/contracts/src/interfaces/IProtocolAdapter.sol
+++ b/contracts/src/interfaces/IProtocolAdapter.sol
@@ -28,25 +28,25 @@ interface IProtocolAdapter {
     /// @param tag The tag of the resource this blob belongs to.
     /// @param index The index of the blob in the payload array.
     /// @param blob The blob.
-    event ResourcePayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
+    event ResourcePayload(bytes32 indexed tag, uint256 index, bytes blob);
 
     /// @notice Emitted to store a discovery payload blob persistently.
     /// @param tag The tag of the resource this blob belongs to.
     /// @param index The index of the blob in the payload array.
     /// @param blob The blob.
-    event DiscoveryPayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
+    event DiscoveryPayload(bytes32 indexed tag, uint256 index, bytes blob);
 
     /// @notice Emitted to store a external payload blob persistently.
     /// @param tag The tag of the resource this blob belongs to.
     /// @param index The index of the blob in the payload array.
     /// @param blob The blob.
-    event ExternalPayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
+    event ExternalPayload(bytes32 indexed tag, uint256 index, bytes blob);
 
     /// @notice Emitted to store an application payload blob persistently.
     /// @param tag The tag of the resource this blob belongs to.
     /// @param index The index of the blob in the payload array.
     /// @param blob The blob.
-    event ApplicationPayload(bytes32 indexed tag, uint256 indexed index, bytes blob);
+    event ApplicationPayload(bytes32 indexed tag, uint256 index, bytes blob);
 
     /// @notice Executes a transaction by adding the commitments and nullifiers to the commitment tree and nullifier
     /// set, respectively.

--- a/contracts/src/state/CommitmentAccumulator.sol
+++ b/contracts/src/state/CommitmentAccumulator.sol
@@ -73,6 +73,7 @@ contract CommitmentAccumulator is ICommitmentAccumulator {
         if (!_roots.add(root)) {
             revert PreExistingRoot(root);
         }
+        emit CommitmentTreeRootStored(root);
     }
 
     /// @notice An internal function verifying that a Merkle path (proof) and a commitment leaf reproduce a given root.

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -6,9 +6,12 @@ import {Pausable} from "@openzeppelin-contracts/utils/Pausable.sol";
 import {RiscZeroVerifierEmergencyStop} from "@risc0-ethereum/RiscZeroVerifierEmergencyStop.sol";
 import {RiscZeroVerifierRouter} from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 
+import {ICommitmentAccumulator} from "../src/interfaces/ICommitmentAccumulator.sol";
+import {IProtocolAdapter} from "../src/interfaces/IProtocolAdapter.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
+import {Transaction, Action} from "../src/Types.sol";
 import {TransactionExample} from "./examples/Transaction.e.sol";
 import {DeployRiscZeroContracts} from "./script/DeployRiscZeroContracts.s.sol";
 
@@ -41,5 +44,27 @@ contract ProtocolAdapterTest is Test {
 
     function test_execute() public {
         _pa.execute(TransactionExample.transaction());
+    }
+
+    function test_execute_executes_the_empty_transaction() public {
+        Transaction memory emptyTx = Transaction({actions: new Action[](0), deltaProof: ""});
+
+        vm.expectEmit(address(_pa));
+        emit IProtocolAdapter.TransactionExecuted({tags: new bytes32[](0), logicRefs: new bytes32[](0)});
+        _pa.execute(emptyTx);
+    }
+
+    function test_execute_does_not_emit_the_CommitmentTreeRootStored_event_for_the_empty_transaction() public {
+        Transaction memory emptyTx = Transaction({actions: new Action[](0), deltaProof: ""});
+
+        vm.recordLogs();
+
+        _pa.execute(emptyTx);
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        for (uint256 i = 0; i < entries.length; i++) {
+            assert(entries[i].topics[0] != ICommitmentAccumulator.CommitmentTreeRootStored.selector);
+        }
     }
 }

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -13,7 +13,7 @@ import {RiscZeroUtils} from "../src/libs/RiscZeroUtils.sol";
 
 import {Logic} from "../src/proving/Logic.sol";
 import {NullifierSet} from "../src/state/NullifierSet.sol";
-import {Transaction, Resource} from "../src/Types.sol";
+import {Transaction, Action} from "../src/Types.sol";
 
 import {ForwarderExample} from "./examples/Forwarder.e.sol";
 import {INPUT, EXPECTED_OUTPUT} from "./examples/ForwarderTarget.e.sol";
@@ -26,7 +26,7 @@ contract ProtocolAdapterMockTest is Test {
     using RiscZeroUtils for Logic.VerifierInput;
     using TxGen for RiscZeroMockVerifier;
     using TxGen for Transaction;
-    using TxGen for Resource;
+    using TxGen for Action[];
 
     bytes32 internal constant _CARRIER_LOGIC_REF = bytes32(uint256(123));
 
@@ -65,7 +65,11 @@ contract ProtocolAdapterMockTest is Test {
         bytes32 expectedRoot = cms.computeRoot({treeDepth: MerkleTree.computeMinimalTreeDepth(cms.length) + 1});
 
         vm.expectEmit(address(_mockPa));
-        emit IProtocolAdapter.TransactionExecuted({id: 0, transaction: txn, newRoot: expectedRoot});
+        emit IProtocolAdapter.TransactionExecuted({
+            tags: txn.actions.collectTags(),
+            logicRefs: txn.actions.collectLogicRefs(),
+            newRoot: expectedRoot
+        });
         _mockPa.execute(txn);
     }
 

--- a/contracts/test/examples/TxGen.sol
+++ b/contracts/test/examples/TxGen.sol
@@ -261,6 +261,20 @@ library TxGen {
         }
     }
 
+    function collectLogicRefs(Action[] memory actions) internal pure returns (bytes32[] memory logicRefs) {
+        logicRefs = new bytes32[](countComplianceUnits(actions) * 2);
+
+        uint256 n = 0;
+        for (uint256 i = 0; i < actions.length; ++i) {
+            uint256 nCUs = actions[i].complianceVerifierInputs.length;
+
+            for (uint256 j = 0; j < nCUs; ++j) {
+                logicRefs[n++] = actions[i].complianceVerifierInputs[j].instance.consumed.logicRef;
+                logicRefs[n++] = actions[i].complianceVerifierInputs[j].instance.created.logicRef;
+            }
+        }
+    }
+
     function mockResource(bytes32 nonce, bytes32 logicRef, bytes32 labelRef, uint128 quantity)
         internal
         pure

--- a/contracts/test/examples/TxGen.sol
+++ b/contracts/test/examples/TxGen.sol
@@ -252,11 +252,10 @@ library TxGen {
 
         uint256 n = 0;
         for (uint256 i = 0; i < actions.length; ++i) {
-            uint256 nCUs = actions[i].complianceVerifierInputs.length;
+            bytes32[] memory actionTags = collectTags(actions[i]);
 
-            for (uint256 j = 0; j < nCUs; ++j) {
-                tags[n++] = actions[i].complianceVerifierInputs[j].instance.consumed.nullifier;
-                tags[n++] = actions[i].complianceVerifierInputs[j].instance.created.commitment;
+            for (uint256 j = 0; j < actionTags.length; ++j) {
+                tags[n++] = actionTags[j];
             }
         }
     }

--- a/contracts/test/examples/TxGen.sol
+++ b/contracts/test/examples/TxGen.sol
@@ -261,6 +261,17 @@ library TxGen {
         }
     }
 
+    function collectTags(Action memory action) internal pure returns (bytes32[] memory tags) {
+        uint256 nCUs = action.complianceVerifierInputs.length;
+
+        tags = new bytes32[](nCUs * 2);
+
+        for (uint256 i = 0; i < nCUs; ++i) {
+            tags[i * 2] = action.complianceVerifierInputs[i].instance.consumed.nullifier;
+            tags[(i * 2) + 1] = action.complianceVerifierInputs[i].instance.created.commitment;
+        }
+    }
+
     function collectLogicRefs(Action[] memory actions) internal pure returns (bytes32[] memory logicRefs) {
         logicRefs = new bytes32[](countComplianceUnits(actions) * 2);
 

--- a/contracts/test/state/CommitmentAccumulator.t.sol
+++ b/contracts/test/state/CommitmentAccumulator.t.sol
@@ -3,11 +3,10 @@ pragma solidity ^0.8.30;
 
 import {Test} from "forge-std/Test.sol";
 
+import {ICommitmentAccumulator} from "../../src/interfaces/ICommitmentAccumulator.sol";
 import {MerkleTree} from "../../src/libs/MerkleTree.sol";
 import {SHA256} from "../../src/libs/SHA256.sol";
-import {ICommitmentAccumulator} from "../../src/interfaces/ICommitmentAccumulator.sol";
 import {CommitmentAccumulator} from "../../src/state/CommitmentAccumulator.sol";
-
 import {MerkleTreeExample} from "../examples/MerkleTree.e.sol";
 import {CommitmentAccumulatorMock} from "../mocks/CommitmentAccumulator.m.sol";
 

--- a/contracts/test/state/CommitmentAccumulator.t.sol
+++ b/contracts/test/state/CommitmentAccumulator.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 
 import {MerkleTree} from "../../src/libs/MerkleTree.sol";
 import {SHA256} from "../../src/libs/SHA256.sol";
+import {ICommitmentAccumulator} from "../../src/interfaces/ICommitmentAccumulator.sol";
 import {CommitmentAccumulator} from "../../src/state/CommitmentAccumulator.sol";
 
 import {MerkleTreeExample} from "../examples/MerkleTree.e.sol";
@@ -46,6 +47,27 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
             assertEq(newCount, ++prevCount);
             prevCount = newCount;
         }
+    }
+
+    function test_storeRoot_stores_the_root() public {
+        bytes32 rootToStore = bytes32(type(uint256).max);
+
+        assertEq(_cmAcc.latestRoot(), _cmAcc.initialRoot());
+        assertEq(_cmAcc.containsRoot(rootToStore), false);
+
+        _cmAcc.storeRoot(rootToStore);
+
+        assertEq(_cmAcc.latestRoot(), rootToStore);
+        assertEq(_cmAcc.containsRoot(rootToStore), true);
+    }
+
+    function test_storeRoot_emits_the_CommitmentTreeRootStored_event() public {
+        bytes32 rootToStore = bytes32(type(uint256).max);
+
+        vm.expectEmit(address(_cmAcc));
+        emit ICommitmentAccumulator.CommitmentTreeRootStored({root: rootToStore});
+
+        _cmAcc.storeRoot(rootToStore);
     }
 
     function test_addCommitment_allows_adding_the_same_commitment_multiple_times() public {


### PR DESCRIPTION
Note that event gas costs are calculated by `k + unindexedBytes * a + indexedTopics * b` where
```
k = 375
a = 8
b = 375
```
Accordingly, not adding the `indexed` keyword to arguments of size is slightly cheaper for types that fit into a 32 bytes slot (`32 byte * 8 gas / byte = 256 gas`). 

However, indexed arguments are faster to index and to filter and query (see https://docs.soliditylang.org/en/latest/contracts.html#events), which we want to make use of.