### PR TITLE
Murisi/use real deltas

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -129,13 +129,10 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
                 tags[resCounter++] = cm;
 
                 // Compute transaction delta
-                transactionDelta = _addUnitDelta({
-                    transactionDelta: transactionDelta,
-                    unitDelta: [
-                        uint256(complianceVerifierInput.instance.unitDeltaX),
-                        uint256(complianceVerifierInput.instance.unitDeltaY)
-                    ]
-                });
+                transactionDelta = transactionDelta.add([
+                    uint256(complianceVerifierInput.instance.unitDeltaX),
+                    uint256(complianceVerifierInput.instance.unitDeltaY)
+                ]);
             }
         }
 
@@ -297,19 +294,5 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         }
 
         root = actionTreeTags.computeRoot();
-    }
-
-    /// @notice An internal function adding a unit delta to the transactionDelta.
-    /// @param transactionDelta The transaction delta.
-    /// @param unitDelta The unit delta to add.
-    /// @return sum The sum of the transaction delta and the unit delta.
-    /// @dev This function is virtual to allow for it to be overridden, e.g., to mock delta proofs.
-    function _addUnitDelta(uint256[2] memory transactionDelta, uint256[2] memory unitDelta)
-        internal
-        pure
-        virtual
-        returns (uint256[2] memory sum)
-    {
-        sum = transactionDelta.add(unitDelta);
     }
 }

--- a/contracts/src/proving/Delta.sol
+++ b/contracts/src/proving/Delta.sol
@@ -45,7 +45,7 @@ library Delta {
     /// @param proof The delta proof.
     /// @param instance The transaction delta.
     /// @param verifyingKey The Keccak-256 hash of all nullifiers and commitments as ordered in the compliance units.
-    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) internal pure {
+    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) public pure {
         // Verify the delta proof using the ECDSA.recover API to obtain the address
         address recovered = ECDSA.recover({hash: verifyingKey, signature: proof});
 

--- a/contracts/src/proving/Delta.sol
+++ b/contracts/src/proving/Delta.sol
@@ -12,6 +12,23 @@ library Delta {
     /// @notice Thrown if the recovered delta public key doesn't match the delta instance.
     error DeltaMismatch(address expected, address actual);
 
+    /// @notice Verifies a delta proof.
+    /// @param proof The delta proof.
+    /// @param instance The transaction delta.
+    /// @param verifyingKey The Keccak-256 hash of all nullifiers and commitments as ordered in the compliance units.
+    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) public pure {
+        // Verify the delta proof using the ECDSA.recover API to obtain the address
+        address recovered = ECDSA.recover({hash: verifyingKey, signature: proof});
+
+        // Convert the public key to an address
+        address expected = toAccount(instance);
+
+        // Compare it with the recovered address
+        if (recovered != expected) {
+            revert DeltaMismatch({expected: expected, actual: recovered});
+        }
+    }
+
     /// @notice Adds to ellipitic curve points and returns the resulting value.
     /// @param p1 The first curve point.
     /// @param p2 The second curve point.
@@ -39,22 +56,5 @@ library Delta {
     /// Since all the tags are 32 bytes in size, tight variable packing will not occur.
     function computeVerifyingKey(bytes32[] memory tags) internal pure returns (bytes32 verifyingKey) {
         verifyingKey = keccak256(abi.encodePacked(tags));
-    }
-
-    /// @notice Verifies a delta proof.
-    /// @param proof The delta proof.
-    /// @param instance The transaction delta.
-    /// @param verifyingKey The Keccak-256 hash of all nullifiers and commitments as ordered in the compliance units.
-    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) public pure {
-        // Verify the delta proof using the ECDSA.recover API to obtain the address
-        address recovered = ECDSA.recover({hash: verifyingKey, signature: proof});
-
-        // Convert the public key to an address
-        address expected = toAccount(instance);
-
-        // Compare it with the recovered address
-        if (recovered != expected) {
-            revert DeltaMismatch({expected: expected, actual: recovered});
-        }
     }
 }

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -138,12 +138,6 @@ contract ProtocolAdapterMockTest is Test {
         _mockPa.execute(txn);
     }
 
-    function test_execute_1_txn_with_1_action_and_0_cus() public {
-        (Transaction memory txn,) =
-            _mockVerifier.transaction({nonce: 0, configs: TxGen.generateActionConfigs({nActions: 1, nCUs: 0})});
-        _mockPa.execute(txn);
-    }
-
     function test_execute_1_txn_with_2_action_with_1_and_0_cus() public {
         TxGen.ActionConfig[] memory configs = new TxGen.ActionConfig[](2);
         configs[0] = TxGen.ActionConfig({nCUs: 1});

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -75,6 +75,7 @@ contract ProtocolAdapterMockTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
+        Transaction memory txn = _mockVerifier.transaction(resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -82,7 +83,7 @@ contract ProtocolAdapterMockTest is Test {
             input: INPUT,
             output: EXPECTED_OUTPUT
         });
-        _mockPa.execute(_mockVerifier.transaction(resourceLists));
+        _mockPa.execute(txn);
     }
 
     function test_execute_emits_the_ForwarderCallExecuted_event_on_consumed_carrier_resource() public {
@@ -91,6 +92,7 @@ contract ProtocolAdapterMockTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
+        Transaction memory txn = _mockVerifier.transaction(resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -99,7 +101,7 @@ contract ProtocolAdapterMockTest is Test {
             output: EXPECTED_OUTPUT
         });
 
-        _mockPa.execute(_mockVerifier.transaction(resourceLists));
+        _mockPa.execute(txn);
     }
 
     function test_execute_emits_all_ForwarderCallExecuted_events() public {
@@ -117,6 +119,7 @@ contract ProtocolAdapterMockTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
+        Transaction memory txn = _mockVerifier.transaction(resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -132,7 +135,7 @@ contract ProtocolAdapterMockTest is Test {
             output: EXPECTED_OUTPUT
         });
 
-        _mockPa.execute(_mockVerifier.transaction(resourceLists));
+        _mockPa.execute(txn);
     }
 
     function test_execute_1_txn_with_1_action_and_0_cus() public {

--- a/contracts/test/examples/TxGen.sol
+++ b/contracts/test/examples/TxGen.sol
@@ -78,26 +78,6 @@ library TxGen {
         });
     }
 
-    function logicVerifierInput(
-        RiscZeroMockVerifier mockVerifier,
-        bytes32 actionTreeRoot,
-        Resource memory resource,
-        bool isConsumed,
-        Logic.AppData memory appData
-    ) internal view returns (Logic.VerifierInput memory input) {
-        input = Logic.VerifierInput({
-            tag: isConsumed ? nullifier(resource, 0) : commitment(resource),
-            verifyingKey: resource.logicRef,
-            appData: appData,
-            proof: ""
-        });
-
-        input.proof = mockVerifier.mockProve({
-            imageId: resource.logicRef,
-            journalDigest: input.toJournalDigest(actionTreeRoot, isConsumed)
-        }).seal;
-    }
-
     function createAction(
         RiscZeroMockVerifier mockVerifier,
         ResourceAndAppData[] memory consumed,
@@ -247,6 +227,26 @@ library TxGen {
                 verifyingKey: Delta.computeVerifyingKey(tags)
         }));
         txn = Transaction({actions: actions, deltaProof: proof});
+    }
+
+    function logicVerifierInput(
+        RiscZeroMockVerifier mockVerifier,
+        bytes32 actionTreeRoot,
+        Resource memory resource,
+        bool isConsumed,
+        Logic.AppData memory appData
+    ) internal view returns (Logic.VerifierInput memory input) {
+        input = Logic.VerifierInput({
+            tag: isConsumed ? nullifier(resource, 0) : commitment(resource),
+            verifyingKey: resource.logicRef,
+            appData: appData,
+            proof: ""
+        });
+
+        input.proof = mockVerifier.mockProve({
+            imageId: resource.logicRef,
+            journalDigest: input.toJournalDigest(actionTreeRoot, isConsumed)
+        }).seal;
     }
 
     function generateActionConfigs(uint256 nActions, uint256 nCUs)

--- a/contracts/test/examples/TxGen.sol
+++ b/contracts/test/examples/TxGen.sol
@@ -12,6 +12,7 @@ import {Compliance} from "../../src/proving/Compliance.sol";
 import {Delta} from "../../src/proving/Delta.sol";
 import {Logic} from "../../src/proving/Logic.sol";
 import {Transaction, Action, Resource} from "../../src/Types.sol";
+import {DeltaProofTest} from "../proofs/DeltaProof.t.sol";
 
 library TxGen {
     using MerkleTree for bytes32[];
@@ -41,16 +42,23 @@ library TxGen {
         bytes32 commitmentTreeRoot, // historical root
         Resource memory consumed,
         Resource memory created
-    ) internal view returns (Compliance.VerifierInput memory unit) {
+    ) internal returns (Compliance.VerifierInput memory unit) {
         bytes32 nf = nullifier(consumed, 0);
         bytes32 cm = commitment(created);
 
-        bytes32 unitDeltaX;
-        bytes32 unitDeltaY;
-        unchecked {
-            unitDeltaX = bytes32(kind(consumed) * consumed.quantity);
-            unitDeltaY = bytes32(kind(created) * created.quantity);
-        }
+        DeltaProofTest deltaProofTest = new DeltaProofTest();
+        // Construct the delta for consumption based on kind and quantity
+        uint256[2] memory unitDelta = deltaProofTest.generateDeltaInstance(DeltaProofTest.DeltaInstanceInputs({
+                kind: kind(consumed),
+                quantity: -int256(uint256(consumed.quantity)),
+                rcv: 1
+        }));
+        // Construct the delta for creation based on kind and quantity
+        unitDelta = Delta.add(unitDelta, deltaProofTest.generateDeltaInstance(DeltaProofTest.DeltaInstanceInputs({
+                kind: kind(created),
+                quantity: int256(uint256(created.quantity)),
+                rcv: 1
+        })));
 
         Compliance.Instance memory instance = Compliance.Instance({
             consumed: Compliance.ConsumedRefs({
@@ -59,8 +67,8 @@ library TxGen {
                 logicRef: consumed.logicRef
             }),
             created: Compliance.CreatedRefs({commitment: cm, logicRef: created.logicRef}),
-            unitDeltaX: unitDeltaX,
-            unitDeltaY: unitDeltaY
+            unitDeltaX: bytes32(unitDelta[0]),
+            unitDeltaY: bytes32(unitDelta[1])
         });
 
         unit = Compliance.VerifierInput({
@@ -94,7 +102,7 @@ library TxGen {
         RiscZeroMockVerifier mockVerifier,
         ResourceAndAppData[] memory consumed,
         ResourceAndAppData[] memory created
-    ) internal view returns (Action memory action) {
+    ) internal returns (Action memory action) {
         if (consumed.length != created.length) {
             revert ConsumedCreatedCountMismatch({nConsumed: consumed.length, nCreated: created.length});
         }
@@ -144,7 +152,6 @@ library TxGen {
 
     function createDefaultAction(RiscZeroMockVerifier mockVerifier, bytes32 nonce, uint256 nCUs)
         internal
-        view
         returns (Action memory action, bytes32 updatedNonce)
     {
         updatedNonce = nonce;
@@ -190,7 +197,6 @@ library TxGen {
 
     function transaction(RiscZeroMockVerifier mockVerifier, ResourceLists[] memory actionResources)
         internal
-        view
         returns (Transaction memory txn)
     {
         Action[] memory actions = new Action[](actionResources.length);
@@ -209,12 +215,19 @@ library TxGen {
             });
         }
 
-        txn = Transaction({actions: actions, deltaProof: abi.encodePacked(collectTags(actions))});
+        DeltaProofTest deltaProofTest = new DeltaProofTest();
+        // Grab the tags that will be signed over
+        bytes32[] memory tags = TxGen.collectTags(actions);
+        // Generate a proof over the tags where rcv value is the expected total
+        bytes memory proof = deltaProofTest.generateDeltaProof(DeltaProofTest.DeltaProofInputs({
+                rcv: tags.length,
+                verifyingKey: Delta.computeVerifyingKey(tags)
+        }));
+        txn = Transaction({actions: actions, deltaProof: proof});
     }
 
     function transaction(RiscZeroMockVerifier mockVerifier, bytes32 nonce, ActionConfig[] memory configs)
         internal
-        view
         returns (Transaction memory txn, bytes32 updatedNonce)
     {
         updatedNonce = nonce;
@@ -225,7 +238,15 @@ library TxGen {
                 createDefaultAction({mockVerifier: mockVerifier, nonce: updatedNonce, nCUs: configs[i].nCUs});
         }
 
-        txn = Transaction({actions: actions, deltaProof: abi.encodePacked(collectTags(actions))});
+        DeltaProofTest deltaProofTest = new DeltaProofTest();
+        // Grab the tags that will be signed over
+        bytes32[] memory tags = TxGen.collectTags(actions);
+        // Generate a proof over the tags where rcv value is the expected total
+        bytes memory proof = deltaProofTest.generateDeltaProof(DeltaProofTest.DeltaProofInputs({
+                rcv: tags.length,
+                verifyingKey: Delta.computeVerifyingKey(tags)
+        }));
+        txn = Transaction({actions: actions, deltaProof: proof});
     }
 
     function generateActionConfigs(uint256 nActions, uint256 nCUs)

--- a/contracts/test/mocks/ProtocolAdapter.m.sol
+++ b/contracts/test/mocks/ProtocolAdapter.m.sol
@@ -7,7 +7,6 @@ import {RiscZeroUtils} from "../../src/libs/RiscZeroUtils.sol";
 import {ProtocolAdapter} from "../../src/ProtocolAdapter.sol";
 import {Compliance} from "../../src/proving/Compliance.sol";
 import {Delta} from "../../src/proving/Delta.sol";
-import {Logic} from "../../src/proving/Logic.sol";
 
 import {_MOCK_VERIFIER_SELECTOR} from "../script/DeployRiscZeroContractsMock.s.sol";
 

--- a/contracts/test/mocks/ProtocolAdapter.m.sol
+++ b/contracts/test/mocks/ProtocolAdapter.m.sol
@@ -20,24 +20,4 @@ contract ProtocolAdapterMock is ProtocolAdapter {
     function getRiscZeroVerifierSelector() public pure override returns (bytes4 verifierSelector) {
         verifierSelector = _MOCK_VERIFIER_SELECTOR;
     }
-
-    function _verifyComplianceProof(Compliance.VerifierInput calldata input) internal view override {
-        _TRUSTED_RISC_ZERO_VERIFIER_ROUTER.verify({
-            seal: input.proof,
-            imageId: Compliance._VERIFYING_KEY,
-            journalDigest: input.instance.toJournalDigest()
-        });
-    }
-
-    function _verifyLogicProof(Logic.VerifierInput calldata input, bytes32 tree, bool consumed)
-        internal
-        view
-        override
-    {
-        _TRUSTED_RISC_ZERO_VERIFIER_ROUTER.verify({
-            seal: input.proof,
-            imageId: input.verifyingKey,
-            journalDigest: RiscZeroUtils.toJournalDigest(input, tree, consumed)
-        });
-    }
 }

--- a/contracts/test/mocks/ProtocolAdapter.m.sol
+++ b/contracts/test/mocks/ProtocolAdapter.m.sol
@@ -40,29 +40,4 @@ contract ProtocolAdapterMock is ProtocolAdapter {
             journalDigest: RiscZeroUtils.toJournalDigest(input, tree, consumed)
         });
     }
-
-    function _verifyDeltaProof(bytes calldata proof, uint256[2] memory transactionDelta, bytes32[] memory tags)
-        internal
-        pure
-        override
-    {
-        if (transactionDelta[0] != transactionDelta[1]) {
-            revert Delta.DeltaMismatch({expected: address(0), actual: address(0)});
-        }
-
-        if (keccak256(proof) != tags.computeVerifyingKey()) {
-            revert Delta.DeltaMismatch({expected: address(type(uint160).max), actual: address(type(uint160).max)});
-        }
-    }
-
-    function _addUnitDelta(uint256[2] memory transactionDelta, uint256[2] memory unitDelta)
-        internal
-        pure
-        override
-        returns (uint256[2] memory sum)
-    {
-        unchecked {
-            sum = [transactionDelta[0] + unitDelta[0], transactionDelta[1] + unitDelta[1]];
-        }
-    }
 }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -12,9 +12,9 @@ contract DeltaProofTest is Test {
     // The parameters required to generate a delta instance
     struct DeltaInstanceInputs {
         // The identifier of the asset
-        uint128 kind;
+        uint256 kind;
         // The quantity of the asset
-        int128 quantity;
+        int256 quantity;
         // Value commitment randomness
         uint256 rcv;
     }
@@ -27,14 +27,20 @@ contract DeltaProofTest is Test {
         bytes32 verifyingKey;
     }
 
+    /// @notice Convert a int256 exponent to an equivalent uin256 assuming an order of SECP256K1_ORDER
+    function canonize_quantity(int256 quantity) public returns (uint256 quantityu) {
+        // If positive, leave the number unchanged
+        quantityu = quantity >= 0 ? uint256(quantity) : (SECP256K1_ORDER - 1 - (uint256(-(quantity + 1)) % SECP256K1_ORDER));
+    }
+
     /// @notice Generates a transaction delta proof by signing verifyingKey with
     /// rcv, and a delta instance by computing a(kind)^quantity * b^rcv
     function generateDeltaInstance(DeltaInstanceInputs memory deltaInputs) public returns (uint256[2] memory instance) {
         deltaInputs.rcv = deltaInputs.rcv % SECP256K1_ORDER;
         vm.assume(deltaInputs.rcv != 0);
         vm.assume(deltaInputs.kind != 0);
-        int256 prodAux = (int256(uint256(deltaInputs.kind)) * int256(deltaInputs.quantity));
-        uint256 prod = prodAux >= 0 ? uint256(prodAux) : SECP256K1_ORDER - (uint256(-prodAux) % SECP256K1_ORDER);
+        uint256 quantity = canonize_quantity(deltaInputs.quantity);
+        uint256 prod = mulmod(deltaInputs.kind, quantity, SECP256K1_ORDER);
         uint256 preDelta = addmod(prod, deltaInputs.rcv, SECP256K1_ORDER);
         vm.assume(preDelta != 0);
         // Derive address and public key from transaction delta
@@ -70,15 +76,15 @@ contract DeltaProofTest is Test {
         // Ensure that we're adding assets of the same kind over the same verifying key
         deltaInputs2.kind = deltaInputs1.kind;
         // Filter out overflows
-        vm.assume(deltaInputs1.quantity < 0 || deltaInputs2.quantity <= type(int128).max - deltaInputs1.quantity);
-        vm.assume(deltaInputs1.quantity >= 0 || type(int128).min - deltaInputs1.quantity <= deltaInputs2.quantity);
+        vm.assume(deltaInputs1.quantity < 0 || deltaInputs2.quantity <= type(int256).max - deltaInputs1.quantity);
+        vm.assume(deltaInputs1.quantity >= 0 || type(int256).min - deltaInputs1.quantity <= deltaInputs2.quantity);
         vm.assume(0 < deltaInputs2.rcv && deltaInputs2.rcv <= type(uint256).max - deltaInputs1.rcv);
         // Compute the inputs corresponding to the sum of deltas
         DeltaInstanceInputs memory deltaInputs3 = DeltaInstanceInputs({
             kind: deltaInputs1.kind,
             quantity: deltaInputs1.quantity + deltaInputs2.quantity,
             rcv: deltaInputs1.rcv + deltaInputs2.rcv
-            });
+        });
         // Generate a delta proof and instance from the above tags and preimage
         uint256[2] memory instance1 = generateDeltaInstance(deltaInputs1);
         uint256[2] memory instance2 = generateDeltaInstance(deltaInputs2);
@@ -93,8 +99,8 @@ contract DeltaProofTest is Test {
     function test_verify_inconsistent_delta_fails1(DeltaInstanceInputs memory deltaInstanceInputs, DeltaProofInputs memory deltaProofInputs) public {
         // Filter out inadmissible private keys or equal keys
         deltaProofInputs.rcv = deltaInstanceInputs.rcv;
-        vm.assume(deltaInstanceInputs.kind != 0);
-        vm.assume(deltaInstanceInputs.quantity != 0);
+        vm.assume(deltaInstanceInputs.kind % SECP256K1_ORDER != 0);
+        vm.assume(canonize_quantity(deltaInstanceInputs.quantity) != 0);
         // Generate a delta proof and instance from the above tags and preimage
         uint256[2] memory instance = generateDeltaInstance(deltaInstanceInputs);
         bytes memory proof = generateDeltaProof(deltaProofInputs);
@@ -137,7 +143,7 @@ contract DeltaProofTest is Test {
         uint256 maxDeltaLen = 10;
         deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % maxDeltaLen);
         // Make sure that the delta quantities balance out
-        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
+        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int256 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
         // Adjust the last delta so that the full sum is zero
         if(quantity != 0) {
             wrappedDeltaInputs[wrappedDeltaInputs.length - 1].quantity -= quantity;
@@ -161,12 +167,12 @@ contract DeltaProofTest is Test {
     function test_verify_imbalanced_delta_fails(DeltaInstanceInputs[] memory deltaInputs, bytes32 verifyingKey) public {
         uint256[2] memory deltaAcc = [uint256(0), uint256(0)];
         // Truncate the delta inputs to improve test performance
-        uint256 maxDeltaLen= 10;
+        uint256 maxDeltaLen = 10;
         deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % maxDeltaLen);
         // Accumulate the total quantity and randomness commitment
-        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
+        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int256 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
         // Assume that the deltas are imbalanced
-        vm.assume(quantity != 0);
+        vm.assume(canonize_quantity(quantity) != 0);
         for(uint256 i = 0; i < wrappedDeltaInputs.length; i++) {
             // Compute the delta instance and accumulate it
             uint256[2] memory instance = generateDeltaInstance(wrappedDeltaInputs[i]);
@@ -185,15 +191,19 @@ contract DeltaProofTest is Test {
 
     /// @notice Wrap the delta inputs in such a way that they can be balanced
     /// and also return the total quantity and value commitment randomness
-    function wrapDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantityAcc, uint256 rcvAcc) {
-        // Grab the kind to use for all deltas
-        uint128 kind = deltaInputs.length > 0 ? deltaInputs[0].kind : 0;
+    function wrapDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory wrappedDeltaInputs, int256 quantityAcc, uint256 rcvAcc) {
         // Compute the window into which the deltas should sum
-        int128 halfMax = type(int128).max >> 1;
-        int128 halfMin = type(int128).min >> 1;
+        int256 halfMax = type(int256).max >> 1;
+        int256 halfMin = type(int256).min >> 1;
         // Track the current quantity and value commitment randomness
         quantityAcc = 0;
         rcvAcc = 0;
+        if (deltaInputs.length == 0) {
+            return (deltaInputs, quantityAcc, rcvAcc);
+        }
+        // Grab the kind to use for all deltas
+        uint256 kind = deltaInputs[0].kind;
+        vm.assume(deltaInputs[0].kind % SECP256K1_ORDER != 0);
         // Wrap the deltas
         for(uint256 i = 0; i < deltaInputs.length; i++) {
             // Ensure that all the deltas have the same kind
@@ -202,10 +212,10 @@ contract DeltaProofTest is Test {
             rcvAcc = addmod(rcvAcc, deltaInputs[i].rcv, SECP256K1_ORDER);
             // Adjust the delta inputs so that the sum remains in a specific range
             if(deltaInputs[i].quantity >= 0 && quantityAcc > halfMax - deltaInputs[i].quantity) {
-                int128 overflow = quantityAcc - (halfMax - deltaInputs[i].quantity);
+                int256 overflow = quantityAcc - (halfMax - deltaInputs[i].quantity);
                 deltaInputs[i].quantity = halfMin + overflow - 1 - quantityAcc;
             } else if(deltaInputs[i].quantity < 0 && quantityAcc < halfMin - deltaInputs[i].quantity) {
-                int128 underflow = (halfMin - deltaInputs[i].quantity) - quantityAcc;
+                int256 underflow = (halfMin - deltaInputs[i].quantity) - quantityAcc;
                 deltaInputs[i].quantity = halfMax + 1 - underflow - quantityAcc;
             }
             // Finally, accumulate the adjusted quantity

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -7,6 +7,7 @@ import {Delta} from "../../src/proving/Delta.sol";
 import {Transaction} from "../../src/Types.sol";
 import {TransactionExample} from "../examples/Transaction.e.sol";
 import {TxGen} from "../examples/TxGen.sol";
+import {VmSafe} from "forge-std/Vm.sol";
 
 contract DeltaProofTest is Test {
     function test_verify_example_delta_proof() public pure {
@@ -20,5 +21,78 @@ contract DeltaProofTest is Test {
             ],
             verifyingKey: Delta.computeVerifyingKey(TxGen.collectTags(txn.actions))
         });
+    }
+
+    /// @notice Generates a transaction delta proof and delta
+    /// @param preDelta The input/preimage to the delta hash
+    /// @param verifyingKey The bytes being authorized
+    function generateDelta(uint256 preDelta, bytes32 verifyingKey) internal returns (bytes memory proof, uint256[2] memory instance) {
+        // Derive address and public key from transaction delta 
+        VmSafe.Wallet memory wallet = vm.createWallet(preDelta);
+        // Extract the transaction delta from the wallet
+        instance[0] = wallet.publicKeyX;
+        instance[1] = wallet.publicKeyY;
+        // Compute the components of the transaction delta proof
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet, verifyingKey);
+        // Finally compute the transaction delta proof
+        proof = abi.encodePacked(r, s, v);
+    }
+
+    /// @notice Test that Delta.verify accepts a well-formed delta proof and instance
+    /// @param preDelta The input/preimage to the delta hash
+    function test_deltaVerify(uint256 preDelta, bytes32 verifyingKey) public {
+        // Filter out inadmissible private keys
+        if(preDelta == 0 || preDelta >= SECP256K1_ORDER) { return; }
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof, uint256[2] memory instance) = generateDelta(preDelta, verifyingKey);
+        // Verify that the generated delta proof is valid
+        Delta.verify({proof: proof, instance: instance, verifyingKey: verifyingKey});
+    }
+
+    /// @notice Test that Delta.add correctly adds deltas
+    /// @param preDelta1 The input/preimage to the first delta hash
+    /// @param preDelta2 The input/preimage to the second delta hash
+    function test_deltaAdd(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+        // Filter out inadmissible private keys
+        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta2 >= SECP256K1_ORDER - preDelta1) { return; }
+        uint256 preDelta3 = preDelta1 + preDelta2;
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
+        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        (bytes memory proof3, uint256[2] memory instance3) = generateDelta(preDelta3, verifyingKey);
+        // Verify that the deltas add correctly
+        uint256[2] memory instance4 = Delta.add(instance1, instance2);
+        assertEq(instance3[0], instance4[0]);
+        assertEq(instance3[1], instance4[1]);
+    }
+
+    /// @notice Test that Delta.verify rejects a delta proof that does not correspond to instance
+    /// @param preDelta1 The input/preimage to the first delta hash
+    /// @param preDelta2 The input/preimage to the second delta hash
+    /// @param verifyingKey The hash being authorized
+    function test_inconsistentDeltaVerify1(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+        // Filter out inadmissible private keys or equal keys
+        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta1 == preDelta2) { return; }
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
+        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        // Verify that the mixing deltas is invalid
+        vm.expectPartialRevert(Delta.DeltaMismatch.selector);
+        Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
+    }
+
+    /// @notice Test that Delta.verify rejects a delta proof that does not correspond to the verifying key
+    /// @param preDelta The input/preimage to the delta hash
+    /// @param verifyingKey1 The first hash being authorized
+    /// @param verifyingKey2 The second hash being authorized
+    function test_inconsistentDeltaVerify2(uint256 preDelta, bytes32 verifyingKey1, bytes32 verifyingKey2) public {
+        // Filter out inadmissible private keys or equal keys
+        if(preDelta == 0 || preDelta >= SECP256K1_ORDER || verifyingKey1 == verifyingKey2) { return; }
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta, verifyingKey1);
+        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta, verifyingKey2);
+        // Verify that the mixing deltas is invalid
+        vm.expectPartialRevert(Delta.DeltaMismatch.selector);
+        Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey2});
     }
 }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -1,33 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Test} from "forge-std/Test.sol";
-
-import {Delta} from "../../src/proving/Delta.sol";
-import {Transaction} from "../../src/Types.sol";
+import { ECDSA } from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import { Test } from "forge-std/Test.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { Delta } from "./../../src/proving/Delta.sol";
+import { Transaction } from "./../../src/Types.sol";
 import {TransactionExample} from "../examples/Transaction.e.sol";
 import {TxGen} from "../examples/TxGen.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
 contract DeltaProofTest is Test {
-    function test_verify_example_delta_proof() public pure {
-        Transaction memory txn = TransactionExample.transaction();
-
-        Delta.verify({
-            proof: txn.deltaProof,
-            instance: [
-                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaX),
-                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaY)
-            ],
-            verifyingKey: Delta.computeVerifyingKey(TxGen.collectTags(txn.actions))
-        });
-    }
-
     /// @notice Generates a transaction delta proof and delta
     /// @param preDelta The input/preimage to the delta hash
     /// @param verifyingKey The bytes being authorized
-    function generateDelta(uint256 preDelta, bytes32 verifyingKey) internal returns (bytes memory proof, uint256[2] memory instance) {
-        // Derive address and public key from transaction delta 
+    function generateDelta(uint256 preDelta, bytes32 verifyingKey) public returns (bytes memory proof, uint256[2] memory instance) {
+        // Derive address and public key from transaction delta
         VmSafe.Wallet memory wallet = vm.createWallet(preDelta);
         // Extract the transaction delta from the wallet
         instance[0] = wallet.publicKeyX;
@@ -40,9 +28,9 @@ contract DeltaProofTest is Test {
 
     /// @notice Test that Delta.verify accepts a well-formed delta proof and instance
     /// @param preDelta The input/preimage to the delta hash
-    function test_deltaVerify(uint256 preDelta, bytes32 verifyingKey) public {
+    function test_verify_delta_succeeds(uint256 preDelta, bytes32 verifyingKey) public {
         // Filter out inadmissible private keys
-        if(preDelta == 0 || preDelta >= SECP256K1_ORDER) { return; }
+        vm.assume(0 < preDelta && preDelta < SECP256K1_ORDER);
         // Generate a delta proof and instance from the above tags and preimage
         (bytes memory proof, uint256[2] memory instance) = generateDelta(preDelta, verifyingKey);
         // Verify that the generated delta proof is valid
@@ -52,14 +40,15 @@ contract DeltaProofTest is Test {
     /// @notice Test that Delta.add correctly adds deltas
     /// @param preDelta1 The input/preimage to the first delta hash
     /// @param preDelta2 The input/preimage to the second delta hash
-    function test_deltaAdd(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+    function test_add_delta_correctness(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
         // Filter out inadmissible private keys
-        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta2 >= SECP256K1_ORDER - preDelta1) { return; }
+        vm.assume(0 < preDelta1 && preDelta1 < SECP256K1_ORDER);
+        vm.assume(0 < preDelta2 && preDelta2 < SECP256K1_ORDER - preDelta1);
         uint256 preDelta3 = preDelta1 + preDelta2;
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
-        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
-        (bytes memory proof3, uint256[2] memory instance3) = generateDelta(preDelta3, verifyingKey);
+        (, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
+        (, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        (, uint256[2] memory instance3) = generateDelta(preDelta3, verifyingKey);
         // Verify that the deltas add correctly
         uint256[2] memory instance4 = Delta.add(instance1, instance2);
         assertEq(instance3[0], instance4[0]);
@@ -70,12 +59,14 @@ contract DeltaProofTest is Test {
     /// @param preDelta1 The input/preimage to the first delta hash
     /// @param preDelta2 The input/preimage to the second delta hash
     /// @param verifyingKey The hash being authorized
-    function test_inconsistentDeltaVerify1(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+    function test_verify_inconsistent_delta_fails1(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
         // Filter out inadmissible private keys or equal keys
-        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta1 == preDelta2) { return; }
+        vm.assume(0 < preDelta1 && preDelta1 < SECP256K1_ORDER);
+        vm.assume(0 < preDelta2 && preDelta2 < SECP256K1_ORDER);
+        vm.assume(preDelta1 != preDelta2);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
-        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        (bytes memory proof1, ) = generateDelta(preDelta1, verifyingKey);
+        (, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
@@ -85,14 +76,27 @@ contract DeltaProofTest is Test {
     /// @param preDelta The input/preimage to the delta hash
     /// @param verifyingKey1 The first hash being authorized
     /// @param verifyingKey2 The second hash being authorized
-    function test_inconsistentDeltaVerify2(uint256 preDelta, bytes32 verifyingKey1, bytes32 verifyingKey2) public {
+    function test_verify_inconsistent_delta_fails2(uint256 preDelta, bytes32 verifyingKey1, bytes32 verifyingKey2) public {
         // Filter out inadmissible private keys or equal keys
-        if(preDelta == 0 || preDelta >= SECP256K1_ORDER || verifyingKey1 == verifyingKey2) { return; }
+        vm.assume(0 < preDelta && preDelta < SECP256K1_ORDER);
+        vm.assume(verifyingKey1 != verifyingKey2);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta, verifyingKey1);
-        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta, verifyingKey2);
+        (bytes memory proof1, ) = generateDelta(preDelta, verifyingKey1);
+        (, uint256[2] memory instance2) = generateDelta(preDelta, verifyingKey2);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey2});
+    }
+
+    function test_verify_example_delta_proof() public pure {
+        Transaction memory txn = TransactionExample.transaction();
+        Delta.verify({
+            proof: txn.deltaProof,
+            instance: [
+                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaX),
+                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaY)
+            ],
+            verifyingKey: Delta.computeVerifyingKey(TxGen.collectTags(txn.actions))
+        });
     }
 }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -28,7 +28,7 @@ contract DeltaProofTest is Test {
     }
 
     /// @notice Convert a int256 exponent to an equivalent uin256 assuming an order of SECP256K1_ORDER
-    function canonize_quantity(int256 quantity) public returns (uint256 quantityu) {
+    function canonize_quantity(int256 quantity) public pure returns (uint256 quantityu) {
         // If positive, leave the number unchanged
         quantityu = quantity >= 0 ? uint256(quantity) : (SECP256K1_ORDER - 1 - (uint256(-(quantity + 1)) % SECP256K1_ORDER));
     }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import { ECDSA } from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
 import { Test } from "forge-std/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 import { Delta } from "./../../src/proving/Delta.sol";
 import { Transaction } from "./../../src/Types.sol";
 import {TransactionExample} from "../examples/Transaction.e.sol";
 import {TxGen} from "../examples/TxGen.sol";
-import {VmSafe} from "forge-std/Vm.sol";
 
 contract DeltaProofTest is Test {
     /// @notice Generates a transaction delta proof and delta

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -27,12 +27,6 @@ contract DeltaProofTest is Test {
         bytes32 verifyingKey;
     }
 
-    /// @notice Convert a int256 exponent to an equivalent uin256 assuming an order of SECP256K1_ORDER
-    function canonize_quantity(int256 quantity) public pure returns (uint256 quantityu) {
-        // If positive, leave the number unchanged
-        quantityu = quantity >= 0 ? uint256(quantity) : (SECP256K1_ORDER - 1 - (uint256(-(quantity + 1)) % SECP256K1_ORDER));
-    }
-
     /// @notice Generates a transaction delta proof by signing verifyingKey with
     /// rcv, and a delta instance by computing a(kind)^quantity * b^rcv
     function generateDeltaInstance(DeltaInstanceInputs memory deltaInputs) public returns (uint256[2] memory instance) {
@@ -187,6 +181,12 @@ contract DeltaProofTest is Test {
         // Verify that the imbalanced transaction proof fails
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         Delta.verify({proof: proof, instance: deltaAcc, verifyingKey: verifyingKey});
+    }
+
+    /// @notice Convert a int256 exponent to an equivalent uin256 assuming an order of SECP256K1_ORDER
+    function canonize_quantity(int256 quantity) public pure returns (uint256 quantityu) {
+        // If positive, leave the number unchanged
+        quantityu = quantity >= 0 ? uint256(quantity) : (SECP256K1_ORDER - 1 - (uint256(-(quantity + 1)) % SECP256K1_ORDER));
     }
 
     /// @notice Wrap the delta inputs in such a way that they can be balanced

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -100,7 +100,7 @@ contract DeltaProofTest is Test {
     function test_verify_inconsistent_delta_fails2(DeltaProofInputs memory deltaInputs1, DeltaInstanceInputs memory deltaInputs2) public {
         deltaInputs2.quantity = 0;
         // Filter out inadmissible private keys or equal keys
-        vm.assume(deltaInputs1.rcv != deltaInputs2.rcv);
+        vm.assume((deltaInputs1.rcv % SECP256K1_ORDER) != (deltaInputs2.rcv % SECP256K1_ORDER));
         // Generate a delta proof and instance from the above tags and preimage
         bytes memory proof1 = generateDeltaProof(deltaInputs1);
         uint256[2] memory instance2 = generateDeltaInstance(deltaInputs2);
@@ -123,17 +123,18 @@ contract DeltaProofTest is Test {
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
     }
 
-    /// @notice Balance the delta inputs and also return the total value commitment randomness
-    function balanceDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory balancedDeltaInputs, uint256 rcv_acc) {
+    /// @notice Wrap the delta inputs in such a way that they can be balanced
+    /// and also return the total quantity and value commitment randomness
+    function wrapDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity_acc, uint256 rcv_acc) {
         // Grab the kind to use for all deltas
         uint128 kind = deltaInputs.length > 0 ? deltaInputs[0].kind : 0;
         // Compute the window into which the deltas should sum
         int128 half_max = type(int128).max >> 1;
         int128 half_min = type(int128).min >> 1;
         // Track the current quantity and value commitment randomness
-        int128 quantity_acc = 0;
+        quantity_acc = 0;
         rcv_acc = 0;
-        // Balance out the deltas
+        // Wrap the deltas
         for(uint i = 0; i < deltaInputs.length; i++) {
             // Ensure that all the deltas have the same kind
             deltaInputs[i].kind = kind;
@@ -150,12 +151,8 @@ contract DeltaProofTest is Test {
             // Finally, accumulate the adjusted quantity
             quantity_acc += deltaInputs[i].quantity;
         }
-        // Adjust the last delta so that the full sum is zero
-        if(quantity_acc != 0) {
-            deltaInputs[deltaInputs.length - 1].quantity -= quantity_acc;
-        }
-        // Finally, return tbe balanced deltas
-        balancedDeltaInputs = deltaInputs;
+        // Finally, return tbe wrapped deltas
+        wrappedDeltaInputs = deltaInputs;
     }
 
     /// @notice Grab the first length elements from deltaInputs
@@ -172,11 +169,15 @@ contract DeltaProofTest is Test {
         // Truncate the delta inputs to improve test performance
         uint MAX_DELTA_LEN = 10;
         deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % MAX_DELTA_LEN);
-        // Make sure that the delta qquantities balance out
-        (DeltaInstanceInputs[] memory balancedDeltaInputs, uint256 rcv) = balanceDeltaInputs(deltaInputs);
-        for(uint i = 0; i < balancedDeltaInputs.length; i++) {
+        // Make sure that the delta quantities balance out
+        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
+        // Adjust the last delta so that the full sum is zero
+        if(quantity != 0) {
+            wrappedDeltaInputs[wrappedDeltaInputs.length - 1].quantity -= quantity;
+        }
+        for(uint i = 0; i < wrappedDeltaInputs.length; i++) {
             // Compute the delta instance and accumulate it
-            uint256[2] memory instance = generateDeltaInstance(balancedDeltaInputs[i]);
+            uint256[2] memory instance = generateDeltaInstance(wrappedDeltaInputs[i]);
             deltaAcc = Delta.add(deltaAcc, instance);
         }
         // Compute the proof for the balanced transaction
@@ -186,6 +187,32 @@ contract DeltaProofTest is Test {
             });
         bytes memory proof = generateDeltaProof(sumDeltaInputs);
         // Verify that the balanced transaction proof succeeds
+        Delta.verify({proof: proof, instance: deltaAcc, verifyingKey: verifyingKey});
+    }
+
+    /// @notice Check that an imbalanced transaction fails verification
+    function test_verify_imbalanced_delta_fails(DeltaInstanceInputs[] memory deltaInputs, bytes32 verifyingKey) public {
+        uint256[2] memory deltaAcc = [uint256(0), uint256(0)];
+        // Truncate the delta inputs to improve test performance
+        uint MAX_DELTA_LEN = 10;
+        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % MAX_DELTA_LEN);
+        // Accumulate the total quantity and randomness commitment
+        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
+        // Assume that the deltas are imbalanced
+        vm.assume(quantity != 0);
+        for(uint i = 0; i < wrappedDeltaInputs.length; i++) {
+            // Compute the delta instance and accumulate it
+            uint256[2] memory instance = generateDeltaInstance(wrappedDeltaInputs[i]);
+            deltaAcc = Delta.add(deltaAcc, instance);
+        }
+        // Compute the proof for the balanced transaction
+        DeltaProofInputs memory sumDeltaInputs = DeltaProofInputs({
+            rcv: rcv,
+            verifyingKey: verifyingKey
+            });
+        bytes memory proof = generateDeltaProof(sumDeltaInputs);
+        // Verify that the imbalanced transaction proof fails
+        vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         Delta.verify({proof: proof, instance: deltaAcc, verifyingKey: verifyingKey});
     }
 

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -9,14 +9,21 @@ import {TransactionExample} from "../examples/Transaction.e.sol";
 import {TxGen} from "../examples/TxGen.sol";
 
 contract DeltaProofTest is Test {
+    // The parameters required to generate a delta instance
     struct DeltaInstanceInputs {
+        // The identifier of the asset
         uint128 kind;
+        // The quantity of the asset
         int128 quantity;
+        // Value commitment randomness
         uint256 rcv;
     }
 
+    // The parameters required to generate a delta proof
     struct DeltaProofInputs {
+        // Value commitment randomness
         uint256 rcv;
+        // The hash being signed over
         bytes32 verifyingKey;
     }
 
@@ -26,8 +33,8 @@ contract DeltaProofTest is Test {
         deltaInputs.rcv = deltaInputs.rcv % SECP256K1_ORDER;
         vm.assume(deltaInputs.rcv != 0);
         vm.assume(deltaInputs.kind != 0);
-        int256 prod_aux = (int256(uint256(deltaInputs.kind)) * int256(deltaInputs.quantity));
-        uint256 prod = prod_aux >= 0 ? uint256(prod_aux) : SECP256K1_ORDER - (uint256(-prod_aux) % SECP256K1_ORDER);
+        int256 prodAux = (int256(uint256(deltaInputs.kind)) * int256(deltaInputs.quantity));
+        uint256 prod = prodAux >= 0 ? uint256(prodAux) : SECP256K1_ORDER - (uint256(-prodAux) % SECP256K1_ORDER);
         uint256 preDelta = addmod(prod, deltaInputs.rcv, SECP256K1_ORDER);
         vm.assume(preDelta != 0);
         // Derive address and public key from transaction delta
@@ -123,59 +130,19 @@ contract DeltaProofTest is Test {
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
     }
 
-    /// @notice Wrap the delta inputs in such a way that they can be balanced
-    /// and also return the total quantity and value commitment randomness
-    function wrapDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity_acc, uint256 rcv_acc) {
-        // Grab the kind to use for all deltas
-        uint128 kind = deltaInputs.length > 0 ? deltaInputs[0].kind : 0;
-        // Compute the window into which the deltas should sum
-        int128 half_max = type(int128).max >> 1;
-        int128 half_min = type(int128).min >> 1;
-        // Track the current quantity and value commitment randomness
-        quantity_acc = 0;
-        rcv_acc = 0;
-        // Wrap the deltas
-        for(uint i = 0; i < deltaInputs.length; i++) {
-            // Ensure that all the deltas have the same kind
-            deltaInputs[i].kind = kind;
-            // Accumulate the randomness commitments modulo SECP256K1_ORDER
-            rcv_acc = addmod(rcv_acc, deltaInputs[i].rcv, SECP256K1_ORDER);
-            // Adjust the delta inputs so that the sum remains in a specific range
-            if(deltaInputs[i].quantity >= 0 && quantity_acc > half_max - deltaInputs[i].quantity) {
-                int128 overflow = quantity_acc - (half_max - deltaInputs[i].quantity);
-                deltaInputs[i].quantity = half_min + overflow - 1 - quantity_acc;
-            } else if(deltaInputs[i].quantity < 0 && quantity_acc < half_min - deltaInputs[i].quantity) {
-                int128 underflow = (half_min - deltaInputs[i].quantity) - quantity_acc;
-                deltaInputs[i].quantity = half_max + 1 - underflow - quantity_acc;
-            }
-            // Finally, accumulate the adjusted quantity
-            quantity_acc += deltaInputs[i].quantity;
-        }
-        // Finally, return tbe wrapped deltas
-        wrappedDeltaInputs = deltaInputs;
-    }
-
-    /// @notice Grab the first length elements from deltaInputs
-    function truncateDeltaInputs(DeltaInstanceInputs[] memory deltaInputs, uint length) public pure returns (DeltaInstanceInputs[] memory truncatedDeltaInputs) {
-        truncatedDeltaInputs = new DeltaInstanceInputs[](length);
-        for(uint i = 0; i < length; i++) {
-            truncatedDeltaInputs[i] = deltaInputs[i];
-        }
-    }
-
     /// @notice Check that a balanced transaction does pass verification
     function test_verify_balanced_delta_succeeds(DeltaInstanceInputs[] memory deltaInputs, bytes32 verifyingKey) public {
         uint256[2] memory deltaAcc = [uint256(0), uint256(0)];
         // Truncate the delta inputs to improve test performance
-        uint MAX_DELTA_LEN = 10;
-        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % MAX_DELTA_LEN);
+        uint256 maxDeltaLen = 10;
+        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % maxDeltaLen);
         // Make sure that the delta quantities balance out
         (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
         // Adjust the last delta so that the full sum is zero
         if(quantity != 0) {
             wrappedDeltaInputs[wrappedDeltaInputs.length - 1].quantity -= quantity;
         }
-        for(uint i = 0; i < wrappedDeltaInputs.length; i++) {
+        for(uint256 i = 0; i < wrappedDeltaInputs.length; i++) {
             // Compute the delta instance and accumulate it
             uint256[2] memory instance = generateDeltaInstance(wrappedDeltaInputs[i]);
             deltaAcc = Delta.add(deltaAcc, instance);
@@ -194,13 +161,13 @@ contract DeltaProofTest is Test {
     function test_verify_imbalanced_delta_fails(DeltaInstanceInputs[] memory deltaInputs, bytes32 verifyingKey) public {
         uint256[2] memory deltaAcc = [uint256(0), uint256(0)];
         // Truncate the delta inputs to improve test performance
-        uint MAX_DELTA_LEN = 10;
-        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % MAX_DELTA_LEN);
+        uint256 maxDeltaLen= 10;
+        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % maxDeltaLen);
         // Accumulate the total quantity and randomness commitment
         (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
         // Assume that the deltas are imbalanced
         vm.assume(quantity != 0);
-        for(uint i = 0; i < wrappedDeltaInputs.length; i++) {
+        for(uint256 i = 0; i < wrappedDeltaInputs.length; i++) {
             // Compute the delta instance and accumulate it
             uint256[2] memory instance = generateDeltaInstance(wrappedDeltaInputs[i]);
             deltaAcc = Delta.add(deltaAcc, instance);
@@ -216,9 +183,49 @@ contract DeltaProofTest is Test {
         Delta.verify({proof: proof, instance: deltaAcc, verifyingKey: verifyingKey});
     }
 
+    /// @notice Wrap the delta inputs in such a way that they can be balanced
+    /// and also return the total quantity and value commitment randomness
+    function wrapDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantityAcc, uint256 rcvAcc) {
+        // Grab the kind to use for all deltas
+        uint128 kind = deltaInputs.length > 0 ? deltaInputs[0].kind : 0;
+        // Compute the window into which the deltas should sum
+        int128 halfMax = type(int128).max >> 1;
+        int128 halfMin = type(int128).min >> 1;
+        // Track the current quantity and value commitment randomness
+        quantityAcc = 0;
+        rcvAcc = 0;
+        // Wrap the deltas
+        for(uint256 i = 0; i < deltaInputs.length; i++) {
+            // Ensure that all the deltas have the same kind
+            deltaInputs[i].kind = kind;
+            // Accumulate the randomness commitments modulo SECP256K1_ORDER
+            rcvAcc = addmod(rcvAcc, deltaInputs[i].rcv, SECP256K1_ORDER);
+            // Adjust the delta inputs so that the sum remains in a specific range
+            if(deltaInputs[i].quantity >= 0 && quantityAcc > halfMax - deltaInputs[i].quantity) {
+                int128 overflow = quantityAcc - (halfMax - deltaInputs[i].quantity);
+                deltaInputs[i].quantity = halfMin + overflow - 1 - quantityAcc;
+            } else if(deltaInputs[i].quantity < 0 && quantityAcc < halfMin - deltaInputs[i].quantity) {
+                int128 underflow = (halfMin - deltaInputs[i].quantity) - quantityAcc;
+                deltaInputs[i].quantity = halfMax + 1 - underflow - quantityAcc;
+            }
+            // Finally, accumulate the adjusted quantity
+            quantityAcc += deltaInputs[i].quantity;
+        }
+        // Finally, return tbe wrapped deltas
+        wrappedDeltaInputs = deltaInputs;
+    }
+
+    /// @notice Grab the first length elements from deltaInputs
+    function truncateDeltaInputs(DeltaInstanceInputs[] memory deltaInputs, uint256 length) public pure returns (DeltaInstanceInputs[] memory truncatedDeltaInputs) {
+        truncatedDeltaInputs = new DeltaInstanceInputs[](length);
+        for(uint256 i = 0; i < length; i++) {
+            truncatedDeltaInputs[i] = deltaInputs[i];
+        }
+    }
+
     function test_verify_example_delta_proof() public pure {
         Transaction memory txn = TransactionExample.transaction();
-        
+
         Delta.verify({
             proof: txn.deltaProof,
             instance: [

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -23,9 +23,8 @@ contract DeltaProofTest is Test {
         vm.assume(deltaInputs.rcv != 0);
         vm.assume(deltaInputs.kind != 0);
         int256 prod_aux = (int256(uint256(deltaInputs.kind)) * int256(deltaInputs.quantity));
-        uint256 prod = prod_aux >= 0 ? uint256(prod_aux) % SECP256K1_ORDER : SECP256K1_ORDER - (uint256(-prod_aux) % SECP256K1_ORDER);
-        vm.assume(prod < SECP256K1_ORDER - deltaInputs.rcv);
-        uint256 preDelta = (prod + deltaInputs.rcv) % SECP256K1_ORDER;
+        uint256 prod = prod_aux >= 0 ? uint256(prod_aux) : SECP256K1_ORDER - (uint256(-prod_aux) % SECP256K1_ORDER);
+        uint256 preDelta = addmod(prod, deltaInputs.rcv, SECP256K1_ORDER);
         vm.assume(preDelta != 0);
         // Derive address and public key from transaction delta
         VmSafe.Wallet memory valueWallet = vm.createWallet(preDelta);
@@ -116,8 +115,78 @@ contract DeltaProofTest is Test {
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: deltaInputs2.verifyingKey});
     }
 
+    /// @notice Balance the delta inputs and also return the total value commitment randomness
+    function balanceDeltaInputs(DeltaInputs[] memory deltaInputs) public pure returns (DeltaInputs[] memory balancedDeltaInputs, uint256 rcv_acc) {
+        // Grab the kind to use for all deltas
+        uint128 kind = deltaInputs.length > 0 ? deltaInputs[0].kind : 0;
+        // Compute the window into which the deltas should sum
+        int128 half_max = type(int128).max >> 1;
+        int128 half_min = type(int128).min >> 1;
+        // Track the current quantity and value commitment randomness
+        int128 quantity_acc = 0;
+        rcv_acc = 0;
+        // Balance out the deltas
+        for(uint i = 0; i < deltaInputs.length; i++) {
+            // Ensure that all the deltas have the same kind
+            deltaInputs[i].kind = kind;
+            // Accumulate the randomness commitments modulo SECP256K1_ORDER
+            rcv_acc = addmod(rcv_acc, deltaInputs[i].rcv, SECP256K1_ORDER);
+            // Adjust the delta inputs so that the sum remains in a specific range
+            if(deltaInputs[i].quantity >= 0 && quantity_acc > half_max - deltaInputs[i].quantity) {
+                int128 overflow = quantity_acc - (half_max - deltaInputs[i].quantity);
+                deltaInputs[i].quantity = half_min + overflow - 1 - quantity_acc;
+            } else if(deltaInputs[i].quantity < 0 && quantity_acc < half_min - deltaInputs[i].quantity) {
+                int128 underflow = (half_min - deltaInputs[i].quantity) - quantity_acc;
+                deltaInputs[i].quantity = half_max + 1 - underflow - quantity_acc;
+            }
+            // Finally, accumulate the adjusted quantity
+            quantity_acc += deltaInputs[i].quantity;
+        }
+        // Adjust the last delta so that the full sum is zero
+        if(quantity_acc != 0) {
+            deltaInputs[deltaInputs.length - 1].quantity -= quantity_acc;
+        }
+        // Finally, return tbe balanced deltas
+        balancedDeltaInputs = deltaInputs;
+    }
+
+    /// @notice Grab the first length elements from deltaInputs
+    function truncateDeltaInputs(DeltaInputs[] memory deltaInputs, uint length) public pure returns (DeltaInputs[] memory truncatedDeltaInputs) {
+        truncatedDeltaInputs = new DeltaInputs[](length);
+        for(uint i = 0; i < length; i++) {
+            truncatedDeltaInputs[i] = deltaInputs[i];
+        }
+    }
+
+    /// @notice Check that a balanced transaction does pass verification
+    function test_verify_balanced_delta_succeeds(DeltaInputs[] memory deltaInputs, bytes32 verifyingKey) public {
+        uint256[2] memory deltaAcc = [uint256(0), uint256(0)];
+        // Truncate the delta inputs to improve test performance
+        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % 10);
+        // Make sure that the delta qquantities balance out
+        (DeltaInputs[] memory balancedDeltaInputs, uint256 rcv) = balanceDeltaInputs(deltaInputs);
+        for(uint i = 0; i < balancedDeltaInputs.length; i++) {
+            // This is not strictly necessary because verifying key is not used to compute delta instance
+            balancedDeltaInputs[i].verifyingKey = verifyingKey;
+            // Compute the delta instance and accumulate it
+            (, uint256[2] memory instance) = generateDelta(balancedDeltaInputs[i]);
+            deltaAcc = Delta.add(deltaAcc, instance);
+        }
+        // Compute the proof for the balanced transaction
+        DeltaInputs memory sumDeltaInputs = DeltaInputs({
+            kind: 1,
+            quantity: 0,
+            rcv: rcv,
+            verifyingKey: verifyingKey
+            });
+        (bytes memory proof, ) = generateDelta(sumDeltaInputs);
+        // Verify that the balanced transaction proof succeeds
+        Delta.verify({proof: proof, instance: deltaAcc, verifyingKey: verifyingKey});
+    }
+
     function test_verify_example_delta_proof() public pure {
         Transaction memory txn = TransactionExample.transaction();
+        
         Delta.verify({
             proof: txn.deltaProof,
             instance: [


### PR DESCRIPTION
Based on https://github.com/anoma/evm-protocol-adapter/pull/172 . This PR modifies `TxGen` so that it uses actual delta instance and proof generation instead of mocks. Furthermore it adjusts `ProtocolAdapterMock` to use the actual verification methods instead of the mock.