### PR TITLE
Murisi/execute tests rebased

### DIFF
--- a/contracts/src/proving/Delta.sol
+++ b/contracts/src/proving/Delta.sol
@@ -45,7 +45,7 @@ library Delta {
     /// @param proof The delta proof.
     /// @param instance The transaction delta.
     /// @param verifyingKey The Keccak-256 hash of all nullifiers and commitments as ordered in the compliance units.
-    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) internal pure {
+    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) public pure {
         // Verify the delta proof using the ECDSA.recover API to obtain the address
         address recovered = ECDSA.recover({hash: verifyingKey, signature: proof});
 

--- a/contracts/src/proving/Delta.sol
+++ b/contracts/src/proving/Delta.sol
@@ -12,6 +12,23 @@ library Delta {
     /// @notice Thrown if the recovered delta public key doesn't match the delta instance.
     error DeltaMismatch(address expected, address actual);
 
+    /// @notice Verifies a delta proof.
+    /// @param proof The delta proof.
+    /// @param instance The transaction delta.
+    /// @param verifyingKey The Keccak-256 hash of all nullifiers and commitments as ordered in the compliance units.
+    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) public pure {
+        // Verify the delta proof using the ECDSA.recover API to obtain the address
+        address recovered = ECDSA.recover({hash: verifyingKey, signature: proof});
+
+        // Convert the public key to an address
+        address expected = toAccount(instance);
+
+        // Compare it with the recovered address
+        if (recovered != expected) {
+            revert DeltaMismatch({expected: expected, actual: recovered});
+        }
+    }
+
     /// @notice Adds to ellipitic curve points and returns the resulting value.
     /// @param p1 The first curve point.
     /// @param p2 The second curve point.
@@ -39,22 +56,5 @@ library Delta {
     /// Since all the tags are 32 bytes in size, tight variable packing will not occur.
     function computeVerifyingKey(bytes32[] memory tags) internal pure returns (bytes32 verifyingKey) {
         verifyingKey = keccak256(abi.encodePacked(tags));
-    }
-
-    /// @notice Verifies a delta proof.
-    /// @param proof The delta proof.
-    /// @param instance The transaction delta.
-    /// @param verifyingKey The Keccak-256 hash of all nullifiers and commitments as ordered in the compliance units.
-    function verify(bytes memory proof, uint256[2] memory instance, bytes32 verifyingKey) public pure {
-        // Verify the delta proof using the ECDSA.recover API to obtain the address
-        address recovered = ECDSA.recover({hash: verifyingKey, signature: proof});
-
-        // Convert the public key to an address
-        address expected = toAccount(instance);
-
-        // Compare it with the recovered address
-        if (recovered != expected) {
-            revert DeltaMismatch({expected: expected, actual: recovered});
-        }
     }
 }

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -14,21 +14,27 @@ import {DeployRiscZeroContracts} from "./script/DeployRiscZeroContracts.s.sol";
 import {Transaction, Action} from "../src/Types.sol";
 import {Compliance} from "../src/proving/Compliance.sol";
 import {Logic} from "../src/proving/Logic.sol";
+import {TxGen} from "./examples/TxGen.sol";
+import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
+import {ProtocolAdapterMock} from "./mocks/ProtocolAdapter.m.sol";
+import {DeployRiscZeroContractsMock} from "./script/DeployRiscZeroContractsMock.s.sol";
 
-contract ProtocolAdapterTest is Test, ProtocolAdapter {
+contract ProtocolAdapterTest is Test, ProtocolAdapterMock {
     RiscZeroVerifierRouter internal _router;
     RiscZeroVerifierEmergencyStop internal _emergencyStop;
     ProtocolAdapter internal _pa;
+    RiscZeroMockVerifier internal _mockVerifier;
+    using TxGen for RiscZeroMockVerifier;
 
-    constructor() ProtocolAdapter(riscZeroVerifierRouter()) {}
+    constructor() ProtocolAdapterMock(riscZeroVerifierRouter()) {}
 
     function riscZeroVerifierRouter() public returns (RiscZeroVerifierRouter router) {
-        (_router, _emergencyStop,) = new DeployRiscZeroContracts().run();
+        (_router, _emergencyStop, _mockVerifier) = new DeployRiscZeroContractsMock().run();
         router = _router;
     }
 
     function setUp() public {
-        _pa = new ProtocolAdapter({
+        _pa = new ProtocolAdapterMock({
             riscZeroVerifierRouter: _router
         });
     }
@@ -38,19 +44,28 @@ contract ProtocolAdapterTest is Test, ProtocolAdapter {
         _emergencyStop.estop();
 
         vm.expectRevert(ProtocolAdapter.RiscZeroVerifierStopped.selector);
-        new ProtocolAdapter(_router);
+        new ProtocolAdapterMock(_router);
     }
 
-    function test_execute_reverts_on_vulnerable_risc_zero_verifier() public {
+    function test_execute_reverts_on_vulnerable_risc_zero_verifier(uint8 nActions, uint8 nCUs, UnknownTagFailsParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+
         vm.prank(_emergencyStop.owner());
         _emergencyStop.estop();
 
         vm.expectRevert(Pausable.EnforcedPause.selector, address(_emergencyStop));
-        _pa.execute(TransactionExample.transaction());
+        _pa.execute(txn);
     }
 
-    function test_execute() public {
-        _pa.execute(TransactionExample.transaction());
+    function test_execute(uint8 nActions, uint8 nCUs) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        _pa.execute(txn);
     }
 
     // solhint-disable-next-line no-empty-blocks
@@ -92,7 +107,12 @@ contract ProtocolAdapterTest is Test, ProtocolAdapter {
         this.execute(transaction);
     }
 
-    function test_execute_non_existing_root_fails(NonExistingRootFailsParams memory params) public {
+    /// @notice Test that transactions with nonexistent rotts fail
+    function test_execute_non_existing_root_fails(uint8 nActions, uint8 nCUs, NonExistingRootFailsParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
         mutation_test_execute_non_existing_root_fails(TransactionExample.transaction(), params);
     }
 
@@ -131,7 +151,12 @@ contract ProtocolAdapterTest is Test, ProtocolAdapter {
         this.execute(transaction);
     }
 
-    function test_execute_short_proof_fails(ShortProofFailsParams memory params) public {
+    /// @notice Test that transactions with short proofs fail
+    function test_execute_short_proof_fails(uint8 nActions, uint8 nCUs, ShortProofFailsParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
         mutation_test_execute_short_proof_fails(TransactionExample.transaction(), params);
     }
 
@@ -170,7 +195,12 @@ contract ProtocolAdapterTest is Test, ProtocolAdapter {
         this.execute(transaction);
     }
 
-    function test_execute_unknown_selector_fails(UnknownSelectorFailsParams memory params) public {
+    /// @notice Test that transactions with unknown selectors fail
+    function test_execute_unknown_selector_fails(uint8 nActions, uint8 nCUs, UnknownSelectorFailsParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
         mutation_test_execute_unknown_selector_fails(TransactionExample.transaction(), params);
     }
 
@@ -213,8 +243,13 @@ contract ProtocolAdapterTest is Test, ProtocolAdapter {
         this.execute(transaction);
     }
 
-    function test_execute_unknown_nullifier_tag_fails(UnknownTagFailsParams memory params) public {
-        mutation_test_execute_unknown_nullifier_tag_fails(TransactionExample.transaction(), params);
+    /// @notice Test that transactions with unknown nullifier tags fail
+    function test_execute_unknown_nullifier_tag_fails(uint8 nActions, uint8 nCUs, UnknownTagFailsParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        mutation_test_execute_unknown_nullifier_tag_fails(txn, params);
     }
 
     /// @notice Take a transaction that would execute successfully and make it
@@ -246,7 +281,12 @@ contract ProtocolAdapterTest is Test, ProtocolAdapter {
         this.execute(transaction);
     }
 
-    function test_execute_unknown_commitment_tag_fails(UnknownTagFailsParams memory params) public {
-        mutation_test_execute_unknown_commitment_tag_fails(TransactionExample.transaction(), params);
+    /// @notice Test that transactions with unknown commitment tags fail
+    function test_execute_unknown_commitment_tag_fails(uint8 nActions, uint8 nCUs, UnknownTagFailsParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        mutation_test_execute_unknown_commitment_tag_fails(txn, params);
     }
 }

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -11,13 +11,17 @@ import {Test} from "forge-std/Test.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 import {TransactionExample} from "./examples/Transaction.e.sol";
 import {DeployRiscZeroContracts} from "./script/DeployRiscZeroContracts.s.sol";
-import {Transaction, Action} from "../src/Types.sol";
+import {Transaction, Action, ForwarderCalldata} from "../src/Types.sol";
 import {Compliance} from "../src/proving/Compliance.sol";
 import {Logic} from "../src/proving/Logic.sol";
 import {TxGen} from "./examples/TxGen.sol";
 import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.sol";
 import {ProtocolAdapterMock} from "./mocks/ProtocolAdapter.m.sol";
 import {DeployRiscZeroContractsMock} from "./script/DeployRiscZeroContractsMock.s.sol";
+import {ForwarderExample} from "./examples/Forwarder.e.sol";
+import {ProtocolAdapterMockTest} from "./ProtocolAdapterMock.t.sol";
+import {RiscZeroUtils} from "../src/libs/RiscZeroUtils.sol";
+import {MerkleTree} from "../src/libs/MerkleTree.sol";
 
 contract ProtocolAdapterTest is Test, ProtocolAdapterMock {
     RiscZeroVerifierRouter internal _router;
@@ -25,6 +29,8 @@ contract ProtocolAdapterTest is Test, ProtocolAdapterMock {
     ProtocolAdapter internal _pa;
     RiscZeroMockVerifier internal _mockVerifier;
     using TxGen for RiscZeroMockVerifier;
+    using RiscZeroUtils for Logic.VerifierInput;
+    using MerkleTree for bytes32[];
 
     constructor() ProtocolAdapterMock(riscZeroVerifierRouter()) {}
 
@@ -413,5 +419,109 @@ contract ProtocolAdapterTest is Test, ProtocolAdapterMock {
 
         (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
         mutate_test_execute_mismatching_logic_refs_fail(txn, params);
+    }
+
+    /// @notice The parameters necessary to make a failing mutation to a transaction
+    struct MismatchingForwarderCallOutputsFailParams {
+        // The index of the action to mutate
+        uint256 actionIdx;
+        // The index of the logic verifier input of the action to mutate
+        uint256 inputIdx;
+        // The index of the external payload to mutate
+        uint256 payloadIdx;
+        // The output to overwrite with
+        bytes output;
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by ensuring that one of its forwarder call outputs mismatch.
+    function mutate_test_execute_mismatching_forwarder_call_outputs_fail(Transaction memory transaction, MismatchingForwarderCallOutputsFailParams memory params) public {
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Action memory action = transaction.actions[params.actionIdx];
+        Logic.VerifierInput[] memory logicVerifierInputs = action.logicVerifierInputs;
+        // Cannot do mutation if transaction has no logic verifier inputs
+        vm.assume(logicVerifierInputs.length > 0);
+        // Wrap the logic verifier input index into range
+        params.inputIdx = params.inputIdx % logicVerifierInputs.length;
+        Logic.VerifierInput memory logicVerifierInput = logicVerifierInputs[params.inputIdx];
+        Logic.ExpirableBlob[] memory externalPayloads = logicVerifierInput.appData.externalPayload;
+        // Cannot do the mutation if transaction has no external payloads
+        vm.assume(externalPayloads.length > 0);
+        // Wrap the external payload index into range
+        params.payloadIdx = params.payloadIdx % externalPayloads.length;
+        // Now corrupt the calldata output
+        ForwarderCalldata memory call = abi.decode(externalPayloads[params.payloadIdx].blob, (ForwarderCalldata));
+        vm.assume(call.output.length != params.output.length || keccak256(call.output) != keccak256(params.output));
+        call.output = params.output;
+        // Re-encode the calldata and replace the value in the external payloads
+        externalPayloads[params.payloadIdx].blob = abi.encode(call);
+        // Now determine whether the current resource is being created or consumed
+        Compliance.VerifierInput[] memory complianceVerifierInputs = action.complianceVerifierInputs;
+        bool isConsumed;
+        for (uint256 i = 0; i < complianceVerifierInputs.length; i++) {
+            if (complianceVerifierInputs[i].instance.consumed.nullifier == logicVerifierInput.tag) {
+                isConsumed = true;
+            } else if (complianceVerifierInputs[i].instance.created.commitment == logicVerifierInputs[params.inputIdx].tag) {
+                isConsumed = false;
+            }
+        }
+        // Compute the action tree root
+        bytes32 actionTreeRoot = _computeActionTreeRoot_memory(action, action.complianceVerifierInputs.length);
+        // Recompute the logic verifier input proof
+        logicVerifierInputs[params.inputIdx].proof = _mockVerifier.mockProve({
+            imageId: logicVerifierInputs[params.inputIdx].verifyingKey,
+            journalDigest: logicVerifierInputs[params.inputIdx].toJournalDigest(actionTreeRoot, isConsumed)
+        }).seal;
+        // With mismatching forwarder call outputs, we expect failure
+        vm.expectPartialRevert(ForwarderCallOutputMismatch.selector);
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    /// @notice Computes the action tree root of an action constituted by all its nullifiers and commitments.
+    /// @param action The action whose root we compute.
+    /// @param nCUs The number of compliance units in the action.
+    /// @return root The root of the corresponding tree.
+    function _computeActionTreeRoot_memory(Action memory action, uint256 nCUs) internal pure returns (bytes32 root) {
+        bytes32[] memory actionTreeTags = new bytes32[](nCUs * 2);
+
+        // The order in which the tags are added to the tree are provided by the compliance units
+        for (uint256 j = 0; j < nCUs; ++j) {
+            Compliance.VerifierInput memory complianceVerifierInput = action.complianceVerifierInputs[j];
+
+            actionTreeTags[2 * j] = complianceVerifierInput.instance.consumed.nullifier;
+            actionTreeTags[(2 * j) + 1] = complianceVerifierInput.instance.created.commitment;
+        }
+
+        root = actionTreeTags.computeRoot();
+    }
+
+    /// @notice Test that transactions with mismatching forwarder call outputs fails
+    function test_execute_mismatching_forwarder_call_outputs_fail(uint8 nActions, uint8 nCUs, MismatchingForwarderCallOutputsFailParams memory params) public {
+        bytes32 _CARRIER_LOGIC_REF = bytes32(uint256(123));
+        address _fwd = address(
+            new ForwarderExample({protocolAdapter: address(this), calldataCarrierLogicRef: _CARRIER_LOGIC_REF})
+        );
+        address fwd2 = address(
+            new ForwarderExample({protocolAdapter: address(this), calldataCarrierLogicRef: _CARRIER_LOGIC_REF})
+        );
+        assertNotEq(_fwd, fwd2);
+
+        address[] memory fwdList = new address[](2);
+        fwdList[0] = _fwd;
+        fwdList[1] = fwd2;
+        ProtocolAdapterMockTest test = new ProtocolAdapterMockTest();
+
+        TxGen.ResourceAndAppData[] memory consumed = test._exampleResourceAndEmptyAppData({nonce: 0});
+        TxGen.ResourceAndAppData[] memory created =
+            test._exampleCarrierResourceAndAppData({nonce: 1, fwdList: fwdList, isConsumed: false});
+
+        TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
+        resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
+        Transaction memory txn = _mockVerifier.transaction(resourceLists);
+        mutate_test_execute_mismatching_forwarder_call_outputs_fail(txn, params);
     }
 }

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -11,16 +11,26 @@ import {Test} from "forge-std/Test.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 import {TransactionExample} from "./examples/Transaction.e.sol";
 import {DeployRiscZeroContracts} from "./script/DeployRiscZeroContracts.s.sol";
+import {Transaction, Action} from "../src/Types.sol";
+import {Compliance} from "../src/proving/Compliance.sol";
+import {Logic} from "../src/proving/Logic.sol";
 
-contract ProtocolAdapterTest is Test {
+contract ProtocolAdapterTest is Test, ProtocolAdapter {
     RiscZeroVerifierRouter internal _router;
     RiscZeroVerifierEmergencyStop internal _emergencyStop;
     ProtocolAdapter internal _pa;
 
-    function setUp() public {
-        (_router, _emergencyStop,) = new DeployRiscZeroContracts().run();
+    constructor() ProtocolAdapter(riscZeroVerifierRouter()) {}
 
-        _pa = new ProtocolAdapter(_router);
+    function riscZeroVerifierRouter() public returns (RiscZeroVerifierRouter router) {
+        (_router, _emergencyStop,) = new DeployRiscZeroContracts().run();
+        router = _router;
+    }
+
+    function setUp() public {
+        _pa = new ProtocolAdapter({
+            riscZeroVerifierRouter: _router
+        });
     }
 
     function test_constructor_reverts_on_vulnerable_risc_zero_verifier() public {
@@ -41,5 +51,202 @@ contract ProtocolAdapterTest is Test {
 
     function test_execute() public {
         _pa.execute(TransactionExample.transaction());
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    function test_tx_with_cu_mismatch_fails() public view {
+        // TODO: create a transaction with no compliance units and two trivial resources
+        //       in the action
+    }
+
+    /// @notice The parameters necessary to make a failing mutation to a transaction
+    struct NonExistingRootFailsParams {
+        // The index of the action to mutate
+        uint256 actionIdx;
+        // The index of the compliance verifier input of the action to mutate
+        uint256 inputIdx;
+        // The value to mutate the action tree root to
+        bytes32 commitmentTreeRoot;
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by giving one of its compliance verifier inputs an incorrect
+    /// commitment tree root.
+    function mutation_test_execute_non_existing_root_fails(Transaction memory transaction, NonExistingRootFailsParams memory params) public {
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Compliance.VerifierInput[] memory complianceVerifierInputs = transaction.actions[params.actionIdx].complianceVerifierInputs;
+        // Assume the proposed commitment tree root is not already contained
+        vm.assume(!_containsRoot(params.commitmentTreeRoot));
+        // Cannot do do mutation if transaction has no compliance verifier inputs
+        vm.assume(complianceVerifierInputs.length > 0);
+        // Wrap the compliance verifier input index into range
+        params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
+        // Finally assign the proposed commitment tree root into the transaction
+        complianceVerifierInputs[params.inputIdx].instance.consumed.commitmentTreeRoot = params.commitmentTreeRoot;
+        // With an incorrect commitment tree root, we expect failure
+        vm.expectPartialRevert(NonExistingRoot.selector);
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    function test_execute_non_existing_root_fails(NonExistingRootFailsParams memory params) public {
+        mutation_test_execute_non_existing_root_fails(TransactionExample.transaction(), params);
+    }
+
+    /// @notice The parameters necessary to make a failing mutation to a transaction
+    struct ShortProofFailsParams {
+        // The index of the action to mutate
+        uint256 actionIdx;
+        // The index of the compliance verifier input of the action to mutate
+        uint256 inputIdx;
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by giving one of its compliance verifier inputs a proof that's too
+    /// short.
+    function mutation_test_execute_short_proof_fails(Transaction memory transaction, ShortProofFailsParams memory params) public {
+        uint256 MIN_PROOF_LEN = 4;
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Compliance.VerifierInput[] memory complianceVerifierInputs = transaction.actions[params.actionIdx].complianceVerifierInputs;
+        // Cannot do do mutation if transaction has no compliance verifier inputs
+        vm.assume(complianceVerifierInputs.length > 0);
+        // Wrap the compliance verifier input index into range
+        params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
+        // Finally truncate the compliance proof to below the minimum
+        bytes memory proof = complianceVerifierInputs[params.inputIdx].proof;
+        bytes memory truncatedProof = new bytes(proof.length % MIN_PROOF_LEN);
+        for (uint256 k = 0; k < truncatedProof.length; k++) {
+            truncatedProof[k] = proof[k];
+        }
+        complianceVerifierInputs[params.inputIdx].proof = truncatedProof;
+        // With a short proof, we expect failure
+        vm.expectRevert(address(_router));
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    function test_execute_short_proof_fails(ShortProofFailsParams memory params) public {
+        mutation_test_execute_short_proof_fails(TransactionExample.transaction(), params);
+    }
+
+    /// @notice The parameters necessary to make a failing mutation to a transaction
+    struct UnknownSelectorFailsParams {
+        // The index of the action to mutate
+        uint256 actionIdx;
+        // The index of the compliance verifier input of the action to mutate
+        uint256 inputIdx;
+        // The proof to overwrite with
+        bytes proof;
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by giving one of its compliance verifier inputs a proof with an
+    /// unknown selector.
+    function mutation_test_execute_unknown_selector_fails(Transaction memory transaction, UnknownSelectorFailsParams memory params) public {
+        // Make sure that the chosen verifier selector does not exist
+        uint256 MIN_PROOF_LEN = 4;
+        vm.assume(params.proof.length >= MIN_PROOF_LEN);
+        vm.assume(address(_router.verifiers(bytes4(params.proof))) == address(0));
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Compliance.VerifierInput[] memory complianceVerifierInputs = transaction.actions[params.actionIdx].complianceVerifierInputs;
+        // Cannot do do mutation if transaction has no compliance verifier inputs
+        vm.assume(complianceVerifierInputs.length > 0);
+        // Wrap the compliance verifier input index into range
+        params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
+        // Finally, corrupt the verifier selector
+        complianceVerifierInputs[params.inputIdx].proof = params.proof;
+        // With an unknown selector, we expect failure
+        vm.expectPartialRevert(RiscZeroVerifierRouter.SelectorUnknown.selector, address(_router));
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    function test_execute_unknown_selector_fails(UnknownSelectorFailsParams memory params) public {
+        mutation_test_execute_unknown_selector_fails(TransactionExample.transaction(), params);
+    }
+
+    /// @notice The parameters necessary to make a failing mutation to a transaction
+    struct UnknownTagFailsParams {
+        // The index of the action to mutate
+        uint256 actionIdx;
+        // The index of the compliance verifier input of the action to mutate
+        uint256 inputIdx;
+        // The tag to overwrite with
+        bytes32 tag;
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by ensuring that the nullifier of one of its compliance verifier
+    /// inputs is not found in the logic verifier inputs.
+    function mutation_test_execute_unknown_nullifier_tag_fails(Transaction memory transaction, UnknownTagFailsParams memory params) public {
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Compliance.VerifierInput[] memory complianceVerifierInputs = transaction.actions[params.actionIdx].complianceVerifierInputs;
+        // Cannot do do mutation if transaction has no compliance verifier inputs
+        vm.assume(complianceVerifierInputs.length > 0);
+        // Wrap the compliance verifier input index into range
+        params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
+        // Finally, corrupt the corresponding logic verifier input tag
+        Logic.VerifierInput[] memory logicVerifierInputs = transaction.actions[params.actionIdx].logicVerifierInputs;
+        // Do a linear search to identify the corresponding logic verifier input
+        for (uint256 i = 0; i < logicVerifierInputs.length; i++) {
+            // Select the logic verifier input with a tag matching the nullifier
+            if (logicVerifierInputs[i].tag == complianceVerifierInputs[params.inputIdx].instance.consumed.nullifier) {
+                // Finally, corrupt the logic verifier input tag so it can no longer be found
+                logicVerifierInputs[i].tag = params.tag;
+            }
+        }
+        // With an unknown tag, we expect failure
+        vm.expectPartialRevert(Logic.TagNotFound.selector);
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    function test_execute_unknown_nullifier_tag_fails(UnknownTagFailsParams memory params) public {
+        mutation_test_execute_unknown_nullifier_tag_fails(TransactionExample.transaction(), params);
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by ensuring that the commitment of one of its compliance verifier
+    /// inputs is not found in the logic verifier inputs.
+    function mutation_test_execute_unknown_commitment_tag_fails(Transaction memory transaction, UnknownTagFailsParams memory params) public {
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Compliance.VerifierInput[] memory complianceVerifierInputs = transaction.actions[params.actionIdx].complianceVerifierInputs;
+        // Cannot do do mutation if transaction has no compliance verifier inputs
+        vm.assume(complianceVerifierInputs.length > 0);
+        // Wrap the compliance verifier input index into range
+        params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
+        // Finally, corrupt the corresponding logic verifier input tag
+        Logic.VerifierInput[] memory logicVerifierInputs = transaction.actions[params.actionIdx].logicVerifierInputs;
+        // Do a linear search to identify the corresponding logic verifier input
+        for (uint256 i = 0; i < logicVerifierInputs.length; i++) {
+            // Select the logic verifier input with a tag matching the commitment
+            if (logicVerifierInputs[i].tag == complianceVerifierInputs[params.inputIdx].instance.created.commitment) {
+                // Finally, corrupt the logic verifier input tag so it can no longer be found
+                logicVerifierInputs[i].tag = params.tag;
+            }
+        }
+        // With an unknown tag, we expect failure
+        vm.expectPartialRevert(Logic.TagNotFound.selector);
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    function test_execute_unknown_commitment_tag_fails(UnknownTagFailsParams memory params) public {
+        mutation_test_execute_unknown_commitment_tag_fails(TransactionExample.transaction(), params);
     }
 }

--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -289,4 +289,129 @@ contract ProtocolAdapterTest is Test, ProtocolAdapterMock {
         (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
         mutation_test_execute_unknown_commitment_tag_fails(txn, params);
     }
+
+    /// @notice The parameters necessary to make a failing mutation to a transaction
+    struct MismatchingResourcesFailParams {
+        // The index of the action to mutate
+        uint256 actionIdx;
+        // The index of the compliance verifier input of the action to mutate
+        uint256 inputIdx;
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by ensuring that it has less compliance verifier inputs than half
+    /// the logic verifier inputs.
+    function mutate_test_execute_missing_compliance_verifier_input_fail(Transaction memory transaction, MismatchingResourcesFailParams memory params) public {
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Compliance.VerifierInput[] memory complianceVerifierInputs = transaction.actions[params.actionIdx].complianceVerifierInputs;
+        // Cannot do do mutation if transaction has no compliance verifier inputs
+        vm.assume(complianceVerifierInputs.length > 0);
+        // Wrap the compliance verifier input index into range
+        params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
+        // Now delete the array entry
+        // Replace the target position with the last element
+        complianceVerifierInputs[params.inputIdx] = complianceVerifierInputs[complianceVerifierInputs.length - 1];
+        // Then make a shorter array of compliance verifier inputs
+        Compliance.VerifierInput[] memory shorter = new Compliance.VerifierInput[](complianceVerifierInputs.length - 1);
+        for (uint256 i = 0; i < shorter.length; i++) {
+            shorter[i] = complianceVerifierInputs[i];
+        }
+        // Finally, replace the compliance verifier inputs with the shorter array
+        transaction.actions[params.actionIdx].complianceVerifierInputs = shorter;
+        // With mismatching resource counts, we expect failure
+        vm.expectPartialRevert(ResourceCountMismatch.selector);
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    /// @notice Test that transactions with a missing compliance verifier input fail
+    function test_execute_missing_compliance_verifier_input_fail(uint8 nActions, uint8 nCUs, MismatchingResourcesFailParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        mutate_test_execute_missing_compliance_verifier_input_fail(txn, params);
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by ensuring that it has less logic verifier inputs double half the
+    /// compliance verifier inputs.
+    function mutate_test_execute_missing_logic_verifier_input_fail(Transaction memory transaction, MismatchingResourcesFailParams memory params) public {
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Logic.VerifierInput[] memory logicVerifierInputs = transaction.actions[params.actionIdx].logicVerifierInputs;
+        // Cannot do do mutation if transaction has no logic verifier inputs
+        vm.assume(logicVerifierInputs.length > 0);
+        // Wrap the logic verifier input index into range
+        params.inputIdx = params.inputIdx % logicVerifierInputs.length;
+        // Now delete the array entry
+        // Replace the target position with the last element
+        logicVerifierInputs[params.inputIdx] = logicVerifierInputs[logicVerifierInputs.length - 1];
+        // Then make a shorter array of logic verifier inputs
+        Logic.VerifierInput[] memory shorter = new Logic.VerifierInput[](logicVerifierInputs.length - 1);
+        for (uint256 i = 0; i < shorter.length; i++) {
+            shorter[i] = logicVerifierInputs[i];
+        }
+        // Finally, replace the logic verifier inputs with the shorter array
+        transaction.actions[params.actionIdx].logicVerifierInputs = shorter;
+        // With mismatching resource counts, we expect failure
+        vm.expectPartialRevert(ResourceCountMismatch.selector);
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    /// @notice Test that transactions with a missing logic verifier input fail
+    function test_execute_missing_logic_verifier_input_fail(uint8 nActions, uint8 nCUs, MismatchingResourcesFailParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        mutate_test_execute_missing_logic_verifier_input_fail(txn, params);
+    }
+
+    /// @notice The parameters necessary to make a failing mutation to a transaction
+    struct MismatchingLogicRefsFailParams {
+        // The index of the action to mutate
+        uint256 actionIdx;
+        // The index of the logic verifier input of the action to mutate
+        uint256 inputIdx;
+        // The logic reference to overwrite with
+        bytes32 logicRef;
+    }
+
+    /// @notice Take a transaction that would execute successfully and make it
+    /// fail by ensuring that it has less compliance verifier inputs than half
+    /// the logic verifier inputs.
+    function mutate_test_execute_mismatching_logic_refs_fail(Transaction memory transaction, MismatchingLogicRefsFailParams memory params) public {
+        // Cannot do mutation if the transaction has no actions
+        vm.assume(transaction.actions.length > 0);
+        // Wrap the action index into range
+        params.actionIdx = params.actionIdx % transaction.actions.length;
+        Logic.VerifierInput[] memory logicVerifierInputs = transaction.actions[params.actionIdx].logicVerifierInputs;
+        // Cannot do do mutation if transaction has no logic verifier inputs
+        vm.assume(logicVerifierInputs.length > 0);
+        // Wrap the logic verifier input index into range
+        params.inputIdx = params.inputIdx % logicVerifierInputs.length;
+        // Now corrupt the logic reference
+        vm.assume(logicVerifierInputs[params.inputIdx].verifyingKey != params.logicRef);
+        logicVerifierInputs[params.inputIdx].verifyingKey = params.logicRef;
+        // With mismatching logic references, we expect failure
+        vm.expectPartialRevert(LogicRefMismatch.selector);
+        // Finally, execute the transaction to make sure that it fails
+        this.execute(transaction);
+    }
+
+    /// @notice Test that transactions with mismatching logic references fail
+    function test_execute_mismatching_logic_refs_fail(uint8 nActions, uint8 nCUs, MismatchingLogicRefsFailParams memory params) public {
+        TxGen.ActionConfig[] memory configs =
+            TxGen.generateActionConfigs({nActions: uint8(bound(nActions, 0, 5)), nCUs: uint8(bound(nCUs, 0, 5))});
+
+        (Transaction memory txn, bytes32 updatedNonce) = _mockVerifier.transaction({nonce: 0, configs: configs});
+        mutate_test_execute_mismatching_logic_refs_fail(txn, params);
+    }
 }

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -78,6 +78,7 @@ contract ProtocolAdapterMockTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
+        Transaction memory txn = _mockVerifier.transaction(resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -85,7 +86,7 @@ contract ProtocolAdapterMockTest is Test {
             input: INPUT,
             output: EXPECTED_OUTPUT
         });
-        _mockPa.execute(_mockVerifier.transaction(resourceLists));
+        _mockPa.execute(txn);
     }
 
     function test_execute_emits_the_ForwarderCallExecuted_event_on_consumed_carrier_resource() public {
@@ -95,6 +96,7 @@ contract ProtocolAdapterMockTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
+        Transaction memory txn = _mockVerifier.transaction(resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -103,7 +105,7 @@ contract ProtocolAdapterMockTest is Test {
             output: EXPECTED_OUTPUT
         });
 
-        _mockPa.execute(_mockVerifier.transaction(resourceLists));
+        _mockPa.execute(txn);
     }
 
     function test_execute_emits_all_ForwarderCallExecuted_events() public {
@@ -122,6 +124,7 @@ contract ProtocolAdapterMockTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
+        Transaction memory txn = _mockVerifier.transaction(resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -137,7 +140,7 @@ contract ProtocolAdapterMockTest is Test {
             output: EXPECTED_OUTPUT
         });
 
-        _mockPa.execute(_mockVerifier.transaction(resourceLists));
+        _mockPa.execute(txn);
     }
 
     function test_execute_1_txn_with_1_action_and_0_cus() public {

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -143,12 +143,6 @@ contract ProtocolAdapterMockTest is Test {
         _mockPa.execute(txn);
     }
 
-    function test_execute_1_txn_with_1_action_and_0_cus() public {
-        (Transaction memory txn,) =
-            _mockVerifier.transaction({nonce: 0, configs: TxGen.generateActionConfigs({nActions: 1, nCUs: 0})});
-        _mockPa.execute(txn);
-    }
-
     function test_execute_1_txn_with_2_action_with_1_and_0_cus() public {
         TxGen.ActionConfig[] memory configs = new TxGen.ActionConfig[](2);
         configs[0] = TxGen.ActionConfig({nCUs: 1});

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -271,7 +271,7 @@ contract ProtocolAdapterMockTest is Test {
     }
 
     function _exampleResourceAndEmptyAppData(uint256 nonce)
-        private
+        public
         view
         returns (TxGen.ResourceAndAppData[] memory data)
     {
@@ -294,7 +294,7 @@ contract ProtocolAdapterMockTest is Test {
     }
 
     function _exampleCarrierResourceAndAppData(uint256 nonce, address[] memory fwdList, bool isConsumed)
-        private
+        public
         view
         returns (TxGen.ResourceAndAppData[] memory data)
     {

--- a/contracts/test/mocks/ProtocolAdapter.m.sol
+++ b/contracts/test/mocks/ProtocolAdapter.m.sol
@@ -20,24 +20,4 @@ contract ProtocolAdapterMock is ProtocolAdapter {
     function getRiscZeroVerifierSelector() public pure override returns (bytes4 verifierSelector) {
         verifierSelector = _MOCK_VERIFIER_SELECTOR;
     }
-
-    function _verifyComplianceProof(Compliance.VerifierInput calldata input) internal view override {
-        _TRUSTED_RISC_ZERO_VERIFIER_ROUTER.verify({
-            seal: input.proof,
-            imageId: Compliance._VERIFYING_KEY,
-            journalDigest: input.instance.toJournalDigest()
-        });
-    }
-
-    function _verifyLogicProof(Logic.VerifierInput calldata input, bytes32 tree, bool consumed)
-        internal
-        view
-        override
-    {
-        _TRUSTED_RISC_ZERO_VERIFIER_ROUTER.verify({
-            seal: input.proof,
-            imageId: input.verifyingKey,
-            journalDigest: RiscZeroUtils.toJournalDigest(input, tree, consumed)
-        });
-    }
 }

--- a/contracts/test/mocks/ProtocolAdapter.m.sol
+++ b/contracts/test/mocks/ProtocolAdapter.m.sol
@@ -40,29 +40,4 @@ contract ProtocolAdapterMock is ProtocolAdapter {
             journalDigest: RiscZeroUtils.toJournalDigest(input, tree, consumed)
         });
     }
-
-    function _verifyDeltaProof(bytes calldata proof, uint256[2] memory transactionDelta, bytes32[] memory tags)
-        internal
-        pure
-        override
-    {
-        if (transactionDelta[0] != transactionDelta[1]) {
-            revert Delta.DeltaMismatch({expected: address(0), actual: address(0)});
-        }
-
-        if (keccak256(proof) != tags.computeVerifyingKey()) {
-            revert Delta.DeltaMismatch({expected: address(type(uint160).max), actual: address(type(uint160).max)});
-        }
-    }
-
-    function _addUnitDelta(uint256[2] memory transactionDelta, uint256[2] memory unitDelta)
-        internal
-        pure
-        override
-        returns (uint256[2] memory sum)
-    {
-        unchecked {
-            sum = [transactionDelta[0] + unitDelta[0], transactionDelta[1] + unitDelta[1]];
-        }
-    }
 }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -14,9 +14,9 @@ contract DeltaProofTest is Test {
     // The parameters required to generate a delta instance
     struct DeltaInstanceInputs {
         // The identifier of the asset
-        uint128 kind;
+        uint256 kind;
         // The quantity of the asset
-        int128 quantity;
+        int256 quantity;
         // Value commitment randomness
         uint256 rcv;
     }
@@ -29,14 +29,20 @@ contract DeltaProofTest is Test {
         bytes32 verifyingKey;
     }
 
+    /// @notice Convert a int256 exponent to an equivalent uin256 assuming an order of SECP256K1_ORDER
+    function canonize_quantity(int256 quantity) public returns (uint256 quantityu) {
+        // If positive, leave the number unchanged
+        quantityu = quantity >= 0 ? uint256(quantity) : (SECP256K1_ORDER - 1 - (uint256(-(quantity + 1)) % SECP256K1_ORDER));
+    }
+
     /// @notice Generates a transaction delta proof by signing verifyingKey with
     /// rcv, and a delta instance by computing a(kind)^quantity * b^rcv
     function generateDeltaInstance(DeltaInstanceInputs memory deltaInputs) public returns (uint256[2] memory instance) {
         deltaInputs.rcv = deltaInputs.rcv % SECP256K1_ORDER;
         vm.assume(deltaInputs.rcv != 0);
         vm.assume(deltaInputs.kind != 0);
-        int256 prodAux = (int256(uint256(deltaInputs.kind)) * int256(deltaInputs.quantity));
-        uint256 prod = prodAux >= 0 ? uint256(prodAux) : SECP256K1_ORDER - (uint256(-prodAux) % SECP256K1_ORDER);
+        uint256 quantity = canonize_quantity(deltaInputs.quantity);
+        uint256 prod = mulmod(deltaInputs.kind, quantity, SECP256K1_ORDER);
         uint256 preDelta = addmod(prod, deltaInputs.rcv, SECP256K1_ORDER);
         vm.assume(preDelta != 0);
         // Derive address and public key from transaction delta
@@ -72,15 +78,15 @@ contract DeltaProofTest is Test {
         // Ensure that we're adding assets of the same kind over the same verifying key
         deltaInputs2.kind = deltaInputs1.kind;
         // Filter out overflows
-        vm.assume(deltaInputs1.quantity < 0 || deltaInputs2.quantity <= type(int128).max - deltaInputs1.quantity);
-        vm.assume(deltaInputs1.quantity >= 0 || type(int128).min - deltaInputs1.quantity <= deltaInputs2.quantity);
+        vm.assume(deltaInputs1.quantity < 0 || deltaInputs2.quantity <= type(int256).max - deltaInputs1.quantity);
+        vm.assume(deltaInputs1.quantity >= 0 || type(int256).min - deltaInputs1.quantity <= deltaInputs2.quantity);
         vm.assume(0 < deltaInputs2.rcv && deltaInputs2.rcv <= type(uint256).max - deltaInputs1.rcv);
         // Compute the inputs corresponding to the sum of deltas
         DeltaInstanceInputs memory deltaInputs3 = DeltaInstanceInputs({
             kind: deltaInputs1.kind,
             quantity: deltaInputs1.quantity + deltaInputs2.quantity,
             rcv: deltaInputs1.rcv + deltaInputs2.rcv
-            });
+        });
         // Generate a delta proof and instance from the above tags and preimage
         uint256[2] memory instance1 = generateDeltaInstance(deltaInputs1);
         uint256[2] memory instance2 = generateDeltaInstance(deltaInputs2);
@@ -95,8 +101,8 @@ contract DeltaProofTest is Test {
     function test_verify_inconsistent_delta_fails1(DeltaInstanceInputs memory deltaInstanceInputs, DeltaProofInputs memory deltaProofInputs) public {
         // Filter out inadmissible private keys or equal keys
         deltaProofInputs.rcv = deltaInstanceInputs.rcv;
-        vm.assume(deltaInstanceInputs.kind != 0);
-        vm.assume(deltaInstanceInputs.quantity != 0);
+        vm.assume(deltaInstanceInputs.kind % SECP256K1_ORDER != 0);
+        vm.assume(canonize_quantity(deltaInstanceInputs.quantity) != 0);
         // Generate a delta proof and instance from the above tags and preimage
         uint256[2] memory instance = generateDeltaInstance(deltaInstanceInputs);
         bytes memory proof = generateDeltaProof(deltaProofInputs);
@@ -139,7 +145,7 @@ contract DeltaProofTest is Test {
         uint256 maxDeltaLen = 10;
         deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % maxDeltaLen);
         // Make sure that the delta quantities balance out
-        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
+        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int256 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
         // Adjust the last delta so that the full sum is zero
         if(quantity != 0) {
             wrappedDeltaInputs[wrappedDeltaInputs.length - 1].quantity -= quantity;
@@ -163,12 +169,12 @@ contract DeltaProofTest is Test {
     function test_verify_imbalanced_delta_fails(DeltaInstanceInputs[] memory deltaInputs, bytes32 verifyingKey) public {
         uint256[2] memory deltaAcc = [uint256(0), uint256(0)];
         // Truncate the delta inputs to improve test performance
-        uint256 maxDeltaLen= 10;
+        uint256 maxDeltaLen = 10;
         deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % maxDeltaLen);
         // Accumulate the total quantity and randomness commitment
-        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
+        (DeltaInstanceInputs[] memory wrappedDeltaInputs, int256 quantity, uint256 rcv) = wrapDeltaInputs(deltaInputs);
         // Assume that the deltas are imbalanced
-        vm.assume(quantity != 0);
+        vm.assume(canonize_quantity(quantity) != 0);
         for(uint256 i = 0; i < wrappedDeltaInputs.length; i++) {
             // Compute the delta instance and accumulate it
             uint256[2] memory instance = generateDeltaInstance(wrappedDeltaInputs[i]);
@@ -187,15 +193,19 @@ contract DeltaProofTest is Test {
 
     /// @notice Wrap the delta inputs in such a way that they can be balanced
     /// and also return the total quantity and value commitment randomness
-    function wrapDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory wrappedDeltaInputs, int128 quantityAcc, uint256 rcvAcc) {
-        // Grab the kind to use for all deltas
-        uint128 kind = deltaInputs.length > 0 ? deltaInputs[0].kind : 0;
+    function wrapDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory wrappedDeltaInputs, int256 quantityAcc, uint256 rcvAcc) {
         // Compute the window into which the deltas should sum
-        int128 halfMax = type(int128).max >> 1;
-        int128 halfMin = type(int128).min >> 1;
+        int256 halfMax = type(int256).max >> 1;
+        int256 halfMin = type(int256).min >> 1;
         // Track the current quantity and value commitment randomness
         quantityAcc = 0;
         rcvAcc = 0;
+        if (deltaInputs.length == 0) {
+            return (deltaInputs, quantityAcc, rcvAcc);
+        }
+        // Grab the kind to use for all deltas
+        uint256 kind = deltaInputs[0].kind;
+        vm.assume(deltaInputs[0].kind % SECP256K1_ORDER != 0);
         // Wrap the deltas
         for(uint256 i = 0; i < deltaInputs.length; i++) {
             // Ensure that all the deltas have the same kind
@@ -204,10 +214,10 @@ contract DeltaProofTest is Test {
             rcvAcc = addmod(rcvAcc, deltaInputs[i].rcv, SECP256K1_ORDER);
             // Adjust the delta inputs so that the sum remains in a specific range
             if(deltaInputs[i].quantity >= 0 && quantityAcc > halfMax - deltaInputs[i].quantity) {
-                int128 overflow = quantityAcc - (halfMax - deltaInputs[i].quantity);
+                int256 overflow = quantityAcc - (halfMax - deltaInputs[i].quantity);
                 deltaInputs[i].quantity = halfMin + overflow - 1 - quantityAcc;
             } else if(deltaInputs[i].quantity < 0 && quantityAcc < halfMin - deltaInputs[i].quantity) {
-                int128 underflow = (halfMin - deltaInputs[i].quantity) - quantityAcc;
+                int256 underflow = (halfMin - deltaInputs[i].quantity) - quantityAcc;
                 deltaInputs[i].quantity = halfMax + 1 - underflow - quantityAcc;
             }
             // Finally, accumulate the adjusted quantity

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -30,7 +30,7 @@ contract DeltaProofTest is Test {
     }
 
     /// @notice Convert a int256 exponent to an equivalent uin256 assuming an order of SECP256K1_ORDER
-    function canonize_quantity(int256 quantity) public returns (uint256 quantityu) {
+    function canonize_quantity(int256 quantity) public pure returns (uint256 quantityu) {
         // If positive, leave the number unchanged
         quantityu = quantity >= 0 ? uint256(quantity) : (SECP256K1_ORDER - 1 - (uint256(-(quantity + 1)) % SECP256K1_ORDER));
     }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -7,6 +7,7 @@ import {Delta} from "../../src/proving/Delta.sol";
 import {Transaction} from "../../src/Types.sol";
 import {TransactionExample} from "../examples/Transaction.e.sol";
 import {TxGen} from "../examples/TxGen.sol";
+import {VmSafe} from "forge-std/Vm.sol";
 
 contract DeltaProofTest is Test {
     function test_verify_example_delta_proof() public pure {
@@ -20,5 +21,78 @@ contract DeltaProofTest is Test {
             ],
             verifyingKey: Delta.computeVerifyingKey(TxGen.collectTags(txn.actions))
         });
+    }
+
+    /// @notice Generates a transaction delta proof and delta
+    /// @param preDelta The input/preimage to the delta hash
+    /// @param verifyingKey The bytes being authorized
+    function generateDelta(uint256 preDelta, bytes32 verifyingKey) internal returns (bytes memory proof, uint256[2] memory instance) {
+        // Derive address and public key from transaction delta 
+        VmSafe.Wallet memory wallet = vm.createWallet(preDelta);
+        // Extract the transaction delta from the wallet
+        instance[0] = wallet.publicKeyX;
+        instance[1] = wallet.publicKeyY;
+        // Compute the components of the transaction delta proof
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet, verifyingKey);
+        // Finally compute the transaction delta proof
+        proof = abi.encodePacked(r, s, v);
+    }
+
+    /// @notice Test that Delta.verify accepts a well-formed delta proof and instance
+    /// @param preDelta The input/preimage to the delta hash
+    function test_deltaVerify(uint256 preDelta, bytes32 verifyingKey) public {
+        // Filter out inadmissible private keys
+        if(preDelta == 0 || preDelta >= SECP256K1_ORDER) { return; }
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof, uint256[2] memory instance) = generateDelta(preDelta, verifyingKey);
+        // Verify that the generated delta proof is valid
+        Delta.verify({proof: proof, instance: instance, verifyingKey: verifyingKey});
+    }
+
+    /// @notice Test that Delta.add correctly adds deltas
+    /// @param preDelta1 The input/preimage to the first delta hash
+    /// @param preDelta2 The input/preimage to the second delta hash
+    function test_deltaAdd(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+        // Filter out inadmissible private keys
+        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta2 >= SECP256K1_ORDER - preDelta1) { return; }
+        uint256 preDelta3 = preDelta1 + preDelta2;
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
+        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        (bytes memory proof3, uint256[2] memory instance3) = generateDelta(preDelta3, verifyingKey);
+        // Verify that the deltas add correctly
+        uint256[2] memory instance4 = Delta.add(instance1, instance2);
+        assertEq(instance3[0], instance4[0]);
+        assertEq(instance3[1], instance4[1]);
+    }
+
+    /// @notice Test that Delta.verify rejects a delta proof that does not correspond to instance
+    /// @param preDelta1 The input/preimage to the first delta hash
+    /// @param preDelta2 The input/preimage to the second delta hash
+    /// @param verifyingKey The hash being authorized
+    function test_inconsistentDeltaVerify1(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+        // Filter out inadmissible private keys or equal keys
+        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta1 == preDelta2) { return; }
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
+        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        // Verify that the mixing deltas is invalid
+        vm.expectPartialRevert(Delta.DeltaMismatch.selector);
+        Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
+    }
+
+    /// @notice Test that Delta.verify rejects a delta proof that does not correspond to the verifying key
+    /// @param preDelta The input/preimage to the delta hash
+    /// @param verifyingKey1 The first hash being authorized
+    /// @param verifyingKey2 The second hash being authorized
+    function test_inconsistentDeltaVerify2(uint256 preDelta, bytes32 verifyingKey1, bytes32 verifyingKey2) public {
+        // Filter out inadmissible private keys or equal keys
+        if(preDelta == 0 || preDelta >= SECP256K1_ORDER || verifyingKey1 == verifyingKey2) { return; }
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta, verifyingKey1);
+        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta, verifyingKey2);
+        // Verify that the mixing deltas is invalid
+        vm.expectPartialRevert(Delta.DeltaMismatch.selector);
+        Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey2});
     }
 }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -1,33 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Test} from "forge-std/Test.sol";
-
-import {Delta} from "../../src/proving/Delta.sol";
-import {Transaction} from "../../src/Types.sol";
+import { ECDSA } from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import { Test } from "forge-std/Test.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { Delta } from "./../../src/proving/Delta.sol";
+import { Transaction } from "./../../src/Types.sol";
 import {TransactionExample} from "../examples/Transaction.e.sol";
 import {TxGen} from "../examples/TxGen.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
 contract DeltaProofTest is Test {
-    function test_verify_example_delta_proof() public pure {
-        Transaction memory txn = TransactionExample.transaction();
-
-        Delta.verify({
-            proof: txn.deltaProof,
-            instance: [
-                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaX),
-                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaY)
-            ],
-            verifyingKey: Delta.computeVerifyingKey(TxGen.collectTags(txn.actions))
-        });
-    }
-
     /// @notice Generates a transaction delta proof and delta
     /// @param preDelta The input/preimage to the delta hash
     /// @param verifyingKey The bytes being authorized
-    function generateDelta(uint256 preDelta, bytes32 verifyingKey) internal returns (bytes memory proof, uint256[2] memory instance) {
-        // Derive address and public key from transaction delta 
+    function generateDelta(uint256 preDelta, bytes32 verifyingKey) public returns (bytes memory proof, uint256[2] memory instance) {
+        // Derive address and public key from transaction delta
         VmSafe.Wallet memory wallet = vm.createWallet(preDelta);
         // Extract the transaction delta from the wallet
         instance[0] = wallet.publicKeyX;
@@ -40,9 +28,9 @@ contract DeltaProofTest is Test {
 
     /// @notice Test that Delta.verify accepts a well-formed delta proof and instance
     /// @param preDelta The input/preimage to the delta hash
-    function test_deltaVerify(uint256 preDelta, bytes32 verifyingKey) public {
+    function test_verify_delta_succeeds(uint256 preDelta, bytes32 verifyingKey) public {
         // Filter out inadmissible private keys
-        if(preDelta == 0 || preDelta >= SECP256K1_ORDER) { return; }
+        vm.assume(0 < preDelta && preDelta < SECP256K1_ORDER);
         // Generate a delta proof and instance from the above tags and preimage
         (bytes memory proof, uint256[2] memory instance) = generateDelta(preDelta, verifyingKey);
         // Verify that the generated delta proof is valid
@@ -52,14 +40,15 @@ contract DeltaProofTest is Test {
     /// @notice Test that Delta.add correctly adds deltas
     /// @param preDelta1 The input/preimage to the first delta hash
     /// @param preDelta2 The input/preimage to the second delta hash
-    function test_deltaAdd(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+    function test_add_delta_correctness(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
         // Filter out inadmissible private keys
-        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta2 >= SECP256K1_ORDER - preDelta1) { return; }
+        vm.assume(0 < preDelta1 && preDelta1 < SECP256K1_ORDER);
+        vm.assume(0 < preDelta2 && preDelta2 < SECP256K1_ORDER - preDelta1);
         uint256 preDelta3 = preDelta1 + preDelta2;
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
-        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
-        (bytes memory proof3, uint256[2] memory instance3) = generateDelta(preDelta3, verifyingKey);
+        (, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
+        (, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        (, uint256[2] memory instance3) = generateDelta(preDelta3, verifyingKey);
         // Verify that the deltas add correctly
         uint256[2] memory instance4 = Delta.add(instance1, instance2);
         assertEq(instance3[0], instance4[0]);
@@ -70,12 +59,14 @@ contract DeltaProofTest is Test {
     /// @param preDelta1 The input/preimage to the first delta hash
     /// @param preDelta2 The input/preimage to the second delta hash
     /// @param verifyingKey The hash being authorized
-    function test_inconsistentDeltaVerify1(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+    function test_verify_inconsistent_delta_fails1(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
         // Filter out inadmissible private keys or equal keys
-        if(preDelta1 == 0 || preDelta1 >= SECP256K1_ORDER || preDelta2 == 0 || preDelta2 >= SECP256K1_ORDER || preDelta1 == preDelta2) { return; }
+        vm.assume(0 < preDelta1 && preDelta1 < SECP256K1_ORDER);
+        vm.assume(0 < preDelta2 && preDelta2 < SECP256K1_ORDER);
+        vm.assume(preDelta1 != preDelta2);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
-        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        (bytes memory proof1, ) = generateDelta(preDelta1, verifyingKey);
+        (, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
@@ -85,14 +76,27 @@ contract DeltaProofTest is Test {
     /// @param preDelta The input/preimage to the delta hash
     /// @param verifyingKey1 The first hash being authorized
     /// @param verifyingKey2 The second hash being authorized
-    function test_inconsistentDeltaVerify2(uint256 preDelta, bytes32 verifyingKey1, bytes32 verifyingKey2) public {
+    function test_verify_inconsistent_delta_fails2(uint256 preDelta, bytes32 verifyingKey1, bytes32 verifyingKey2) public {
         // Filter out inadmissible private keys or equal keys
-        if(preDelta == 0 || preDelta >= SECP256K1_ORDER || verifyingKey1 == verifyingKey2) { return; }
+        vm.assume(0 < preDelta && preDelta < SECP256K1_ORDER);
+        vm.assume(verifyingKey1 != verifyingKey2);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, uint256[2] memory instance1) = generateDelta(preDelta, verifyingKey1);
-        (bytes memory proof2, uint256[2] memory instance2) = generateDelta(preDelta, verifyingKey2);
+        (bytes memory proof1, ) = generateDelta(preDelta, verifyingKey1);
+        (, uint256[2] memory instance2) = generateDelta(preDelta, verifyingKey2);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey2});
+    }
+
+    function test_verify_example_delta_proof() public pure {
+        Transaction memory txn = TransactionExample.transaction();
+        Delta.verify({
+            proof: txn.deltaProof,
+            instance: [
+                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaX),
+                uint256(txn.actions[0].complianceVerifierInputs[0].instance.unitDeltaY)
+            ],
+            verifyingKey: Delta.computeVerifyingKey(TxGen.collectTags(txn.actions))
+        });
     }
 }

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -13,7 +13,7 @@ import {VmSafe} from "forge-std/Vm.sol";
 contract DeltaProofTest is Test {
     struct DeltaInputs {
         uint128 kind;
-        uint128 quantity;
+        int128 quantity;
         uint256 rcv;
         bytes32 verifyingKey;
     }
@@ -24,7 +24,8 @@ contract DeltaProofTest is Test {
         deltaInputs.rcv = deltaInputs.rcv % SECP256K1_ORDER;
         vm.assume(deltaInputs.rcv != 0);
         vm.assume(deltaInputs.kind != 0);
-        uint256 prod = (uint256(deltaInputs.kind) * uint256(deltaInputs.quantity)) % SECP256K1_ORDER;
+        int256 prod_aux = (int256(uint256(deltaInputs.kind)) * int256(deltaInputs.quantity));
+        uint256 prod = prod_aux >= 0 ? uint256(prod_aux) % SECP256K1_ORDER : SECP256K1_ORDER - (uint256(-prod_aux) % SECP256K1_ORDER);
         vm.assume(prod < SECP256K1_ORDER - deltaInputs.rcv);
         uint256 preDelta = (prod + deltaInputs.rcv) % SECP256K1_ORDER;
         vm.assume(preDelta != 0);
@@ -54,12 +55,9 @@ contract DeltaProofTest is Test {
         // Ensure that we're adding assets of the same kind over the same verifying key
         deltaInputs2.kind = deltaInputs1.kind;
         deltaInputs2.verifyingKey = deltaInputs1.verifyingKey;
-        // Simplify the quantities
-        deltaInputs1.quantity = uint128(deltaInputs1.quantity % SECP256K1_ORDER);
-        deltaInputs2.quantity = uint128(deltaInputs2.quantity % SECP256K1_ORDER);
         // Filter out overflows
-        vm.assume(0 < deltaInputs2.quantity && deltaInputs2.quantity < SECP256K1_ORDER - deltaInputs1.quantity);
-        vm.assume(0 < deltaInputs2.quantity && deltaInputs2.quantity < type(uint128).max - deltaInputs1.quantity);
+        vm.assume(deltaInputs1.quantity < 0 || deltaInputs2.quantity <= type(int128).max - deltaInputs1.quantity);
+        vm.assume(deltaInputs1.quantity >= 0 || type(int128).min - deltaInputs1.quantity <= deltaInputs2.quantity);
         vm.assume(0 < deltaInputs2.rcv && deltaInputs2.rcv <= type(uint256).max - deltaInputs1.rcv);
         // Compute the inputs corresponding to the sum of deltas
         DeltaInputs memory deltaInputs3 = DeltaInputs({

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -11,44 +11,67 @@ import {TxGen} from "../examples/TxGen.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
 contract DeltaProofTest is Test {
-    /// @notice Generates a transaction delta proof and delta
-    /// @param preDelta The input/preimage to the delta hash
-    /// @param verifyingKey The bytes being authorized
-    function generateDelta(uint256 preDelta, bytes32 verifyingKey) public returns (bytes memory proof, uint256[2] memory instance) {
+    struct DeltaInputs {
+        uint128 kind;
+        uint128 quantity;
+        uint256 rcv;
+        bytes32 verifyingKey;
+    }
+
+    /// @notice Generates a transaction delta proof by signing verifyingKey with
+    /// rcv, and a delta instance by computing a(kind)^quantity * b^rcv
+    function generateDelta(DeltaInputs memory deltaInputs) public returns (bytes memory proof, uint256[2] memory instance) {
+        deltaInputs.rcv = deltaInputs.rcv % SECP256K1_ORDER;
+        vm.assume(deltaInputs.rcv != 0);
+        vm.assume(deltaInputs.kind != 0);
+        uint256 prod = (uint256(deltaInputs.kind) * uint256(deltaInputs.quantity)) % SECP256K1_ORDER;
+        vm.assume(prod < SECP256K1_ORDER - deltaInputs.rcv);
+        uint256 preDelta = (prod + deltaInputs.rcv) % SECP256K1_ORDER;
+        vm.assume(preDelta != 0);
         // Derive address and public key from transaction delta
-        VmSafe.Wallet memory wallet = vm.createWallet(preDelta);
+        VmSafe.Wallet memory valueWallet = vm.createWallet(preDelta);
         // Extract the transaction delta from the wallet
-        instance[0] = wallet.publicKeyX;
-        instance[1] = wallet.publicKeyY;
+        instance[0] = valueWallet.publicKeyX;
+        instance[1] = valueWallet.publicKeyY;
         // Compute the components of the transaction delta proof
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet, verifyingKey);
+        VmSafe.Wallet memory randomWallet = vm.createWallet(deltaInputs.rcv);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(randomWallet, deltaInputs.verifyingKey);
         // Finally compute the transaction delta proof
         proof = abi.encodePacked(r, s, v);
     }
 
     /// @notice Test that Delta.verify accepts a well-formed delta proof and instance
-    /// @param preDelta The input/preimage to the delta hash
-    function test_verify_delta_succeeds(uint256 preDelta, bytes32 verifyingKey) public {
-        // Filter out inadmissible private keys
-        vm.assume(0 < preDelta && preDelta < SECP256K1_ORDER);
+    function test_verify_delta_succeeds(DeltaInputs memory deltaInputs) public {
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof, uint256[2] memory instance) = generateDelta(preDelta, verifyingKey);
+        deltaInputs.quantity = 0;
+        (bytes memory proof, uint256[2] memory instance) = generateDelta(deltaInputs);
         // Verify that the generated delta proof is valid
-        Delta.verify({proof: proof, instance: instance, verifyingKey: verifyingKey});
+        Delta.verify({proof: proof, instance: instance, verifyingKey: deltaInputs.verifyingKey});
     }
 
     /// @notice Test that Delta.add correctly adds deltas
-    /// @param preDelta1 The input/preimage to the first delta hash
-    /// @param preDelta2 The input/preimage to the second delta hash
-    function test_add_delta_correctness(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
-        // Filter out inadmissible private keys
-        vm.assume(0 < preDelta1 && preDelta1 < SECP256K1_ORDER);
-        vm.assume(0 < preDelta2 && preDelta2 < SECP256K1_ORDER - preDelta1);
-        uint256 preDelta3 = preDelta1 + preDelta2;
+    function test_add_delta_correctness(DeltaInputs memory deltaInputs1, DeltaInputs memory deltaInputs2) public {
+        // Ensure that we're adding assets of the same kind over the same verifying key
+        deltaInputs2.kind = deltaInputs1.kind;
+        deltaInputs2.verifyingKey = deltaInputs1.verifyingKey;
+        // Simplify the quantities
+        deltaInputs1.quantity = uint128(deltaInputs1.quantity % SECP256K1_ORDER);
+        deltaInputs2.quantity = uint128(deltaInputs2.quantity % SECP256K1_ORDER);
+        // Filter out overflows
+        vm.assume(0 < deltaInputs2.quantity && deltaInputs2.quantity < SECP256K1_ORDER - deltaInputs1.quantity);
+        vm.assume(0 < deltaInputs2.quantity && deltaInputs2.quantity < type(uint128).max - deltaInputs1.quantity);
+        vm.assume(0 < deltaInputs2.rcv && deltaInputs2.rcv <= type(uint256).max - deltaInputs1.rcv);
+        // Compute the inputs corresponding to the sum of deltas
+        DeltaInputs memory deltaInputs3 = DeltaInputs({
+            kind: deltaInputs1.kind,
+            quantity: deltaInputs1.quantity + deltaInputs2.quantity,
+            rcv: deltaInputs1.rcv + deltaInputs2.rcv,
+            verifyingKey: deltaInputs1.verifyingKey
+            });
         // Generate a delta proof and instance from the above tags and preimage
-        (, uint256[2] memory instance1) = generateDelta(preDelta1, verifyingKey);
-        (, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
-        (, uint256[2] memory instance3) = generateDelta(preDelta3, verifyingKey);
+        (, uint256[2] memory instance1) = generateDelta(deltaInputs1);
+        (, uint256[2] memory instance2) = generateDelta(deltaInputs2);
+        (, uint256[2] memory instance3) = generateDelta(deltaInputs3);
         // Verify that the deltas add correctly
         uint256[2] memory instance4 = Delta.add(instance1, instance2);
         assertEq(instance3[0], instance4[0]);
@@ -56,36 +79,45 @@ contract DeltaProofTest is Test {
     }
 
     /// @notice Test that Delta.verify rejects a delta proof that does not correspond to instance
-    /// @param preDelta1 The input/preimage to the first delta hash
-    /// @param preDelta2 The input/preimage to the second delta hash
-    /// @param verifyingKey The hash being authorized
-    function test_verify_inconsistent_delta_fails1(uint256 preDelta1, uint256 preDelta2, bytes32 verifyingKey) public {
+    function test_verify_inconsistent_delta_fails1(DeltaInputs memory deltaInputs) public {
         // Filter out inadmissible private keys or equal keys
-        vm.assume(0 < preDelta1 && preDelta1 < SECP256K1_ORDER);
-        vm.assume(0 < preDelta2 && preDelta2 < SECP256K1_ORDER);
-        vm.assume(preDelta1 != preDelta2);
+        vm.assume(deltaInputs.kind != 0);
+        vm.assume(deltaInputs.quantity != 0);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, ) = generateDelta(preDelta1, verifyingKey);
-        (, uint256[2] memory instance2) = generateDelta(preDelta2, verifyingKey);
+        (bytes memory proof, uint256[2] memory instance) = generateDelta(deltaInputs);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
-        Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
+        Delta.verify({proof: proof, instance: instance, verifyingKey: deltaInputs.verifyingKey});
+    }
+
+    /// @notice Test that Delta.verify rejects a delta proof that does not correspond to instance
+    function test_verify_inconsistent_delta_fails2(DeltaInputs memory deltaInputs1, DeltaInputs memory deltaInputs2) public {
+        deltaInputs2.verifyingKey = deltaInputs1.verifyingKey;
+        deltaInputs2.kind = deltaInputs1.kind;
+        deltaInputs2.quantity = deltaInputs1.quantity;
+        // Filter out inadmissible private keys or equal keys
+        vm.assume(deltaInputs1.rcv != deltaInputs2.rcv);
+        // Generate a delta proof and instance from the above tags and preimage
+        (bytes memory proof1, ) = generateDelta(deltaInputs1);
+        (, uint256[2] memory instance2) = generateDelta(deltaInputs2);
+        // Verify that the mixing deltas is invalid
+        vm.expectPartialRevert(Delta.DeltaMismatch.selector);
+        Delta.verify({proof: proof1, instance: instance2, verifyingKey: deltaInputs1.verifyingKey});
     }
 
     /// @notice Test that Delta.verify rejects a delta proof that does not correspond to the verifying key
-    /// @param preDelta The input/preimage to the delta hash
-    /// @param verifyingKey1 The first hash being authorized
-    /// @param verifyingKey2 The second hash being authorized
-    function test_verify_inconsistent_delta_fails2(uint256 preDelta, bytes32 verifyingKey1, bytes32 verifyingKey2) public {
+    function test_verify_inconsistent_delta_fails3(DeltaInputs memory deltaInputs1, DeltaInputs memory deltaInputs2) public {
+        deltaInputs2.kind = deltaInputs1.kind;
+        deltaInputs2.quantity = deltaInputs1.quantity;
+        deltaInputs2.rcv = deltaInputs1.rcv;
         // Filter out inadmissible private keys or equal keys
-        vm.assume(0 < preDelta && preDelta < SECP256K1_ORDER);
-        vm.assume(verifyingKey1 != verifyingKey2);
+        vm.assume(deltaInputs1.verifyingKey != deltaInputs2.verifyingKey);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, ) = generateDelta(preDelta, verifyingKey1);
-        (, uint256[2] memory instance2) = generateDelta(preDelta, verifyingKey2);
+        (bytes memory proof1, ) = generateDelta(deltaInputs1);
+        (, uint256[2] memory instance2) = generateDelta(deltaInputs2);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
-        Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey2});
+        Delta.verify({proof: proof1, instance: instance2, verifyingKey: deltaInputs2.verifyingKey});
     }
 
     function test_verify_example_delta_proof() public pure {

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -11,16 +11,20 @@ import {TxGen} from "../examples/TxGen.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
 contract DeltaProofTest is Test {
-    struct DeltaInputs {
+    struct DeltaInstanceInputs {
         uint128 kind;
         int128 quantity;
+        uint256 rcv;
+    }
+
+    struct DeltaProofInputs {
         uint256 rcv;
         bytes32 verifyingKey;
     }
 
     /// @notice Generates a transaction delta proof by signing verifyingKey with
     /// rcv, and a delta instance by computing a(kind)^quantity * b^rcv
-    function generateDelta(DeltaInputs memory deltaInputs) public returns (bytes memory proof, uint256[2] memory instance) {
+    function generateDeltaInstance(DeltaInstanceInputs memory deltaInputs) public returns (uint256[2] memory instance) {
         deltaInputs.rcv = deltaInputs.rcv % SECP256K1_ORDER;
         vm.assume(deltaInputs.rcv != 0);
         vm.assume(deltaInputs.kind != 0);
@@ -33,6 +37,11 @@ contract DeltaProofTest is Test {
         // Extract the transaction delta from the wallet
         instance[0] = valueWallet.publicKeyX;
         instance[1] = valueWallet.publicKeyY;
+    }
+
+    function generateDeltaProof(DeltaProofInputs memory deltaInputs) public returns (bytes memory proof) {
+        deltaInputs.rcv = deltaInputs.rcv % SECP256K1_ORDER;
+        vm.assume(deltaInputs.rcv != 0);
         // Compute the components of the transaction delta proof
         VmSafe.Wallet memory randomWallet = vm.createWallet(deltaInputs.rcv);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(randomWallet, deltaInputs.verifyingKey);
@@ -41,34 +50,34 @@ contract DeltaProofTest is Test {
     }
 
     /// @notice Test that Delta.verify accepts a well-formed delta proof and instance
-    function test_verify_delta_succeeds(DeltaInputs memory deltaInputs) public {
+    function test_verify_delta_succeeds(DeltaInstanceInputs memory deltaInstanceInputs, DeltaProofInputs memory deltaProofInputs) public {
         // Generate a delta proof and instance from the above tags and preimage
-        deltaInputs.quantity = 0;
-        (bytes memory proof, uint256[2] memory instance) = generateDelta(deltaInputs);
+        deltaInstanceInputs.quantity = 0;
+        deltaProofInputs.rcv = deltaInstanceInputs.rcv;
+        uint256[2] memory instance = generateDeltaInstance(deltaInstanceInputs);
+        bytes memory proof = generateDeltaProof(deltaProofInputs);
         // Verify that the generated delta proof is valid
-        Delta.verify({proof: proof, instance: instance, verifyingKey: deltaInputs.verifyingKey});
+        Delta.verify({proof: proof, instance: instance, verifyingKey: deltaProofInputs.verifyingKey});
     }
 
     /// @notice Test that Delta.add correctly adds deltas
-    function test_add_delta_correctness(DeltaInputs memory deltaInputs1, DeltaInputs memory deltaInputs2) public {
+    function test_add_delta_correctness(DeltaInstanceInputs memory deltaInputs1, DeltaInstanceInputs memory deltaInputs2) public {
         // Ensure that we're adding assets of the same kind over the same verifying key
         deltaInputs2.kind = deltaInputs1.kind;
-        deltaInputs2.verifyingKey = deltaInputs1.verifyingKey;
         // Filter out overflows
         vm.assume(deltaInputs1.quantity < 0 || deltaInputs2.quantity <= type(int128).max - deltaInputs1.quantity);
         vm.assume(deltaInputs1.quantity >= 0 || type(int128).min - deltaInputs1.quantity <= deltaInputs2.quantity);
         vm.assume(0 < deltaInputs2.rcv && deltaInputs2.rcv <= type(uint256).max - deltaInputs1.rcv);
         // Compute the inputs corresponding to the sum of deltas
-        DeltaInputs memory deltaInputs3 = DeltaInputs({
+        DeltaInstanceInputs memory deltaInputs3 = DeltaInstanceInputs({
             kind: deltaInputs1.kind,
             quantity: deltaInputs1.quantity + deltaInputs2.quantity,
-            rcv: deltaInputs1.rcv + deltaInputs2.rcv,
-            verifyingKey: deltaInputs1.verifyingKey
+            rcv: deltaInputs1.rcv + deltaInputs2.rcv
             });
         // Generate a delta proof and instance from the above tags and preimage
-        (, uint256[2] memory instance1) = generateDelta(deltaInputs1);
-        (, uint256[2] memory instance2) = generateDelta(deltaInputs2);
-        (, uint256[2] memory instance3) = generateDelta(deltaInputs3);
+        uint256[2] memory instance1 = generateDeltaInstance(deltaInputs1);
+        uint256[2] memory instance2 = generateDeltaInstance(deltaInputs2);
+        uint256[2] memory instance3 = generateDeltaInstance(deltaInputs3);
         // Verify that the deltas add correctly
         uint256[2] memory instance4 = Delta.add(instance1, instance2);
         assertEq(instance3[0], instance4[0]);
@@ -76,49 +85,48 @@ contract DeltaProofTest is Test {
     }
 
     /// @notice Test that Delta.verify rejects a delta proof that does not correspond to instance
-    function test_verify_inconsistent_delta_fails1(DeltaInputs memory deltaInputs) public {
+    function test_verify_inconsistent_delta_fails1(DeltaInstanceInputs memory deltaInstanceInputs, DeltaProofInputs memory deltaProofInputs) public {
         // Filter out inadmissible private keys or equal keys
-        vm.assume(deltaInputs.kind != 0);
-        vm.assume(deltaInputs.quantity != 0);
+        deltaProofInputs.rcv = deltaInstanceInputs.rcv;
+        vm.assume(deltaInstanceInputs.kind != 0);
+        vm.assume(deltaInstanceInputs.quantity != 0);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof, uint256[2] memory instance) = generateDelta(deltaInputs);
+        uint256[2] memory instance = generateDeltaInstance(deltaInstanceInputs);
+        bytes memory proof = generateDeltaProof(deltaProofInputs);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
-        Delta.verify({proof: proof, instance: instance, verifyingKey: deltaInputs.verifyingKey});
+        Delta.verify({proof: proof, instance: instance, verifyingKey: deltaProofInputs.verifyingKey});
     }
 
     /// @notice Test that Delta.verify rejects a delta proof that does not correspond to instance
-    function test_verify_inconsistent_delta_fails2(DeltaInputs memory deltaInputs1, DeltaInputs memory deltaInputs2) public {
-        deltaInputs2.verifyingKey = deltaInputs1.verifyingKey;
-        deltaInputs2.kind = deltaInputs1.kind;
-        deltaInputs2.quantity = deltaInputs1.quantity;
+    function test_verify_inconsistent_delta_fails2(DeltaProofInputs memory deltaInputs1, DeltaInstanceInputs memory deltaInputs2) public {
+        deltaInputs2.quantity = 0;
         // Filter out inadmissible private keys or equal keys
         vm.assume(deltaInputs1.rcv != deltaInputs2.rcv);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, ) = generateDelta(deltaInputs1);
-        (, uint256[2] memory instance2) = generateDelta(deltaInputs2);
+        bytes memory proof1 = generateDeltaProof(deltaInputs1);
+        uint256[2] memory instance2 = generateDeltaInstance(deltaInputs2);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         Delta.verify({proof: proof1, instance: instance2, verifyingKey: deltaInputs1.verifyingKey});
     }
 
     /// @notice Test that Delta.verify rejects a delta proof that does not correspond to the verifying key
-    function test_verify_inconsistent_delta_fails3(DeltaInputs memory deltaInputs1, DeltaInputs memory deltaInputs2) public {
-        deltaInputs2.kind = deltaInputs1.kind;
-        deltaInputs2.quantity = deltaInputs1.quantity;
+    function test_verify_inconsistent_delta_fails3(DeltaProofInputs memory deltaInputs1, DeltaInstanceInputs memory deltaInputs2, bytes32 verifyingKey) public {
         deltaInputs2.rcv = deltaInputs1.rcv;
+        deltaInputs2.quantity = 0;
         // Filter out inadmissible private keys or equal keys
-        vm.assume(deltaInputs1.verifyingKey != deltaInputs2.verifyingKey);
+        vm.assume(deltaInputs1.verifyingKey != verifyingKey);
         // Generate a delta proof and instance from the above tags and preimage
-        (bytes memory proof1, ) = generateDelta(deltaInputs1);
-        (, uint256[2] memory instance2) = generateDelta(deltaInputs2);
+        bytes memory proof1 = generateDeltaProof(deltaInputs1);
+        uint256[2] memory instance2 = generateDeltaInstance(deltaInputs2);
         // Verify that the mixing deltas is invalid
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
-        Delta.verify({proof: proof1, instance: instance2, verifyingKey: deltaInputs2.verifyingKey});
+        Delta.verify({proof: proof1, instance: instance2, verifyingKey: verifyingKey});
     }
 
     /// @notice Balance the delta inputs and also return the total value commitment randomness
-    function balanceDeltaInputs(DeltaInputs[] memory deltaInputs) public pure returns (DeltaInputs[] memory balancedDeltaInputs, uint256 rcv_acc) {
+    function balanceDeltaInputs(DeltaInstanceInputs[] memory deltaInputs) public pure returns (DeltaInstanceInputs[] memory balancedDeltaInputs, uint256 rcv_acc) {
         // Grab the kind to use for all deltas
         uint128 kind = deltaInputs.length > 0 ? deltaInputs[0].kind : 0;
         // Compute the window into which the deltas should sum
@@ -153,35 +161,32 @@ contract DeltaProofTest is Test {
     }
 
     /// @notice Grab the first length elements from deltaInputs
-    function truncateDeltaInputs(DeltaInputs[] memory deltaInputs, uint length) public pure returns (DeltaInputs[] memory truncatedDeltaInputs) {
-        truncatedDeltaInputs = new DeltaInputs[](length);
+    function truncateDeltaInputs(DeltaInstanceInputs[] memory deltaInputs, uint length) public pure returns (DeltaInstanceInputs[] memory truncatedDeltaInputs) {
+        truncatedDeltaInputs = new DeltaInstanceInputs[](length);
         for(uint i = 0; i < length; i++) {
             truncatedDeltaInputs[i] = deltaInputs[i];
         }
     }
 
     /// @notice Check that a balanced transaction does pass verification
-    function test_verify_balanced_delta_succeeds(DeltaInputs[] memory deltaInputs, bytes32 verifyingKey) public {
+    function test_verify_balanced_delta_succeeds(DeltaInstanceInputs[] memory deltaInputs, bytes32 verifyingKey) public {
         uint256[2] memory deltaAcc = [uint256(0), uint256(0)];
         // Truncate the delta inputs to improve test performance
-        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % 10);
+        uint MAX_DELTA_LEN = 10;
+        deltaInputs = truncateDeltaInputs(deltaInputs, deltaInputs.length % MAX_DELTA_LEN);
         // Make sure that the delta qquantities balance out
-        (DeltaInputs[] memory balancedDeltaInputs, uint256 rcv) = balanceDeltaInputs(deltaInputs);
+        (DeltaInstanceInputs[] memory balancedDeltaInputs, uint256 rcv) = balanceDeltaInputs(deltaInputs);
         for(uint i = 0; i < balancedDeltaInputs.length; i++) {
-            // This is not strictly necessary because verifying key is not used to compute delta instance
-            balancedDeltaInputs[i].verifyingKey = verifyingKey;
             // Compute the delta instance and accumulate it
-            (, uint256[2] memory instance) = generateDelta(balancedDeltaInputs[i]);
+            uint256[2] memory instance = generateDeltaInstance(balancedDeltaInputs[i]);
             deltaAcc = Delta.add(deltaAcc, instance);
         }
         // Compute the proof for the balanced transaction
-        DeltaInputs memory sumDeltaInputs = DeltaInputs({
-            kind: 1,
-            quantity: 0,
+        DeltaProofInputs memory sumDeltaInputs = DeltaProofInputs({
             rcv: rcv,
             verifyingKey: verifyingKey
             });
-        (bytes memory proof, ) = generateDelta(sumDeltaInputs);
+        bytes memory proof = generateDeltaProof(sumDeltaInputs);
         // Verify that the balanced transaction proof succeeds
         Delta.verify({proof: proof, instance: deltaAcc, verifyingKey: verifyingKey});
     }


### PR DESCRIPTION
Based on #235 . Wrote some more tests for the protocol adapter. This PR essentially extends the testing approach taken so far of mutating/corrupting good transactions and expecting reversions during the execution of `ProtocolAdapter.execute`.