### PR TITLE
Fix Execution Semantics

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -147,16 +147,16 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
         }
 
         // Check if the transaction induced a state change and the state root has changed
-        if (newRoot != bytes32(0)) {
+        if (resCounter != 0) {
             // Check the delta proof
             _verifyDeltaProof({proof: transaction.deltaProof, transactionDelta: transactionDelta, tags: tags});
 
             // Store the final root
             _storeRoot(newRoot);
-        }
 
-        // Emit the event containing the transaction and new root
-        emit TransactionExecuted({id: _txCount++, transaction: transaction, newRoot: newRoot});
+            // Emit the event containing the transaction and new root
+            emit TransactionExecuted({id: _txCount++, transaction: transaction, newRoot: newRoot});
+        }
     }
     // slither-disable-end reentrancy-no-eth
 


### PR DESCRIPTION
Previously the check whether any resources were added was based on the root value. Instead it should be based on the resource count.

Moreover, the event that a new root was added was emitted possibly when a new root was not added.