### PR TITLE
Rename Merkle Tree Example Variables

### DIFF
--- a/contracts/test/examples/MerkleTree.e.sol
+++ b/contracts/test/examples/MerkleTree.e.sol
@@ -7,12 +7,12 @@ import {SHA256} from "../../src/libs/SHA256.sol";
 contract MerkleTreeExample {
     using MerkleTree for bytes32[];
 
-    uint256 internal constant _N_LEAFS = 7;
+    uint256 internal constant _N_LEAVES = 7;
     uint256 internal constant _N_ROOTS = 8;
 
-    // We will push 4 leafs - hence the tree will have 5 states
+    // We will push 4 leaves - hence the tree will have 5 states
 
-    bytes32[][_N_ROOTS] internal _leafs;
+    bytes32[][_N_ROOTS] internal _leaves;
     bytes32[][_N_ROOTS] internal _heightOneNodes;
     bytes32[][_N_ROOTS] internal _heightTwoNodes;
 
@@ -37,286 +37,286 @@ contract MerkleTreeExample {
 
         // State 0
         {
-            _leafs[0] = new bytes32[](1);
-            _leafs[0][0] = SHA256.EMPTY_HASH;
+            _leaves[0] = new bytes32[](1);
+            _leaves[0][0] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[0] = _calculateNextLevel(_leafs[0]);
+            _heightOneNodes[0] = _calculateNextLevel(_leaves[0]);
 
             _heightTwoNodes[0] = _calculateNextLevel(_heightOneNodes[0]);
 
             _siblings[0] = new bytes32[][](0);
 
-            _roots[0] = _leafs[0].computeRoot();
+            _roots[0] = _leaves[0].computeRoot();
         }
 
         // State 1
         {
-            _leafs[1] = new bytes32[](2);
-            _leafs[1][0] = bytes32(uint256(1));
-            _leafs[1][1] = SHA256.EMPTY_HASH;
+            _leaves[1] = new bytes32[](2);
+            _leaves[1][0] = bytes32(uint256(1));
+            _leaves[1][1] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[1] = _calculateNextLevel(_leafs[1]);
+            _heightOneNodes[1] = _calculateNextLevel(_leaves[1]);
 
             _heightTwoNodes[1] = _calculateNextLevel(_heightOneNodes[1]);
 
-            _roots[1] = _leafs[1].computeRoot();
+            _roots[1] = _leaves[1].computeRoot();
 
             _siblings[1] = new bytes32[][](1);
 
             _siblings[1][0] = new bytes32[](1);
-            _siblings[1][0][0] = _leafs[1][1];
+            _siblings[1][0][0] = _leaves[1][1];
         }
 
         // State 2
         {
-            _leafs[2] = new bytes32[](4);
-            _leafs[2][0] = _leafs[1][0];
-            _leafs[2][1] = bytes32(uint256(2));
-            _leafs[2][2] = SHA256.EMPTY_HASH;
-            _leafs[2][3] = SHA256.EMPTY_HASH;
+            _leaves[2] = new bytes32[](4);
+            _leaves[2][0] = _leaves[1][0];
+            _leaves[2][1] = bytes32(uint256(2));
+            _leaves[2][2] = SHA256.EMPTY_HASH;
+            _leaves[2][3] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[2] = _calculateNextLevel(_leafs[2]);
+            _heightOneNodes[2] = _calculateNextLevel(_leaves[2]);
 
             _heightTwoNodes[2] = _calculateNextLevel(_heightOneNodes[2]);
 
-            _roots[2] = _leafs[2].computeRoot();
+            _roots[2] = _leaves[2].computeRoot();
 
             _siblings[2] = new bytes32[][](2);
 
             _siblings[2][0] = new bytes32[](2);
-            _siblings[2][0][0] = _leafs[2][1];
+            _siblings[2][0][0] = _leaves[2][1];
             _siblings[2][0][1] = _heightOneNodes[2][1];
 
             _siblings[2][1] = new bytes32[](2);
-            _siblings[2][1][0] = _leafs[2][0];
+            _siblings[2][1][0] = _leaves[2][0];
             _siblings[2][1][1] = _heightOneNodes[2][1];
         }
 
         // State 3
         {
-            _leafs[3] = new bytes32[](4);
-            _leafs[3][0] = _leafs[2][0];
-            _leafs[3][1] = _leafs[2][1];
-            _leafs[3][2] = bytes32(uint256(3));
-            _leafs[3][3] = SHA256.EMPTY_HASH;
+            _leaves[3] = new bytes32[](4);
+            _leaves[3][0] = _leaves[2][0];
+            _leaves[3][1] = _leaves[2][1];
+            _leaves[3][2] = bytes32(uint256(3));
+            _leaves[3][3] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[3] = _calculateNextLevel(_leafs[3]);
+            _heightOneNodes[3] = _calculateNextLevel(_leaves[3]);
 
             _heightTwoNodes[3] = _calculateNextLevel(_heightOneNodes[3]);
 
-            _roots[3] = MerkleTree.computeRoot(_leafs[3]);
+            _roots[3] = MerkleTree.computeRoot(_leaves[3]);
 
             _siblings[3] = new bytes32[][](3);
 
             _siblings[3][0] = new bytes32[](3);
-            _siblings[3][0][0] = _leafs[3][1];
+            _siblings[3][0][0] = _leaves[3][1];
             _siblings[3][0][1] = _heightOneNodes[3][1];
 
             _siblings[3][1] = new bytes32[](2);
-            _siblings[3][1][0] = _leafs[3][0];
+            _siblings[3][1][0] = _leaves[3][0];
             _siblings[3][1][1] = _heightOneNodes[3][1];
 
             _siblings[3][2] = new bytes32[](2);
-            _siblings[3][2][0] = _leafs[3][3];
+            _siblings[3][2][0] = _leaves[3][3];
             _siblings[3][2][1] = _heightOneNodes[3][0];
         }
 
         // State 4
         {
-            _leafs[4] = new bytes32[](8);
-            _leafs[4][0] = _leafs[3][0];
-            _leafs[4][1] = _leafs[3][1];
-            _leafs[4][2] = _leafs[3][2];
-            _leafs[4][3] = bytes32(uint256(4));
-            _leafs[4][4] = SHA256.EMPTY_HASH;
+            _leaves[4] = new bytes32[](8);
+            _leaves[4][0] = _leaves[3][0];
+            _leaves[4][1] = _leaves[3][1];
+            _leaves[4][2] = _leaves[3][2];
+            _leaves[4][3] = bytes32(uint256(4));
+            _leaves[4][4] = SHA256.EMPTY_HASH;
 
-            _leafs[4][5] = SHA256.EMPTY_HASH;
+            _leaves[4][5] = SHA256.EMPTY_HASH;
 
-            _leafs[4][6] = SHA256.EMPTY_HASH;
+            _leaves[4][6] = SHA256.EMPTY_HASH;
 
-            _leafs[4][7] = SHA256.EMPTY_HASH;
+            _leaves[4][7] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[4] = _calculateNextLevel(_leafs[4]);
+            _heightOneNodes[4] = _calculateNextLevel(_leaves[4]);
 
             _heightTwoNodes[4] = _calculateNextLevel(_heightOneNodes[4]);
 
-            _roots[4] = _leafs[4].computeRoot();
+            _roots[4] = _leaves[4].computeRoot();
 
             _siblings[4] = new bytes32[][](4);
 
             _siblings[4][0] = new bytes32[](3);
-            _siblings[4][0][0] = _leafs[4][1];
+            _siblings[4][0][0] = _leaves[4][1];
             _siblings[4][0][1] = _heightOneNodes[4][1];
             _siblings[4][0][2] = _heightTwoNodes[4][1];
 
             _siblings[4][1] = new bytes32[](3);
-            _siblings[4][1][0] = _leafs[4][0];
+            _siblings[4][1][0] = _leaves[4][0];
             _siblings[4][1][1] = _heightOneNodes[4][1];
             _siblings[4][1][2] = _heightTwoNodes[4][1];
 
             _siblings[4][2] = new bytes32[](3);
-            _siblings[4][2][0] = _leafs[4][3];
+            _siblings[4][2][0] = _leaves[4][3];
             _siblings[4][2][1] = _heightOneNodes[4][0];
             _siblings[4][2][2] = _heightTwoNodes[4][1];
 
             _siblings[4][3] = new bytes32[](3);
-            _siblings[4][3][0] = _leafs[4][2];
+            _siblings[4][3][0] = _leaves[4][2];
             _siblings[4][3][1] = _heightOneNodes[4][0];
             _siblings[4][3][2] = _heightTwoNodes[4][1];
         }
 
         // State 5
         {
-            _leafs[5] = new bytes32[](8);
-            _leafs[5][0] = _leafs[4][0];
-            _leafs[5][1] = _leafs[4][1];
-            _leafs[5][2] = _leafs[4][2];
-            _leafs[5][3] = _leafs[4][3];
-            _leafs[5][4] = bytes32(uint256(5));
-            _leafs[5][5] = SHA256.EMPTY_HASH;
+            _leaves[5] = new bytes32[](8);
+            _leaves[5][0] = _leaves[4][0];
+            _leaves[5][1] = _leaves[4][1];
+            _leaves[5][2] = _leaves[4][2];
+            _leaves[5][3] = _leaves[4][3];
+            _leaves[5][4] = bytes32(uint256(5));
+            _leaves[5][5] = SHA256.EMPTY_HASH;
 
-            _leafs[5][6] = SHA256.EMPTY_HASH;
+            _leaves[5][6] = SHA256.EMPTY_HASH;
 
-            _leafs[5][7] = SHA256.EMPTY_HASH;
+            _leaves[5][7] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[5] = _calculateNextLevel(_leafs[5]);
+            _heightOneNodes[5] = _calculateNextLevel(_leaves[5]);
 
             _heightTwoNodes[5] = _calculateNextLevel(_heightOneNodes[5]);
 
-            _roots[5] = _leafs[5].computeRoot();
+            _roots[5] = _leaves[5].computeRoot();
 
             _siblings[5] = new bytes32[][](5);
 
             _siblings[5][0] = new bytes32[](3);
-            _siblings[5][0][0] = _leafs[5][1];
+            _siblings[5][0][0] = _leaves[5][1];
             _siblings[5][0][1] = _heightOneNodes[5][1];
             _siblings[5][0][2] = _heightTwoNodes[5][1];
 
             _siblings[5][1] = new bytes32[](3);
-            _siblings[5][1][0] = _leafs[5][0];
+            _siblings[5][1][0] = _leaves[5][0];
             _siblings[5][1][1] = _heightOneNodes[5][1];
             _siblings[5][1][2] = _heightTwoNodes[5][1];
 
             _siblings[5][2] = new bytes32[](3);
-            _siblings[5][2][0] = _leafs[5][3];
+            _siblings[5][2][0] = _leaves[5][3];
             _siblings[5][2][1] = _heightOneNodes[5][0];
             _siblings[5][2][2] = _heightTwoNodes[5][1];
 
             _siblings[5][3] = new bytes32[](3);
-            _siblings[5][3][0] = _leafs[5][2];
+            _siblings[5][3][0] = _leaves[5][2];
             _siblings[5][3][1] = _heightOneNodes[5][0];
             _siblings[5][3][2] = _heightTwoNodes[5][1];
 
             _siblings[5][4] = new bytes32[](3);
-            _siblings[5][4][0] = _leafs[5][5];
+            _siblings[5][4][0] = _leaves[5][5];
             _siblings[5][4][1] = _heightOneNodes[5][3];
             _siblings[5][4][2] = _heightTwoNodes[5][0];
         }
 
         // State 6
         {
-            _leafs[6] = new bytes32[](8);
-            _leafs[6][0] = _leafs[5][0];
-            _leafs[6][1] = _leafs[5][1];
-            _leafs[6][2] = _leafs[5][2];
-            _leafs[6][3] = _leafs[5][3];
-            _leafs[6][4] = _leafs[5][4];
-            _leafs[6][5] = bytes32(uint256(6));
-            _leafs[6][6] = SHA256.EMPTY_HASH;
+            _leaves[6] = new bytes32[](8);
+            _leaves[6][0] = _leaves[5][0];
+            _leaves[6][1] = _leaves[5][1];
+            _leaves[6][2] = _leaves[5][2];
+            _leaves[6][3] = _leaves[5][3];
+            _leaves[6][4] = _leaves[5][4];
+            _leaves[6][5] = bytes32(uint256(6));
+            _leaves[6][6] = SHA256.EMPTY_HASH;
 
-            _leafs[6][7] = SHA256.EMPTY_HASH;
+            _leaves[6][7] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[6] = _calculateNextLevel(_leafs[6]);
+            _heightOneNodes[6] = _calculateNextLevel(_leaves[6]);
 
             _heightTwoNodes[6] = _calculateNextLevel(_heightOneNodes[6]);
 
-            _roots[6] = _leafs[6].computeRoot();
+            _roots[6] = _leaves[6].computeRoot();
 
             _siblings[6] = new bytes32[][](6);
 
             _siblings[6][0] = new bytes32[](3);
-            _siblings[6][0][0] = _leafs[6][1];
+            _siblings[6][0][0] = _leaves[6][1];
             _siblings[6][0][1] = _heightOneNodes[6][1];
             _siblings[6][0][2] = _heightTwoNodes[6][1];
 
             _siblings[6][1] = new bytes32[](3);
-            _siblings[6][1][0] = _leafs[6][0];
+            _siblings[6][1][0] = _leaves[6][0];
             _siblings[6][1][1] = _heightOneNodes[6][1];
             _siblings[6][1][2] = _heightTwoNodes[6][1];
 
             _siblings[6][2] = new bytes32[](3);
-            _siblings[6][2][0] = _leafs[6][3];
+            _siblings[6][2][0] = _leaves[6][3];
             _siblings[6][2][1] = _heightOneNodes[6][0];
             _siblings[6][2][2] = _heightTwoNodes[6][1];
 
             _siblings[6][3] = new bytes32[](3);
-            _siblings[6][3][0] = _leafs[6][2];
+            _siblings[6][3][0] = _leaves[6][2];
             _siblings[6][3][1] = _heightOneNodes[6][0];
             _siblings[6][3][2] = _heightTwoNodes[6][1];
 
             _siblings[6][4] = new bytes32[](3);
-            _siblings[6][4][0] = _leafs[6][5];
+            _siblings[6][4][0] = _leaves[6][5];
             _siblings[6][4][1] = _heightOneNodes[6][3];
             _siblings[6][4][2] = _heightTwoNodes[6][0];
 
             _siblings[6][5] = new bytes32[](3);
-            _siblings[6][5][0] = _leafs[6][4];
+            _siblings[6][5][0] = _leaves[6][4];
             _siblings[6][5][1] = _heightOneNodes[6][3];
             _siblings[6][5][2] = _heightTwoNodes[6][0];
         }
 
         // State 7
         {
-            _leafs[7] = new bytes32[](8);
-            _leafs[7][0] = _leafs[6][0];
-            _leafs[7][1] = _leafs[6][1];
-            _leafs[7][2] = _leafs[6][2];
-            _leafs[7][3] = _leafs[6][3];
-            _leafs[7][4] = _leafs[6][4];
-            _leafs[7][5] = _leafs[6][5];
-            _leafs[7][6] = bytes32(uint256(7));
-            _leafs[7][7] = SHA256.EMPTY_HASH;
+            _leaves[7] = new bytes32[](8);
+            _leaves[7][0] = _leaves[6][0];
+            _leaves[7][1] = _leaves[6][1];
+            _leaves[7][2] = _leaves[6][2];
+            _leaves[7][3] = _leaves[6][3];
+            _leaves[7][4] = _leaves[6][4];
+            _leaves[7][5] = _leaves[6][5];
+            _leaves[7][6] = bytes32(uint256(7));
+            _leaves[7][7] = SHA256.EMPTY_HASH;
 
-            _heightOneNodes[7] = _calculateNextLevel(_leafs[7]);
+            _heightOneNodes[7] = _calculateNextLevel(_leaves[7]);
 
             _heightTwoNodes[7] = _calculateNextLevel(_heightOneNodes[7]);
 
-            _roots[7] = _leafs[7].computeRoot();
+            _roots[7] = _leaves[7].computeRoot();
 
             _siblings[7] = new bytes32[][](7);
 
             _siblings[7][0] = new bytes32[](3);
-            _siblings[7][0][0] = _leafs[7][1];
+            _siblings[7][0][0] = _leaves[7][1];
             _siblings[7][0][1] = _heightOneNodes[7][1];
             _siblings[7][0][2] = _heightTwoNodes[7][1];
 
             _siblings[7][1] = new bytes32[](3);
-            _siblings[7][1][0] = _leafs[7][0];
+            _siblings[7][1][0] = _leaves[7][0];
             _siblings[7][1][1] = _heightOneNodes[7][1];
             _siblings[7][1][2] = _heightTwoNodes[7][1];
 
             _siblings[7][2] = new bytes32[](3);
-            _siblings[7][2][0] = _leafs[7][3];
+            _siblings[7][2][0] = _leaves[7][3];
             _siblings[7][2][1] = _heightOneNodes[7][0];
             _siblings[7][2][2] = _heightTwoNodes[7][1];
 
             _siblings[7][3] = new bytes32[](3);
-            _siblings[7][3][0] = _leafs[7][2];
+            _siblings[7][3][0] = _leaves[7][2];
             _siblings[7][3][1] = _heightOneNodes[7][0];
             _siblings[7][3][2] = _heightTwoNodes[7][1];
 
             _siblings[7][4] = new bytes32[](3);
-            _siblings[7][4][0] = _leafs[7][4];
+            _siblings[7][4][0] = _leaves[7][4];
             _siblings[7][4][1] = _heightOneNodes[7][3];
             _siblings[7][4][2] = _heightTwoNodes[7][0];
 
             _siblings[7][5] = new bytes32[](3);
-            _siblings[7][5][0] = _leafs[7][4];
+            _siblings[7][5][0] = _leaves[7][4];
             _siblings[7][5][1] = _heightOneNodes[7][3];
             _siblings[7][5][2] = _heightTwoNodes[7][0];
 
             _siblings[7][6] = new bytes32[](3);
-            _siblings[7][6][0] = _leafs[7][7];
+            _siblings[7][6][0] = _leaves[7][7];
             _siblings[7][6][1] = _heightOneNodes[7][2];
             _siblings[7][6][2] = _heightTwoNodes[7][0];
         }

--- a/contracts/test/state/CommitmentAccumulator.t.sol
+++ b/contracts/test/state/CommitmentAccumulator.t.sol
@@ -30,8 +30,8 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
         assertEq(initialRoot, _roots[0]);
         assertEq(initialRoot, _cmAcc.initialRoot());
 
-        for (uint256 i = 0; i < _N_LEAFS; ++i) {
-            assertEq(_cmAcc.addCommitment(_leafs[i + 1][i]), _roots[i + 1]);
+        for (uint256 i = 0; i < _N_LEAVES; ++i) {
+            assertEq(_cmAcc.addCommitment(_leaves[i + 1][i]), _roots[i + 1]);
         }
     }
 
@@ -39,8 +39,8 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
         uint256 prevCount = 0;
         uint256 newCount = 0;
 
-        for (uint256 i = 0; i < _N_LEAFS; ++i) {
-            _cmAcc.addCommitment(_leafs[i + 1][i]);
+        for (uint256 i = 0; i < _N_LEAVES; ++i) {
+            _cmAcc.addCommitment(_leaves[i + 1][i]);
             newCount = _cmAcc.commitmentCount();
 
             assertEq(newCount, ++prevCount);
@@ -80,8 +80,8 @@ contract CommitmentAccumulatorTest is Test, MerkleTreeExample {
     function test_should_produce_an_invalid_root_for_a_non_existent_leaf() public {
         bytes32 nonExistentCommitment = sha256("NON_EXISTENT");
 
-        for (uint256 i = 0; i < _N_LEAFS; ++i) {
-            bytes32 root = _cmAcc.addCommitment(_leafs[i + 1][i]);
+        for (uint256 i = 0; i < _N_LEAVES; ++i) {
+            bytes32 root = _cmAcc.addCommitment(_leaves[i + 1][i]);
 
             for (uint256 j = 0; j <= i; ++j) {
                 bytes32 computedRoot = MerkleTree.processProof({

--- a/contracts/test/state/MerkleTree.t.sol
+++ b/contracts/test/state/MerkleTree.t.sol
@@ -22,31 +22,31 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
         assertEq(_merkleTree.leafCount(), 0);
         assertEq(_merkleTree.depth(), 0);
 
-        _merkleTree.push(_leafs[7][0]);
+        _merkleTree.push(_leaves[7][0]);
         assertEq(_merkleTree.leafCount(), 1);
         assertEq(_merkleTree.depth(), 1);
 
-        _merkleTree.push(_leafs[7][1]);
+        _merkleTree.push(_leaves[7][1]);
         assertEq(_merkleTree.leafCount(), 2);
         assertEq(_merkleTree.depth(), 2);
 
-        _merkleTree.push(_leafs[7][2]);
+        _merkleTree.push(_leaves[7][2]);
         assertEq(_merkleTree.leafCount(), 3);
         assertEq(_merkleTree.depth(), 2);
 
-        _merkleTree.push(_leafs[7][3]);
+        _merkleTree.push(_leaves[7][3]);
         assertEq(_merkleTree.leafCount(), 4);
         assertEq(_merkleTree.depth(), 3);
 
-        _merkleTree.push(_leafs[7][4]);
+        _merkleTree.push(_leaves[7][4]);
         assertEq(_merkleTree.leafCount(), 5);
         assertEq(_merkleTree.depth(), 3);
 
-        _merkleTree.push(_leafs[7][5]);
+        _merkleTree.push(_leaves[7][5]);
         assertEq(_merkleTree.leafCount(), 6);
         assertEq(_merkleTree.depth(), 3);
 
-        _merkleTree.push(_leafs[7][6]);
+        _merkleTree.push(_leaves[7][6]);
         assertEq(_merkleTree.leafCount(), 7);
         assertEq(_merkleTree.depth(), 3);
     }


### PR DESCRIPTION
- `_a` to `_leaves`
- `_b` to `_heightOneNodes`
- `_c` to `_heightTwoNodes` 