### PR TITLE
style: use forge lint and fix linter warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Show Foundry version
         run: forge --version
 
+      - name: Run Forge Lint
+        run: forge lint
+        working-directory: ./contracts
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: forge --version
 
       - name: Run Forge Lint
-        run: forge lint
+        run: forge lint --deny-warnings
         working-directory: ./contracts
 
       - name: Install Bun

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "contracts/lib/permit2"]
 	path = contracts/lib/permit2
 	url = https://github.com/Uniswap/permit2
+[submodule "contracts/lib/solady"]
+	path = contracts/lib/solady
+	url = https://github.com/vectorized/solady

--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -1,0 +1,26 @@
+{
+  "lib/elliptic-curve-solidity": {
+    "branch": {
+      "name": "master",
+      "rev": "347547890840fd501809dfe0b855206407136ec0"
+    }
+  },
+  "lib/forge-std": {
+    "rev": "3b20d60d14b343ee4f908cb8079495c07f5e8981"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "e4f70216d759d8e6a64144a9e1f7bbeed78e7079"
+  },
+  "lib/permit2": {
+    "rev": "cc56ad0f3439c502c246fc5cfcc3db92bb8b7219"
+  },
+  "lib/risc0-ethereum": {
+    "rev": "365e7b2db4f620fa256580c27558d2623362b9ae"
+  },
+  "lib/solady": {
+    "tag": {
+      "name": "v0.1.26",
+      "rev": "acd959aa4bd04720d640bf4e6a5c71037510cc4b"
+    }
+  }
+}

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -15,6 +15,7 @@ fs_permissions = [
 remappings = [
     "forge-std/=lib/forge-std/src/",
     "@openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
+    "@solady/=lib/solady/src",
     "@risc0-ethereum/=lib/risc0-ethereum/contracts/src/",
     "@elliptic-curve-solidity/=lib/elliptic-curve-solidity/",
     "@permit2/=lib/permit2/",

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -50,9 +50,7 @@ contract ProtocolAdapter is IProtocolAdapter, ReentrancyGuardTransient, Commitme
     /// @notice Constructs the protocol adapter contract.
     /// @param riscZeroVerifierRouter The RISC Zero verifier router contract.
     /// @param riscZeroVerifierSelector The RISC Zero verifier selector this protocol adapter is associated with.
-    constructor(RiscZeroVerifierRouter riscZeroVerifierRouter, bytes4 riscZeroVerifierSelector)
-        CommitmentAccumulator()
-    {
+    constructor(RiscZeroVerifierRouter riscZeroVerifierRouter, bytes4 riscZeroVerifierSelector) {
         if (address(riscZeroVerifierRouter) == address(0)) {
             revert ZeroNotAllowed();
         }

--- a/contracts/src/libs/MerkleTree.sol
+++ b/contracts/src/libs/MerkleTree.sol
@@ -90,8 +90,8 @@ library MerkleTree {
     /// @notice Returns the tree depth.
     /// @param self The tree data structure.
     /// @return treeDepth The depth of the tree.
-    function depth(Tree storage self) internal view returns (uint256 treeDepth) {
-        treeDepth = self._sides.length;
+    function depth(Tree storage self) internal view returns (uint8 treeDepth) {
+        treeDepth = uint8(self._sides.length);
     }
 
     /// @notice Returns the number of leaves that have been added to the tree.
@@ -105,7 +105,7 @@ library MerkleTree {
     /// @param self The tree data structure.
     /// @return treeCapacity The computed tree capacity.
     function capacity(Tree storage self) internal view returns (uint256 treeCapacity) {
-        treeCapacity = 1 << depth(self);
+        treeCapacity = uint256(1) << depth(self); // 2^treeDepth
     }
 
     /// @notice Checks whether a node is the left or right child according to its index.
@@ -154,7 +154,7 @@ library MerkleTree {
     /// @return root The computed root.
     /// @dev This method should only be used for trees with low depth.
     function computeRoot(bytes32[] memory leaves, uint8 treeDepth) internal pure returns (bytes32 root) {
-        uint256 treeCapacity = 1 << treeDepth; // 2^treeDepth
+        uint256 treeCapacity = uint256(1) << treeDepth; // 2^treeDepth
 
         // Create array of full leaf set with padding if necessary
         bytes32[] memory nodes = new bytes32[](treeCapacity);

--- a/contracts/src/proving/Delta.sol
+++ b/contracts/src/proving/Delta.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.30;
 
 import {ECDSA} from "@openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import {EfficientHashLib} from "@solady/utils/EfficientHashLib.sol";
+
 import {EllipticCurveK256} from "../libs/EllipticCurveK256.sol";
 
 /// @title Delta
@@ -25,7 +27,7 @@ library Delta {
     /// @return account The associated account.
     function toAccount(uint256[2] memory delta) internal pure returns (address account) {
         // Hash the public key with Keccak-256
-        bytes32 hashedKey = keccak256(abi.encode(delta[0], delta[1]));
+        bytes32 hashedKey = EfficientHashLib.hash(delta[0], delta[1]);
 
         // Take the last 20 bytes to obtain an Ethereum address.
         account = address(uint160(uint256(hashedKey)));
@@ -38,7 +40,7 @@ library Delta {
     /// @dev The tags are encoded in packed form to remove the array header.
     /// Since all the tags are 32 bytes in size, tight variable packing will not occur.
     function computeVerifyingKey(bytes32[] memory tags) internal pure returns (bytes32 verifyingKey) {
-        verifyingKey = keccak256(abi.encodePacked(tags));
+        verifyingKey = EfficientHashLib.hash(tags);
     }
 
     /// @notice Verifies a delta proof.

--- a/contracts/test/mocks/CommitmentAccumulator.m.sol
+++ b/contracts/test/mocks/CommitmentAccumulator.m.sol
@@ -10,8 +10,6 @@ contract CommitmentAccumulatorMock is CommitmentAccumulator {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using MerkleTree for MerkleTree.Tree;
 
-    constructor() CommitmentAccumulator() {}
-
     function addCommitment(bytes32 commitment) external returns (bytes32 newRoot) {
         newRoot = _addCommitment(commitment);
     }

--- a/contracts/test/proofs/LogicProof.t.sol
+++ b/contracts/test/proofs/LogicProof.t.sol
@@ -17,8 +17,6 @@ contract LogicProofTest is Test {
     RiscZeroVerifierRouter internal _router;
     RiscZeroVerifierEmergencyStop internal _emergencyStop;
 
-    bytes32 internal _complianceCircuitID;
-
     function setUp() public {
         (_router, _emergencyStop,) = new DeployRiscZeroContracts().run();
     }


### PR DESCRIPTION
This PR introduces the `solady` library as a dependency to use `EfficientHashLib`.