### PR TITLE
feat: add differential tests for the variable depth Merkle tree implementation

### DIFF
--- a/contracts/test/state/MerkleTree.t.sol
+++ b/contracts/test/state/MerkleTree.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {MerkleTree as ZeppelinMerkleTree} from "@openzeppelin/contracts/utils/structs/MerkleTree.sol";
+import {MerkleTree as OzMerkleTree} from "@openzeppelin/contracts/utils/structs/MerkleTree.sol";
 import {Test} from "forge-std/Test.sol";
 import {MerkleTree} from "./../../src/libs/MerkleTree.sol";
 import {SHA256} from "./../../src/libs/SHA256.sol";
@@ -10,11 +10,11 @@ import {MerkleTreeExample} from "./../examples/MerkleTree.e.sol";
 contract MerkleTreeTest is Test, MerkleTreeExample {
     using MerkleTree for MerkleTree.Tree;
     using MerkleTree for bytes32[];
-    using ZeppelinMerkleTree for ZeppelinMerkleTree.Bytes32PushTree;
+    using OzMerkleTree for OzMerkleTree.Bytes32PushTree;
 
     MerkleTree.Tree internal _merkleTree;
     MerkleTree.Tree internal _paMerkleTree;
-    ZeppelinMerkleTree.Bytes32PushTree internal _zeppelinMerkleTree;
+    OzMerkleTree.Bytes32PushTree internal _ozMerkleTree;
 
     constructor() {
         _setupMockTree();
@@ -58,9 +58,7 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
         assertEq(_merkleTree.setup(), SHA256.EMPTY_HASH);
     }
 
-    /// @notice Differentially test our Merkle tree implementation against
-    /// OpenZeppelin's implementation.
-    function testFuzz_push_implementations_yield_same_roots(bytes32[] memory leaves) public {
+    function testFuzz_push_returns_the_same_roots(bytes32[] memory leaves) public {
         // First compute what tree depth is required to store leaves
         uint8 treeDepth = 0;
         // Essentially compute the logarithm of the leaf count base 2
@@ -68,55 +66,49 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
             treeDepth++;
         }
         // Set up a protocol adapter Merkle tree and an OpenZeppelin one
-        bytes32 newRoot1 = _paMerkleTree.setup();
+        bytes32 paRoot = _paMerkleTree.setup();
         // OpenZeppelin implementation is not variable depth, it is easier to
         // just compare the end state once we have reached the final depth
-        bytes32 newRoot2 = _zeppelinMerkleTree.setup(treeDepth, SHA256.EMPTY_HASH, _hashPair);
+        bytes32 ozRoot = _ozMerkleTree.setup(treeDepth, SHA256.EMPTY_HASH, _hashPair);
 
-        uint256 index1 = 0;
-        uint256 index2 = 0;
+        uint256 paIndex = 0;
+        uint256 ozIndex = 0;
         // Now add all the leaves to each Merkle tree
         for (uint256 i = 0; i < leaves.length; i++) {
-            (index1, newRoot1) = _paMerkleTree.push(leaves[i]);
-            (index2, newRoot2) = _zeppelinMerkleTree.push(leaves[i], _hashPair);
+            (paIndex, paRoot) = _paMerkleTree.push(leaves[i]);
+            (ozIndex, ozRoot) = _ozMerkleTree.push(leaves[i], _hashPair);
             // The lead counts must remain matched throughout
-            assertEq(index1, index2);
+            assertEq(paIndex, ozIndex);
             // Once we have reached the final depth, we might as well start
             // comparing the roots
-            if (_paMerkleTree.depth() == _zeppelinMerkleTree.depth()) {
-                assertEq(newRoot1, newRoot2);
+            if (_paMerkleTree.depth() == _ozMerkleTree.depth()) {
+                assertEq(paRoot, ozRoot);
             }
         }
         // Now confirm that the Merkle trees have the same leaf count
-        assertEq(index1, index2);
+        assertEq(paIndex, ozIndex);
         // Same roots
-        assertEq(newRoot1, newRoot2);
+        assertEq(paRoot, ozRoot);
         // Same depths
-        assertEq(_paMerkleTree.depth(), _zeppelinMerkleTree.depth());
+        assertEq(_paMerkleTree.depth(), _ozMerkleTree.depth());
     }
 
-    /// @notice Differentially test our Merkle tree implementation against
-    /// OpenZeppelin's implementation. Ensuring that we hit the 0 leaf case.
-    function testFuzz_push_implementations_yield_same_roots() public {
+    function testFuzz_push_returns_the_same_roots() public {
         bytes32[] memory dynamicLeaves = new bytes32[](0);
-        testFuzz_push_implementations_yield_same_roots(dynamicLeaves);
+        testFuzz_push_returns_the_same_roots(dynamicLeaves);
     }
 
-    /// @notice Differentially test our Merkle tree implementation against
-    /// OpenZeppelin's implementation. Ensuring that we hit the 1 leaf case.
-    function testFuzz_push_implementations_yield_same_roots(bytes32[1] memory leaves) public {
+    function testFuzz_push_returns_the_same_roots(bytes32[1] memory leaves) public {
         bytes32[] memory dynamicLeaves = new bytes32[](1);
         dynamicLeaves[0] = leaves[0];
-        testFuzz_push_implementations_yield_same_roots(dynamicLeaves);
+        testFuzz_push_returns_the_same_roots(dynamicLeaves);
     }
 
-    /// @notice Differentially test our Merkle tree implementation against
-    /// OpenZeppelin's implementation. Ensuring that we hit the 2 leaf case.
-    function testFuzz_push_implementations_yield_same_roots(bytes32[2] memory leaves) public {
+    function testFuzz_push_returns_the_same_roots(bytes32[2] memory leaves) public {
         bytes32[] memory dynamicLeaves = new bytes32[](2);
         dynamicLeaves[0] = leaves[0];
         dynamicLeaves[1] = leaves[1];
-        testFuzz_push_implementations_yield_same_roots(dynamicLeaves);
+        testFuzz_push_returns_the_same_roots(dynamicLeaves);
     }
 
     /// @notice Hashes two `bytes32` values.


### PR DESCRIPTION
This PR is an attempt to compare the Protocol Adapter Merkle Tree implementation to OpenZeppelin's. The approach taken is essentially to add the some leaves to the Protocol Adapter implementation, add the same leaves to the OpenZeppelin implementation, then verify that the same Merkle tree roots are computed.