### PR TITLE
test: execute testing

### DIFF
--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -330,7 +330,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         });
 
         bytes32 tag = txn.actions[actionIndex].complianceVerifierInputs[complianceIndex].instance.consumed.nullifier;
-        uint256 tagIndex = TxGen.getExistingTagIndex(txn.actions[actionIndex], tag);
+        uint256 tagIndex = TxGen.getTagIndex(txn.actions[actionIndex], tag);
 
         // Generate a different tag with the nonce.
         // We assume that the tags are generated using sha256. Hence the tag is different modulo hash-breaking.
@@ -369,7 +369,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         );
 
         bytes32 tag = txn.actions[actionIndex].complianceVerifierInputs[complianceIndex].instance.created.commitment;
-        uint256 tagIndex = TxGen.getExistingTagIndex(txn.actions[actionIndex], tag);
+        uint256 tagIndex = TxGen.getTagIndex(txn.actions[actionIndex], tag);
 
         // Replace the commitment corresponding to the selected compliance unit with a fake one
         txn.actions[actionIndex].logicVerifierInputs[tagIndex].tag = fakeTag;
@@ -469,7 +469,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
         Compliance.ConsumedRefs memory consumed =
             txn.actions[actionIndex].complianceVerifierInputs[complianceIndex].instance.consumed;
-        uint256 tagIndex = TxGen.getExistingTagIndex(txn.actions[actionIndex], consumed.nullifier);
+        uint256 tagIndex = TxGen.getTagIndex(txn.actions[actionIndex], consumed.nullifier);
 
         // Generate a fake logic using a nonce.
         bytes32 fakeLogic = SHA256.hash(consumed.logicRef, nonce);
@@ -500,7 +500,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
         Compliance.CreatedRefs memory created =
             txn.actions[actionIndex].complianceVerifierInputs[complianceIndex].instance.created;
-        uint256 tagIndex = TxGen.getExistingTagIndex(txn.actions[actionIndex], created.commitment);
+        uint256 tagIndex = TxGen.getTagIndex(txn.actions[actionIndex], created.commitment);
 
         // Generate a fake logic using a nonce.
         bytes32 fakeLogic = SHA256.hash(created.logicRef, nonce);

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -34,6 +34,7 @@ library TxGen {
     }
 
     error ConsumedCreatedCountMismatch(uint256 nConsumed, uint256 nCreated);
+    error NonExistingTag(bytes32 tag);
 
     function complianceVerifierInput(
         VmSafe vm,
@@ -351,7 +352,7 @@ library TxGen {
         });
     }
 
-    function getExistingTagIndex(Action memory action, bytes32 tag) internal pure returns (uint256 index) {
+    function getTagIndex(Action memory action, bytes32 tag) internal pure returns (uint256 index) {
         uint256 logicVerifierInputCount = action.logicVerifierInputs.length;
 
         for (uint256 i = 0; i < logicVerifierInputCount; ++i) {
@@ -359,6 +360,8 @@ library TxGen {
                 return (index = i);
             }
         }
+
+        revert NonExistingTag(tag);
     }
 
     function commitment(Resource memory resource) internal pure returns (bytes32 hash) {


### PR DESCRIPTION
Based on #244 by @murisi

Changelog:

Simplifications:

- Removal of structs in favor of explicit fuzzing arguments
- Minimize assumes and replace them with nonced computations based on fuzzing arguments
- Abstract bounding of fuzzing variables
- Make Mock just a test again

Improvements:

- Generalize ResourceCount reverts: tests not accepts more inputs, not only less

General comments:

- Made the output test into a unit one as there is no proper way to fuzz it currently.
- Certain mutations are assumed to fail early so are not properly generated to replicate the original constructions.
