### PR TITLE
small fix: SemVerLib.sol import

### DIFF
--- a/contracts/test/libs/Versioning.t.sol
+++ b/contracts/test/libs/Versioning.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {SemVerLib} from "@solady/utils/SemVerlib.sol";
+import {SemVerLib} from "@solady/utils/SemVerLib.sol";
 
 import {Test} from "forge-std/Test.sol";
 


### PR DESCRIPTION
`forge build` broken (at least for forge 1.2.2-dev/1.3.2-nightly since https://github.com/anoma/evm-protocol-adapter/commit/026aeecc0b6026b3253a3d86b84d6b05d033267d) due to missing upper case in import
```bash
❯ forge build --ast
[⠃] Compiling...2025-09-24T17:26:34.135816Z ERROR foundry_compilers_artifacts_solc::sources: error=".../evm-protocol-adapter/contracts/lib/solady/src/utils/SemVerlib.sol": No such file or directory (os error 2)
[⠊] Compiling...
Error: file cannot be resolved due to mismatch of file name case: ".../evm-protocol-adapter/contracts/lib/solady/src/utils/SemVerlib.sol": No such file or directory (os error 2).
Found existing file: ".../evm-protocol-adapter/contracts/lib/solady/src/utils/SemVerLib.sol"
Please check the case of the import.
        --> .../evm-protocol-adapter/contracts/test/libs/Versioning.t.sol
        @solady/utils/SemVerlib.sol
```