### PR TITLE
ci: run CI on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This will allow running the CIs after explicit approval for external contributions (see, e.g., https://github.com/anoma/evm-protocol-adapter/pull/236), see https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks.