### PR TITLE
feat: implement block time forwarder

### DIFF
--- a/contracts/src/forwarders/BlockTimeForwarder.sol
+++ b/contracts/src/forwarders/BlockTimeForwarder.sol
@@ -17,7 +17,7 @@ contract BlockTimeForwarder is IForwarder {
         returns (bytes memory output)
     {
         // 248-limit is imposed by Risc0 not accepting 256-bit inputs.
-        (uint256 expectedTime) = abi.decode(input, (uint256));
+        (uint256 expectedTime) = abi.decode(input, (uint248));
 
         // slither-disable-next-line timestamp
         output = abi.encode(expectedTime < block.timestamp);  // solhint-disable-line not-rely-on-time

--- a/contracts/src/forwarders/BlockTimeForwarder.sol
+++ b/contracts/src/forwarders/BlockTimeForwarder.sol
@@ -3,11 +3,10 @@ pragma solidity ^0.8.30;
 
 import {IForwarder} from "../interfaces/IForwarder.sol";
 
-/// @title ForwarderBase
+/// @title BlockTimeForwarder
 /// @author Anoma Foundation, 2025
-/// @notice The forwarder contract allowing to check whether a certain block time has passed.
+/// @notice A forwarder contract allowing to check whether a certain block time has passed.
 /// @custom:security-contact security@anoma.foundation
-
 contract BlockTimeForwarder is IForwarder {
     /// @inheritdoc IForwarder
     function forwardCall(bytes32, /* logicRef */ bytes calldata input)

--- a/contracts/src/forwarders/BlockTimeForwarder.sol
+++ b/contracts/src/forwarders/BlockTimeForwarder.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Time} from "@openzeppelin-contracts/utils/types/Time.sol";
+
 import {IForwarder} from "../interfaces/IForwarder.sol";
 
 /// @title BlockTimeForwarder
@@ -21,11 +23,9 @@ contract BlockTimeForwarder is IForwarder {
         override
         returns (bytes memory output)
     {
-        // 248-limit is imposed by Risc0 not accepting 256-bit inputs.
-        (uint256 expectedTime) = abi.decode(input, (uint248));
+        (uint48 expectedTime) = abi.decode(input, (uint48));
 
-        // slither-disable-next-line timestamp
-        uint256 currentTime = block.timestamp; // solhint-disable-line not-rely-on-time
+        uint48 currentTime = Time.timestamp();
 
         TimeComparison result;
         if (expectedTime < currentTime) {

--- a/contracts/src/forwarders/BlockTimeForwarder.sol
+++ b/contracts/src/forwarders/BlockTimeForwarder.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IForwarder} from "../interfaces/IForwarder.sol";
+
+/// @title ForwarderBase
+/// @author Anoma Foundation, 2025
+/// @notice The forwarder contract allowing to check whether a certain block time has passed.
+/// @custom:security-contact security@anoma.foundation
+
+contract BlockTimeForwarder is IForwarder {
+    /// @inheritdoc IForwarder
+    function forwardCall(bytes32, /* logicRef */ bytes calldata input)
+        external
+        view
+        override
+        returns (bytes memory output)
+    {
+        // 248-limit is imposed by Risc0 not accepting 256-bit inputs.
+        (uint256 expectedTime) = abi.decode(input, (uint256));
+
+        // slither-disable-next-line timestamp
+        output = abi.encode(expectedTime < block.timestamp);  // solhint-disable-line not-rely-on-time
+    }
+}

--- a/contracts/src/forwarders/BlockTimeForwarder.sol
+++ b/contracts/src/forwarders/BlockTimeForwarder.sol
@@ -15,7 +15,7 @@ contract BlockTimeForwarder is IForwarder {
     }
 
     /// @inheritdoc IForwarder
-    function forwardCall(bytes32, /* logicRef */ bytes calldata input)
+    function forwardCall( /* logicRef */ bytes32, bytes calldata input)
         external
         view
         override

--- a/contracts/src/forwarders/BlockTimeForwarder.sol
+++ b/contracts/src/forwarders/BlockTimeForwarder.sol
@@ -8,6 +8,12 @@ import {IForwarder} from "../interfaces/IForwarder.sol";
 /// @notice A forwarder contract allowing to check whether a certain block time has passed.
 /// @custom:security-contact security@anoma.foundation
 contract BlockTimeForwarder is IForwarder {
+    enum TimeComparison {
+        LT,
+        EQ,
+        GT
+    }
+
     /// @inheritdoc IForwarder
     function forwardCall(bytes32, /* logicRef */ bytes calldata input)
         external
@@ -19,6 +25,17 @@ contract BlockTimeForwarder is IForwarder {
         (uint256 expectedTime) = abi.decode(input, (uint248));
 
         // slither-disable-next-line timestamp
-        output = abi.encode(expectedTime < block.timestamp);  // solhint-disable-line not-rely-on-time
+        uint256 currentTime = block.timestamp; // solhint-disable-line not-rely-on-time
+
+        TimeComparison result;
+        if (expectedTime < currentTime) {
+            result = TimeComparison.LT;
+        } else if (expectedTime > currentTime) {
+            result = TimeComparison.GT;
+        } else {
+            result = TimeComparison.EQ;
+        }
+
+        output = abi.encode(result);
     }
 }

--- a/contracts/test/forwarders/BlockTimeForwarder.t.sol
+++ b/contracts/test/forwarders/BlockTimeForwarder.t.sol
@@ -12,11 +12,6 @@ import {ProtocolAdapter} from "../../src/ProtocolAdapter.sol";
 
 import {DeployRiscZeroContracts} from "../script/DeployRiscZeroContracts.s.sol";
 
-/// @title ForwarderBase
-/// @author Anoma Foundation, 2025
-/// @notice The forwarder contract returning whether a specific block time has passed.
-/// @custom:security-contact security@anoma.foundation
-
 contract BlockTimeForwarderTest is Test {
     address internal constant _EMERGENCY_COMMITTEE = address(uint160(1));
 

--- a/contracts/test/forwarders/BlockTimeForwarder.t.sol
+++ b/contracts/test/forwarders/BlockTimeForwarder.t.sol
@@ -35,14 +35,14 @@ contract BlockTimeForwarderTest is Test {
 
     function test_forwardCall_returns_true_if_timestamp_is_in_the_past() public view {
         // solhint-disable-next-line not-rely-on-time
-        bytes memory passedTimestampBytes = abi.encode(uint256(block.timestamp - 1));
+        bytes memory passedTimestampBytes = abi.encode(uint248(block.timestamp - 1));
         bytes memory output = _fwd.forwardCall("", passedTimestampBytes);
 
         assert(abi.decode(output, (bool)));
     }
 
     function test_forwardCall_returns_false_if_timestamp_is_in_the_future() public view {
-        bytes memory futureTimestampBytes = abi.encode(type(uint256).max);
+        bytes memory futureTimestampBytes = abi.encode(type(uint248).max);
         bytes memory output = _fwd.forwardCall("", futureTimestampBytes);
 
         assert(!abi.decode(output, (bool)));
@@ -50,7 +50,7 @@ contract BlockTimeForwarderTest is Test {
 
     function test_forwardCall_returns_false_if_timestamp_is_in_the_present() public view {
         // solhint-disable-next-line not-rely-on-time
-        bytes memory presentTimestampBytes = abi.encode(block.timestamp);
+        bytes memory presentTimestampBytes = abi.encode(uint248(block.timestamp));
         bytes memory output = _fwd.forwardCall("", presentTimestampBytes);
 
         assert(!abi.decode(output, (bool)));

--- a/contracts/test/forwarders/BlockTimeForwarder.t.sol
+++ b/contracts/test/forwarders/BlockTimeForwarder.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Time} from "@openzeppelin-contracts/utils/types/Time.sol";
 import {RiscZeroGroth16Verifier} from "@risc0-ethereum/groth16/RiscZeroGroth16Verifier.sol";
 import {RiscZeroVerifierRouter} from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
 
@@ -35,7 +36,7 @@ contract BlockTimeForwarderTest is Test {
 
     function test_forwardCall_returns_LT_if_timestamp_is_in_the_past() public view {
         // solhint-disable-next-line not-rely-on-time
-        bytes memory passedTimestampBytes = abi.encode(uint248(block.timestamp - 1));
+        bytes memory passedTimestampBytes = abi.encode(uint48(Time.timestamp() - 1));
         bytes memory output = _fwd.forwardCall("", passedTimestampBytes);
 
         BlockTimeForwarder.TimeComparison decodedOutput = abi.decode(output, (BlockTimeForwarder.TimeComparison));
@@ -44,7 +45,7 @@ contract BlockTimeForwarderTest is Test {
     }
 
     function test_forwardCall_returns_GT_if_timestamp_is_in_the_future() public view {
-        bytes memory futureTimestampBytes = abi.encode(type(uint248).max);
+        bytes memory futureTimestampBytes = abi.encode(type(uint48).max);
         bytes memory output = _fwd.forwardCall("", futureTimestampBytes);
 
         BlockTimeForwarder.TimeComparison decodedOutput = abi.decode(output, (BlockTimeForwarder.TimeComparison));
@@ -54,7 +55,7 @@ contract BlockTimeForwarderTest is Test {
 
     function test_forwardCall_returns_EQ_if_timestamp_is_in_the_present() public view {
         // solhint-disable-next-line not-rely-on-time
-        bytes memory presentTimestampBytes = abi.encode(uint248(block.timestamp));
+        bytes memory presentTimestampBytes = abi.encode(uint48(Time.timestamp()));
         bytes memory output = _fwd.forwardCall("", presentTimestampBytes);
 
         BlockTimeForwarder.TimeComparison decodedOutput = abi.decode(output, (BlockTimeForwarder.TimeComparison));

--- a/contracts/test/forwarders/BlockTimeForwarder.t.sol
+++ b/contracts/test/forwarders/BlockTimeForwarder.t.sol
@@ -33,27 +33,33 @@ contract BlockTimeForwarderTest is Test {
         _fwd = new BlockTimeForwarder();
     }
 
-    function test_forwardCall_returns_true_if_timestamp_is_in_the_past() public view {
+    function test_forwardCall_returns_LT_if_timestamp_is_in_the_past() public view {
         // solhint-disable-next-line not-rely-on-time
         bytes memory passedTimestampBytes = abi.encode(uint248(block.timestamp - 1));
         bytes memory output = _fwd.forwardCall("", passedTimestampBytes);
 
-        assert(abi.decode(output, (bool)));
+        BlockTimeForwarder.TimeComparison decodedOutput = abi.decode(output, (BlockTimeForwarder.TimeComparison));
+
+        assertEq(uint8(decodedOutput), uint8(BlockTimeForwarder.TimeComparison.LT));
     }
 
-    function test_forwardCall_returns_false_if_timestamp_is_in_the_future() public view {
+    function test_forwardCall_returns_GT_if_timestamp_is_in_the_future() public view {
         bytes memory futureTimestampBytes = abi.encode(type(uint248).max);
         bytes memory output = _fwd.forwardCall("", futureTimestampBytes);
 
-        assert(!abi.decode(output, (bool)));
+        BlockTimeForwarder.TimeComparison decodedOutput = abi.decode(output, (BlockTimeForwarder.TimeComparison));
+
+        assertEq(uint8(decodedOutput), uint8(BlockTimeForwarder.TimeComparison.GT));
     }
 
-    function test_forwardCall_returns_false_if_timestamp_is_in_the_present() public view {
+    function test_forwardCall_returns_EQ_if_timestamp_is_in_the_present() public view {
         // solhint-disable-next-line not-rely-on-time
         bytes memory presentTimestampBytes = abi.encode(uint248(block.timestamp));
         bytes memory output = _fwd.forwardCall("", presentTimestampBytes);
 
-        assert(!abi.decode(output, (bool)));
+        BlockTimeForwarder.TimeComparison decodedOutput = abi.decode(output, (BlockTimeForwarder.TimeComparison));
+
+        assertEq(uint8(decodedOutput), uint8(BlockTimeForwarder.TimeComparison.EQ));
     }
 
     function testFuzz_forwardCall_accepts_arbitrary_logic(bytes32 logicRef) public view {

--- a/contracts/test/forwarders/BlockTimeForwarder.t.sol
+++ b/contracts/test/forwarders/BlockTimeForwarder.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {RiscZeroGroth16Verifier} from "@risc0-ethereum/groth16/RiscZeroGroth16Verifier.sol";
+import {RiscZeroVerifierRouter} from "@risc0-ethereum/RiscZeroVerifierRouter.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+import {BlockTimeForwarder} from "../../src/forwarders/BlockTimeForwarder.sol";
+import {ProtocolAdapter} from "../../src/ProtocolAdapter.sol";
+
+import {DeployRiscZeroContracts} from "../script/DeployRiscZeroContracts.s.sol";
+
+/// @title ForwarderBase
+/// @author Anoma Foundation, 2025
+/// @notice The forwarder contract returning whether a specific block time has passed.
+/// @custom:security-contact security@anoma.foundation
+
+contract BlockTimeForwarderTest is Test {
+    address internal constant _EMERGENCY_COMMITTEE = address(uint160(1));
+
+    ProtocolAdapter internal _pa;
+    BlockTimeForwarder internal _fwd;
+
+    function setUp() public virtual {
+        // Deploy RISC Zero contracts
+        (RiscZeroVerifierRouter router,, RiscZeroGroth16Verifier verifier) = new DeployRiscZeroContracts().run();
+
+        // Deploy the protocol adapter
+        _pa = new ProtocolAdapter(router, verifier.SELECTOR(), _EMERGENCY_COMMITTEE);
+
+        // Setup the block time forwarder
+        _fwd = new BlockTimeForwarder();
+    }
+
+    function test_forwardCall_returns_true_if_timestamp_is_in_the_past() public view {
+        // solhint-disable-next-line not-rely-on-time
+        bytes memory passedTimestampBytes = abi.encode(uint256(block.timestamp - 1));
+        bytes memory output = _fwd.forwardCall("", passedTimestampBytes);
+
+        assert(abi.decode(output, (bool)));
+    }
+
+    function test_forwardCall_returns_false_if_timestamp_is_in_the_future() public view {
+        bytes memory futureTimestampBytes = abi.encode(type(uint256).max);
+        bytes memory output = _fwd.forwardCall("", futureTimestampBytes);
+
+        assert(!abi.decode(output, (bool)));
+    }
+
+    function test_forwardCall_returns_false_if_timestamp_is_in_the_present() public view {
+        // solhint-disable-next-line not-rely-on-time
+        bytes memory presentTimestampBytes = abi.encode(block.timestamp);
+        bytes memory output = _fwd.forwardCall("", presentTimestampBytes);
+
+        assert(!abi.decode(output, (bool)));
+    }
+
+    function testFuzz_forwardCall_accepts_arbitrary_logic(bytes32 logicRef) public view {
+        _fwd.forwardCall(logicRef, abi.encode(1));
+    }
+}


### PR DESCRIPTION
Implements a forwarder returning the encoded `true` bytes iff a block time specified in the inputs has passed.