### PR TITLE
feat: optimize minimal merkle tree size computation

### DIFF
--- a/contracts/src/libs/MerkleTree.sol
+++ b/contracts/src/libs/MerkleTree.sol
@@ -195,7 +195,7 @@ library MerkleTree {
         treeDepth = 0;
 
         while (treeCapacity < leavesCount) {
-            treeCapacity *= 2;
+            treeCapacity <<= 1;
             ++treeDepth;
         }
 


### PR DESCRIPTION
Bitshift costs 3 gas, multiplication costs 5 gas.