### PR TITLE
doc: comment on `uint32` overflow assumptions

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -59,6 +59,8 @@ contract ProtocolAdapter is
         bytes packedLogicProofJournals;
     }
 
+    uint256 internal constant _MAX_ARRAY_LENGTH = type(uint32).max;
+
     RiscZeroVerifierRouter internal immutable _TRUSTED_RISC_ZERO_VERIFIER_ROUTER;
     bytes4 internal immutable _RISC_ZERO_VERIFIER_SELECTOR;
 
@@ -94,6 +96,7 @@ contract ProtocolAdapter is
     /// @inheritdoc IProtocolAdapter
     function execute(Transaction calldata transaction) external override nonReentrant whenNotPaused {
         uint256 actionCount = transaction.actions.length;
+
         uint256 tagCounter = 0;
 
         // Count the total number of tags in the transaction.
@@ -121,6 +124,7 @@ contract ProtocolAdapter is
             bytes32 actionTreeRoot = _computeActionTreeRoot(action);
 
             uint256 complianceUnitCount = action.complianceVerifierInputs.length;
+
             for (uint256 j = 0; j < complianceUnitCount; ++j) {
                 // Compliance Proof
                 Compliance.VerifierInput calldata complianceVerifierInput = action.complianceVerifierInputs[j];

--- a/contracts/src/libs/RiscZeroUtils.sol
+++ b/contracts/src/libs/RiscZeroUtils.sol
@@ -55,6 +55,8 @@ library RiscZeroUtils {
     /// @notice Converts the aggregation instance to the RISC Zero journal format.
     /// @param instance The aggregation instance.
     /// @return journal The resulting RISC Zero journal.
+    /// @dev `instance.logicRefs.length` can be assumed to fit into `uint32` because the block gas limit constitutes a
+    /// lower bound in practice.
     function toJournal(Aggregation.Instance memory instance) internal pure returns (bytes memory journal) {
         uint32 tagCount = uint32(instance.logicRefs.length);
 
@@ -77,6 +79,8 @@ library RiscZeroUtils {
     /// @notice Encodes a given payload for Risc0 Journal format.
     /// @param payload The payload.
     /// @return encoded The encoded bytes of the payload.
+    /// @dev `payload.length` and `blob.length` can be assumed to fit into `uint32` because the block gas limit
+    /// constitutes a lower bound in practice.
     function encodePayload(Logic.ExpirableBlob[] memory payload) internal pure returns (bytes memory encoded) {
         uint256 nBlobs = payload.length;
         encoded = abi.encodePacked(reverseByteOrderUint32(uint32(nBlobs)));
@@ -95,6 +99,8 @@ library RiscZeroUtils {
     /// words in little-endian order.
     /// @param journal The journal to encode.
     /// @return lengthEncodedJournal The length encoded journal.
+    /// @dev `journal.length` can be assumed to fit into `uint32` because the block gas limit constitutes a lower bound
+    /// in practice.
     function toJournalWithEncodedLength(bytes memory journal)
         internal
         pure


### PR DESCRIPTION
Arrays sizes resulting in an overflow error won't happen in practice. Hence, we don't need to introduce an explict custom error.
We could down-cast unchecked, but the gas savings seem not worth it.