### PR TITLE
Murisi/generalize tx generation

### DIFF
--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -240,6 +240,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
         _mockPa.execute(txn);
     }
 
+    function test_random_transactions_execute(TxGen.TransactionParams memory params) public {
+        _mockPa.execute(vm.transaction(_mockVerifier, params));
+    }
+
     function testFuzz_execute_reverts_on_pre_existing_nullifier(bool aggregated) public {
         TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({actionCount: 1, complianceUnitCount: 1});
 

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -48,6 +48,7 @@ library TxGen {
     struct TransactionParams {
         ActionParams[MAX_ACTIONS] actionParams;
         uint256 targetActionsLen;
+        bool isProofAggregated;
     }
 
     error ConsumedCreatedCountMismatch(uint256 nConsumed, uint256 nCreated);
@@ -409,6 +410,9 @@ library TxGen {
         }
         // Generate transaction
         txn = Transaction({actions: actions, deltaProof: proof, aggregationProof: ""});
+        if (params.isProofAggregated) {
+            txn = transactionAggregation(mockVerifier, txn);
+        }
     }
 
     function logicVerifierInput(


### PR DESCRIPTION
An attempt to try and generalize test transaction generation, the goal being to ultimately make ordinary and fuzz-based tests cover a larger transaction space. Amongst others, the following generalizations have been achieved:
* Each action automatically has differing compliance unit counts.
* Compliance units are now non-balancing by default.
* The value commitment randomness is now actually random.

This generalization was achieved by making tests accept more randomness from the Solidity fuzz tester, and transforming that into well-formed transactions. Confirmed that the protocol adapter executes all these additional variations successfully. This PR is also being used to check the latest proposed changes to the protocol adapter.