### PR TITLE
Murisi/execute tests rebased3 abrev with generalized generation

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -45,6 +45,7 @@ contract ProtocolAdapter is
     using RiscZeroUtils for Logic.VerifierInput;
     using Logic for Logic.VerifierInput[];
     using Delta for uint256[2];
+    using Compliance for Compliance.VerifierInput[];
 
     RiscZeroVerifierRouter internal immutable _TRUSTED_RISC_ZERO_VERIFIER_ROUTER;
     bytes4 internal immutable _RISC_ZERO_VERIFIER_SELECTOR;
@@ -366,16 +367,6 @@ contract ProtocolAdapter is
         pure
         returns (bytes32 root)
     {
-        bytes32[] memory actionTreeTags = new bytes32[](complianceUnitCount * 2);
-
-        // The order in which the tags are added to the tree is provided by the compliance units.
-        for (uint256 j = 0; j < complianceUnitCount; ++j) {
-            Compliance.VerifierInput calldata complianceVerifierInput = action.complianceVerifierInputs[j];
-
-            actionTreeTags[2 * j] = complianceVerifierInput.instance.consumed.nullifier;
-            actionTreeTags[(2 * j) + 1] = complianceVerifierInput.instance.created.commitment;
-        }
-
-        root = actionTreeTags.computeRoot();
+        root = action.complianceVerifierInputs.computeActionTreeTags(complianceUnitCount).computeRoot();
     }
 }

--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -136,7 +136,7 @@ contract ProtocolAdapter is
                 // Check the consumed resource.
                 // slither-disable-next-line reentrancy-benign
                 _processResourceLogicContext({
-                    input: action.logicVerifierInputs.lookup(nf),
+                    input: action.logicVerifierInputs[action.logicVerifierInputs.lookup(nf)],
                     logicRef: complianceVerifierInput.instance.consumed.logicRef,
                     actionTreeRoot: actionTreeRoot,
                     consumed: true
@@ -145,7 +145,7 @@ contract ProtocolAdapter is
                 // Check the created resource.
                 // slither-disable-next-line reentrancy-benign
                 _processResourceLogicContext({
-                    input: action.logicVerifierInputs.lookup(cm),
+                    input: action.logicVerifierInputs[action.logicVerifierInputs.lookup(cm)],
                     logicRef: complianceVerifierInput.instance.created.logicRef,
                     actionTreeRoot: actionTreeRoot,
                     consumed: false

--- a/contracts/src/proving/Compliance.sol
+++ b/contracts/src/proving/Compliance.sol
@@ -48,4 +48,24 @@ library Compliance {
     /// @notice The compliance verifying key.
     /// @dev The key is fixed as long as the compliance circuit binary is not changed.
     bytes32 internal constant _VERIFYING_KEY = 0x706468196fd92568220f5271e843c608126f7a8f204205d42ceef1f2c69f91df;
+
+    /// @notice Computes the action tree root of an action constituted by all its nullifiers and commitments.
+    /// @param complianceVerifierInputs Compliance verifier inputs.
+    /// @param complianceUnitCount The number of compliance units in the action.
+    /// @return actionTreeTags The action tree tags corresponding to the compliance verifier inputs.
+    function computeActionTreeTags(Compliance.VerifierInput[] calldata complianceVerifierInputs, uint256 complianceUnitCount)
+        internal
+        pure
+        returns (bytes32[] memory actionTreeTags)
+    {
+        actionTreeTags = new bytes32[](complianceUnitCount * 2);
+
+        // The order in which the tags are added to the tree is provided by the compliance units.
+        for (uint256 j = 0; j < complianceUnitCount; ++j) {
+            Compliance.VerifierInput calldata complianceVerifierInput = complianceVerifierInputs[j];
+
+            actionTreeTags[2 * j] = complianceVerifierInput.instance.consumed.nullifier;
+            actionTreeTags[(2 * j) + 1] = complianceVerifierInput.instance.created.commitment;
+        }
+    }
 }

--- a/contracts/src/proving/Compliance.sol
+++ b/contracts/src/proving/Compliance.sol
@@ -53,11 +53,10 @@ library Compliance {
     /// @param complianceVerifierInputs Compliance verifier inputs.
     /// @param complianceUnitCount The number of compliance units in the action.
     /// @return actionTreeTags The action tree tags corresponding to the compliance verifier inputs.
-    function computeActionTreeTags(Compliance.VerifierInput[] calldata complianceVerifierInputs, uint256 complianceUnitCount)
-        internal
-        pure
-        returns (bytes32[] memory actionTreeTags)
-    {
+    function computeActionTreeTags(
+        Compliance.VerifierInput[] calldata complianceVerifierInputs,
+        uint256 complianceUnitCount
+    ) internal pure returns (bytes32[] memory actionTreeTags) {
         actionTreeTags = new bytes32[](complianceUnitCount * 2);
 
         // The order in which the tags are added to the tree is provided by the compliance units.

--- a/contracts/src/proving/Logic.sol
+++ b/contracts/src/proving/Logic.sol
@@ -53,15 +53,11 @@ library Logic {
     /// @param list The list of verifier inputs.
     /// @param tag The tag to look up.
     /// @return foundElement The found `VerifierInput` element.
-    function lookup(VerifierInput[] calldata list, bytes32 tag)
-        internal
-        pure
-        returns (VerifierInput calldata foundElement)
-    {
+    function lookup(VerifierInput[] calldata list, bytes32 tag) internal pure returns (uint256) {
         uint256 len = list.length;
         for (uint256 i = 0; i < len; ++i) {
             if (list[i].tag == tag) {
-                return foundElement = list[i];
+                return i;
             }
         }
         revert TagNotFound(tag);

--- a/contracts/src/proving/Logic.sol
+++ b/contracts/src/proving/Logic.sol
@@ -52,12 +52,12 @@ library Logic {
     /// @notice Looks up a `VerifierInput` element from a list by its tag.
     /// @param list The list of verifier inputs.
     /// @param tag The tag to look up.
-    /// @return foundElement The found `VerifierInput` element.
-    function lookup(VerifierInput[] calldata list, bytes32 tag) internal pure returns (uint256) {
+    /// @return foundElementIdx The index of the found `VerifierInput` element.
+    function lookup(VerifierInput[] calldata list, bytes32 tag) internal pure returns (uint256 foundElementIdx) {
         uint256 len = list.length;
         for (uint256 i = 0; i < len; ++i) {
             if (list[i].tag == tag) {
-                return i;
+                return foundElementIdx = i;
             }
         }
         revert TagNotFound(tag);

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -246,6 +246,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
         _mockPa.execute(txn);
     }
 
+    function test_random_transactions_execute(TxGen.TransactionParams memory params) public {
+        _mockPa.execute(vm.transaction(_mockVerifier, params));
+    }
+
     function test_execute_reverts_on_pre_existing_nullifier() public {
         TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({actionCount: 1, complianceUnitCount: 1});
 

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -380,8 +380,8 @@ contract ProtocolAdapterMockVerifierTest is Test, ProtocolAdapter {
             truncatedProof[k] = proof[k];
         }
         complianceVerifierInputs[params.inputIdx].proof = truncatedProof;
-        // With a short proof, we expect failure
-        vm.expectRevert(address(_router));
+        // With a short proof, we expect an EVM error (which is message-less)
+        vm.expectRevert(bytes(""), address(_router));
         // Finally, execute the transaction to make sure that it fails
         this.execute(transaction);
     }

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -295,12 +295,14 @@ contract ProtocolAdapterMockVerifierTest is Test {
         NonExistingRootFailsParams memory params
     ) public {
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Compliance.VerifierInput[] memory complianceVerifierInputs =
             transaction.actions[params.actionIdx].complianceVerifierInputs;
         // Assume the proposed commitment tree root is not already contained
         vm.assume(!_mockPa.containsRoot(params.commitmentTreeRoot));
         // Wrap the compliance verifier input index into range
+        vm.assume(complianceVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
         // Finally assign the proposed commitment tree root into the transaction
         complianceVerifierInputs[params.inputIdx].instance.consumed.commitmentTreeRoot = params.commitmentTreeRoot;
@@ -328,10 +330,12 @@ contract ProtocolAdapterMockVerifierTest is Test {
         Transaction memory transaction = transactionCalldata;
         uint256 minProofLen = 4;
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Compliance.VerifierInput[] memory complianceVerifierInputs =
             transaction.actions[params.actionIdx].complianceVerifierInputs;
         // Wrap the compliance verifier input index into range
+        vm.assume(complianceVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
         // Finally truncate the compliance proof to below the minimum
         bytes calldata proof =
@@ -361,10 +365,12 @@ contract ProtocolAdapterMockVerifierTest is Test {
         vm.assume(params.proof.length >= minProofLen);
         vm.assume(address(_router.verifiers(bytes4(params.proof))) == address(0));
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Compliance.VerifierInput[] memory complianceVerifierInputs =
             transaction.actions[params.actionIdx].complianceVerifierInputs;
         // Wrap the compliance verifier input index into range
+        vm.assume(complianceVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
         // Finally, corrupt the verifier selector
         complianceVerifierInputs[params.inputIdx].proof = params.proof;
@@ -392,11 +398,13 @@ contract ProtocolAdapterMockVerifierTest is Test {
     ) public {
         Transaction memory transaction = transactionCalldata;
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Action calldata actionCalldata = transactionCalldata.actions[params.actionIdx];
         Action memory action = transaction.actions[params.actionIdx];
         Compliance.VerifierInput[] memory complianceVerifierInputs = action.complianceVerifierInputs;
         // Wrap the compliance verifier input index into range
+        vm.assume(complianceVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
         Compliance.VerifierInput memory complianceVerifierInput = complianceVerifierInputs[params.inputIdx];
         // Make sure that the planned corruption will change something
@@ -427,10 +435,12 @@ contract ProtocolAdapterMockVerifierTest is Test {
         GenericFailParams memory params
     ) public {
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Action memory action = transaction.actions[params.actionIdx];
         Compliance.VerifierInput[] memory complianceVerifierInputs = action.complianceVerifierInputs;
         // Wrap the compliance verifier input index into range
+        vm.assume(complianceVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
         // Now delete the array entry
         // Replace the target position with the last element
@@ -466,10 +476,12 @@ contract ProtocolAdapterMockVerifierTest is Test {
         GenericFailParams memory params
     ) public {
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Action memory action = transaction.actions[params.actionIdx];
         Logic.VerifierInput[] memory logicVerifierInputs = action.logicVerifierInputs;
         // Wrap the logic verifier input index into range
+        vm.assume(logicVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % logicVerifierInputs.length;
         // Now delete the array entry
         // Replace the target position with the last element
@@ -505,9 +517,11 @@ contract ProtocolAdapterMockVerifierTest is Test {
         MismatchingLogicRefsFailParams memory params
     ) public {
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Logic.VerifierInput[] memory logicVerifierInputs = transaction.actions[params.actionIdx].logicVerifierInputs;
         // Wrap the logic verifier input index into range
+        vm.assume(logicVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % logicVerifierInputs.length;
         // Now corrupt the logic reference
         vm.assume(logicVerifierInputs[params.inputIdx].verifyingKey != params.logicRef);
@@ -533,11 +547,13 @@ contract ProtocolAdapterMockVerifierTest is Test {
     ) public {
         Transaction memory transaction = transactionCalldata;
         // Wrap the action index into range
+        vm.assume(transaction.actions.length > 0);
         params.actionIdx = params.actionIdx % transaction.actions.length;
         Action calldata actionCalldata = transactionCalldata.actions[params.actionIdx];
         Action memory action = transaction.actions[params.actionIdx];
         Compliance.VerifierInput[] memory complianceVerifierInputs = action.complianceVerifierInputs;
         // Wrap the logic verifier input index into range
+        vm.assume(complianceVerifierInputs.length > 0);
         params.inputIdx = params.inputIdx % complianceVerifierInputs.length;
         Compliance.VerifierInput memory complianceVerifierInput = complianceVerifierInputs[params.inputIdx];
         bytes32 tag = params.consumed

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -37,12 +37,6 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     /// @notice The parameters necessary to make a failing mutation to a transaction
-    struct ShortProofFailsParams {
-        uint256 actionIdx;
-        uint256 inputIdx;
-    }
-
-    /// @notice The parameters necessary to make a failing mutation to a transaction
     struct UnknownSelectorFailsParams {
         uint256 actionIdx;
         uint256 inputIdx;
@@ -58,7 +52,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     /// @notice The parameters necessary to make a failing mutation to a transaction
-    struct MismatchingResourcesFailParams {
+    struct GenericFailParams {
         uint256 actionIdx;
         uint256 inputIdx;
     }
@@ -330,7 +324,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     /// @notice Make transaction fail by giving it a proof that's too short
-    function mutationTestExecuteShortProofFails(Transaction memory transaction, ShortProofFailsParams memory params)
+    function mutationTestExecuteShortProofFails(Transaction memory transaction, GenericFailParams memory params)
         public
     {
         uint256 minProofLen = 4;
@@ -357,7 +351,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     function testFuzz_execute_short_proof_fails(
         uint8 actionCount,
         uint8 complianceUnitCount,
-        ShortProofFailsParams memory params
+        GenericFailParams memory params
     ) public {
         TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
             actionCount: uint8(bound(actionCount, 1, 5)),
@@ -455,7 +449,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     /// @notice Make transaction fail by ensuring that it has less compliance verifier inputs
     function mutationTestExecuteMissingComplianceVerifierInputFail(
         Transaction memory transaction,
-        MismatchingResourcesFailParams memory params
+        GenericFailParams memory params
     ) public {
         // Wrap the action index into range
         params.actionIdx = params.actionIdx % transaction.actions.length;
@@ -487,7 +481,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     function testFuzz_execute_missing_compliance_verifier_input_fail(
         uint8 actionCount,
         uint8 complianceUnitCount,
-        MismatchingResourcesFailParams memory params
+        GenericFailParams memory params
     ) public {
         TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
             actionCount: uint8(bound(actionCount, 1, 5)),
@@ -501,7 +495,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     /// @notice Make transaction fail by ensuring that it has less logic verifier inputs
     function mutationTestExecuteMissingLogicVerifierInputFail(
         Transaction memory transaction,
-        MismatchingResourcesFailParams memory params
+        GenericFailParams memory params
     ) public {
         // Wrap the action index into range
         params.actionIdx = params.actionIdx % transaction.actions.length;
@@ -533,7 +527,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     function testFuzz_execute_missing_logic_verifier_input_fail(
         uint8 actionCount,
         uint8 complianceUnitCount,
-        MismatchingResourcesFailParams memory params
+        GenericFailParams memory params
     ) public {
         TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
             actionCount: uint8(bound(actionCount, 1, 5)),

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -314,17 +314,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
     /// @notice Test that transactions with nonexistent rotts fail
     function testFuzz_execute_non_existing_root_fails(
-        uint8 actionCount,
-        uint8 complianceUnitCount,
-        NonExistingRootFailsParams memory params
+        TxGen.TransactionParams memory txParams,
+        NonExistingRootFailsParams memory mutParams
     ) public {
-        TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            actionCount: uint8(bound(actionCount, 1, 5)),
-            complianceUnitCount: uint8(bound(complianceUnitCount, 1, 5))
-        });
-
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
-        mutationTestExecuteNonExistingRootFails(txn, params);
+        mutationTestExecuteNonExistingRootFails(vm.transaction(_mockVerifier, txParams), mutParams);
     }
 
     /// @notice Make transaction fail by giving it a proof that's too short
@@ -352,17 +345,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
     /// @notice Test that transactions with short proofs fail
     function testFuzz_execute_short_proof_fails(
-        uint8 actionCount,
-        uint8 complianceUnitCount,
-        GenericFailParams memory params
+        TxGen.TransactionParams memory txParams,
+        GenericFailParams memory mutParams
     ) public {
-        TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            actionCount: uint8(bound(actionCount, 1, 5)),
-            complianceUnitCount: uint8(bound(complianceUnitCount, 1, 5))
-        });
-
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
-        this.mutationTestExecuteShortProofFails(txn, params);
+        this.mutationTestExecuteShortProofFails(vm.transaction(_mockVerifier, txParams), mutParams);
     }
 
     /// @notice Make transaction fail by giving it an unknown selector.
@@ -393,17 +379,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
     /// @notice Test that transactions with unknown selectors fail
     function testFuzz_execute_unknown_selector_fails(
-        uint8 actionCount,
-        uint8 complianceUnitCount,
-        UnknownSelectorFailsParams memory params
+        TxGen.TransactionParams memory txParams,
+        UnknownSelectorFailsParams memory mutParams
     ) public {
-        TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            actionCount: uint8(bound(actionCount, 1, 5)),
-            complianceUnitCount: uint8(bound(complianceUnitCount, 1, 5))
-        });
-
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
-        mutationTestExecuteUnknownSelectorFails(txn, params);
+        mutationTestExecuteUnknownSelectorFails(vm.transaction(_mockVerifier, txParams), mutParams);
     }
 
     /// @notice Make transaction fail by ensuring unknown tag
@@ -436,17 +415,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
     /// @notice Test that transactions with unknown tags fail
     function testFuzz_execute_unknown_tag_fails(
-        uint8 actionCount,
-        uint8 complianceUnitCount,
-        UnknownTagFailsParams memory params
+        TxGen.TransactionParams memory txParams,
+        UnknownTagFailsParams memory mutParams
     ) public {
-        TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            actionCount: uint8(bound(actionCount, 1, 5)),
-            complianceUnitCount: uint8(bound(complianceUnitCount, 1, 5))
-        });
-
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
-        this.mutationTestExecuteUnknownTagFails(txn, params);
+        this.mutationTestExecuteUnknownTagFails(vm.transaction(_mockVerifier, txParams), mutParams);
     }
 
     /// @notice Make transaction fail by ensuring that it has less compliance verifier inputs
@@ -482,17 +454,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
     /// @notice Test that transactions with a missing compliance verifier input fail
     function testFuzz_execute_missing_compliance_verifier_input_fail(
-        uint8 actionCount,
-        uint8 complianceUnitCount,
-        GenericFailParams memory params
+        TxGen.TransactionParams memory txParams,
+        GenericFailParams memory mutParams
     ) public {
-        TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            actionCount: uint8(bound(actionCount, 1, 5)),
-            complianceUnitCount: uint8(bound(complianceUnitCount, 1, 5))
-        });
-
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
-        mutationTestExecuteMissingComplianceVerifierInputFail(txn, params);
+        mutationTestExecuteMissingComplianceVerifierInputFail(vm.transaction(_mockVerifier, txParams), mutParams);
     }
 
     /// @notice Make transaction fail by ensuring that it has less logic verifier inputs
@@ -528,17 +493,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
     /// @notice Test that transactions with a missing logic verifier input fail
     function testFuzz_execute_missing_logic_verifier_input_fail(
-        uint8 actionCount,
-        uint8 complianceUnitCount,
-        GenericFailParams memory params
+        TxGen.TransactionParams memory txParams,
+        GenericFailParams memory mutParams
     ) public {
-        TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            actionCount: uint8(bound(actionCount, 1, 5)),
-            complianceUnitCount: uint8(bound(complianceUnitCount, 1, 5))
-        });
-
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
-        mutationTestExecuteMissingLogicVerifierInputFail(txn, params);
+        mutationTestExecuteMissingLogicVerifierInputFail(vm.transaction(_mockVerifier, txParams), mutParams);
     }
 
     /// @notice Make transaction fail by making logic reference mismatch
@@ -562,17 +520,10 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
     /// @notice Test that transactions with mismatching logic references fail
     function testFuzz_execute_mismatching_logic_refs_fail(
-        uint8 actionCount,
-        uint8 complianceUnitCount,
-        MismatchingLogicRefsFailParams memory params
+        TxGen.TransactionParams memory txParams,
+        MismatchingLogicRefsFailParams memory mutParams
     ) public {
-        TxGen.ActionConfig[] memory configs = TxGen.generateActionConfigs({
-            actionCount: uint8(bound(actionCount, 1, 5)),
-            complianceUnitCount: uint8(bound(complianceUnitCount, 1, 5))
-        });
-
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
-        mutationTestExecuteMismatchingLogicRefsFail(txn, params);
+        mutationTestExecuteMismatchingLogicRefsFail(vm.transaction(_mockVerifier, txParams), mutParams);
     }
 
     /// @notice Make transaction fail by ensuring that one of its forwarder call outputs mismatch.


### PR DESCRIPTION
Based on the same code as #341 . This PR is an attempt to integrate generalized transaction generation with the property tests that induce transaction failure. The end goal being to generate a larger range of failing transactions and discover potential issues. Specifically, the following approach is taken:
* Use #341 to generate a maximally general transaction that would actually successfully execute
* Make exactly one mutation/modification to this transaction so that it will fail in a known way
* Execute this mutated transaction and check that it fails in exactly that known way
* In pseudo-code, the tests now look like `mutationTestExecuteNonExistingRootFails(vm.transaction(_mockVerifier, txParams), mutParams);`

Currently in `main` we only mutate a more limited set of transactions where actions all have the same number of compliance units (amongst other minor restrictions). This draft is only for checking/demonstrating whether this idea is workable and for testing the latest proposed changes to the protocol adapter. This PR would have to be rebased for actual use.