### PR TITLE
test: generate aggregated transactions and fuzz aggregation

### DIFF
--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -37,6 +37,7 @@ library TxGen {
 
     error ConsumedCreatedCountMismatch(uint256 nConsumed, uint256 nCreated);
     error NonExistingTag(bytes32 tag);
+    error TransactionTagCountMismatch();
 
     function complianceVerifierInput(
         VmSafe vm,
@@ -370,6 +371,11 @@ library TxGen {
     {
         uint256 n = 0;
         bytes32[] memory logicRefs = collectLogicRefs(txn.actions);
+
+        if (countComplianceUnits(txn.actions) * 2 != logicRefs.length) {
+            revert TransactionTagCountMismatch();
+        }
+
         Compliance.Instance[] memory complianceInstances = new Compliance.Instance[](logicRefs.length / 2);
         Logic.Instance[] memory logicInstances = new Logic.Instance[](logicRefs.length);
         for (uint256 i = 0; i < txn.actions.length; ++i) {

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -6,6 +6,7 @@ import {VmSafe} from "forge-std/Vm.sol";
 import {MerkleTree} from "./../../src/libs/MerkleTree.sol";
 import {RiscZeroUtils} from "./../../src/libs/RiscZeroUtils.sol";
 import {SHA256} from "./../../src/libs/SHA256.sol";
+import {Aggregation} from "./../../src/proving/Aggregation.sol";
 import {Compliance} from "./../../src/proving/Compliance.sol";
 import {Delta} from "./../../src/proving/Delta.sol";
 import {Logic} from "./../../src/proving/Logic.sol";
@@ -14,6 +15,7 @@ import {DeltaGen} from "./../proofs/DeltaProof.t.sol";
 
 library TxGen {
     using MerkleTree for bytes32[];
+    using RiscZeroUtils for Aggregation.Instance;
     using RiscZeroUtils for Compliance.Instance;
     using RiscZeroUtils for Logic.Instance;
     using Logic for Logic.VerifierInput[];
@@ -189,10 +191,12 @@ library TxGen {
         action = createAction({vm: vm, mockVerifier: mockVerifier, consumed: consumed, created: created});
     }
 
-    function transaction(VmSafe vm, RiscZeroMockVerifier mockVerifier, ResourceLists[] memory actionResources)
-        internal
-        returns (Transaction memory txn)
-    {
+    function transaction(
+        VmSafe vm,
+        RiscZeroMockVerifier mockVerifier,
+        ResourceLists[] memory actionResources,
+        bool isProofAggregated
+    ) internal returns (Transaction memory txn) {
         Action[] memory actions = new Action[](actionResources.length);
 
         for (uint256 i = 0; i < actionResources.length; ++i) {
@@ -224,12 +228,19 @@ library TxGen {
             );
         }
         txn = Transaction({actions: actions, deltaProof: proof, aggregationProof: ""});
+
+        if (isProofAggregated) {
+            txn = transactionAggregation(mockVerifier, txn);
+        }
     }
 
-    function transaction(VmSafe vm, RiscZeroMockVerifier mockVerifier, bytes32 nonce, ActionConfig[] memory configs)
-        internal
-        returns (Transaction memory txn, bytes32 updatedNonce)
-    {
+    function transaction(
+        VmSafe vm,
+        RiscZeroMockVerifier mockVerifier,
+        bytes32 nonce,
+        ActionConfig[] memory configs,
+        bool isProofAggregated
+    ) internal returns (Transaction memory txn, bytes32 updatedNonce) {
         updatedNonce = nonce;
 
         Action[] memory actions = new Action[](configs.length);
@@ -256,6 +267,24 @@ library TxGen {
             );
         }
         txn = Transaction({actions: actions, deltaProof: proof, aggregationProof: ""});
+
+        if (isProofAggregated) {
+            txn = transactionAggregation(mockVerifier, txn);
+        }
+    }
+
+    function transactionAggregation(RiscZeroMockVerifier mockVerifier, Transaction memory txn)
+        internal
+        view
+        returns (Transaction memory aggregatedTxn)
+    {
+        aggregatedTxn = txn;
+        Aggregation.Instance memory instance = aggregatedInstanceGeneration(txn);
+
+        bytes32 digest = sha256(instance.toJournal());
+
+        aggregatedTxn.aggregationProof =
+            mockVerifier.mockProve({imageId: Aggregation._VERIFYING_KEY, journalDigest: digest}).seal;
     }
 
     function logicVerifierInput(
@@ -335,6 +364,45 @@ library TxGen {
         }
     }
 
+    function aggregatedInstanceGeneration(Transaction memory txn)
+        internal
+        pure
+        returns (Aggregation.Instance memory aggregationInstance)
+    {
+        uint256 n = 0;
+        bytes32[] memory logicRefs = collectLogicRefs(txn.actions);
+        Compliance.Instance[] memory complianceInstances = new Compliance.Instance[](logicRefs.length / 2);
+        Logic.Instance[] memory logicInstances = new Logic.Instance[](logicRefs.length);
+        for (uint256 i = 0; i < txn.actions.length; ++i) {
+            for (uint256 j = 0; j < txn.actions[i].complianceVerifierInputs.length; ++j) {
+                Compliance.VerifierInput memory complianceUnit = txn.actions[i].complianceVerifierInputs[j];
+                complianceInstances[n / 2] = complianceUnit.instance;
+                bytes32 actionTreeRoot = computeActionTreeRoot(txn.actions[i]);
+
+                {
+                    {
+                        uint256 nullifierIndex = getTagIndex(txn.actions[i], complianceUnit.instance.consumed.nullifier);
+                        logicInstances[n++] =
+                            Logic.toInstance(txn.actions[i].logicVerifierInputs[nullifierIndex], actionTreeRoot, true);
+                    }
+
+                    {
+                        uint256 commitmentIndex =
+                            getTagIndex(txn.actions[i], complianceUnit.instance.created.commitment);
+                        logicInstances[n++] =
+                            Logic.toInstance(txn.actions[i].logicVerifierInputs[commitmentIndex], actionTreeRoot, false);
+                    }
+                }
+            }
+        }
+
+        aggregationInstance = Aggregation.Instance({
+            logicRefs: logicRefs,
+            complianceInstances: complianceInstances,
+            logicInstances: logicInstances
+        });
+    }
+
     function mockResource(bytes32 nonce, bytes32 logicRef, bytes32 labelRef, uint128 quantity)
         internal
         pure
@@ -390,5 +458,21 @@ library TxGen {
 
     function initialRoot() internal pure returns (bytes32 root) {
         root = SHA256.EMPTY_HASH;
+    }
+
+    function computeActionTreeRoot(Action memory action) internal pure returns (bytes32 root) {
+        uint256 complianceUnitCount = action.complianceVerifierInputs.length;
+
+        bytes32[] memory actionTreeTags = new bytes32[](complianceUnitCount * 2);
+
+        // The order in which the tags are added to the tree is provided by the compliance units.
+        for (uint256 j = 0; j < complianceUnitCount; ++j) {
+            Compliance.VerifierInput memory complianceUnit = action.complianceVerifierInputs[j];
+
+            actionTreeTags[2 * j] = complianceUnit.instance.consumed.nullifier;
+            actionTreeTags[(2 * j) + 1] = complianceUnit.instance.created.commitment;
+        }
+
+        root = actionTreeTags.computeRoot();
     }
 }

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -379,18 +379,15 @@ library TxGen {
                 bytes32 actionTreeRoot = computeActionTreeRoot(txn.actions[i]);
 
                 {
-                    {
-                        uint256 nullifierIndex = getTagIndex(txn.actions[i], complianceUnit.instance.consumed.nullifier);
-                        logicInstances[n++] =
-                            Logic.toInstance(txn.actions[i].logicVerifierInputs[nullifierIndex], actionTreeRoot, true);
-                    }
+                    uint256 nullifierIndex = getTagIndex(txn.actions[i], complianceUnit.instance.consumed.nullifier);
+                    logicInstances[n++] =
+                        Logic.toInstance(txn.actions[i].logicVerifierInputs[nullifierIndex], actionTreeRoot, true);
+                }
 
-                    {
-                        uint256 commitmentIndex =
-                            getTagIndex(txn.actions[i], complianceUnit.instance.created.commitment);
-                        logicInstances[n++] =
-                            Logic.toInstance(txn.actions[i].logicVerifierInputs[commitmentIndex], actionTreeRoot, false);
-                    }
+                {
+                    uint256 commitmentIndex = getTagIndex(txn.actions[i], complianceUnit.instance.created.commitment);
+                    logicInstances[n++] =
+                        Logic.toInstance(txn.actions[i].logicVerifierInputs[commitmentIndex], actionTreeRoot, false);
                 }
             }
         }

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -279,12 +279,11 @@ library TxGen {
         returns (Transaction memory aggregatedTxn)
     {
         aggregatedTxn = txn;
-        Aggregation.Instance memory instance = aggregatedInstanceGeneration(txn);
 
-        bytes32 digest = sha256(instance.toJournal());
-
-        aggregatedTxn.aggregationProof =
-            mockVerifier.mockProve({imageId: Aggregation._VERIFYING_KEY, journalDigest: digest}).seal;
+        aggregatedTxn.aggregationProof = mockVerifier.mockProve({
+            imageId: Aggregation._VERIFYING_KEY,
+            journalDigest: sha256(aggregatedInstanceGeneration(txn).toJournal())
+        }).seal;
     }
 
     function logicVerifierInput(


### PR DESCRIPTION
Provide test generation of aggregated transactions and fuzz execution tests to make sure usual semantics are still preserved.