### PR TITLE
refactor: reduce code and move tag-related methods into library

### DIFF
--- a/contracts/src/libs/TagUtils.sol
+++ b/contracts/src/libs/TagUtils.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Compliance} from "../proving/Compliance.sol";
+import {Transaction, Action} from "../Types.sol";
+
+/// @title TagUtils
+/// @author Anoma Foundation, 2025
+/// @notice A library containing utility function to handle tags.
+/// @custom:security-contact security@anoma.foundation
+library TagUtils {
+    using TagUtils for Action;
+
+    error TagCountMismatch(uint256 expected, uint256 actual);
+
+    /// @notice Collects the resource tags in an action as ordered by the compliance units.
+    /// @param action The action to collect the tags frm.
+    /// @return tags The collected tags.
+    function collectTags(Action calldata action) internal pure returns (bytes32[] memory tags) {
+        uint256 complianceUnitCount = action.complianceVerifierInputs.length;
+
+        tags = new bytes32[](complianceUnitCount * 2);
+
+        for (uint256 i = 0; i < complianceUnitCount; ++i) {
+            Compliance.Instance calldata instance = action.complianceVerifierInputs[i].instance;
+            tags[(i * 2)] = instance.consumed.nullifier;
+            tags[(i * 2) + 1] = instance.created.commitment;
+        }
+    }
+
+    /// @notice Counts the resource tags in a transaction and checks for each action that the tag count within is
+    /// twice the number of compliance units.
+    /// @param transaction The transaction to count and check the tags for.
+    /// @return tagCount The computed tag count.
+    function countTags(Transaction calldata transaction) internal pure returns (uint256 tagCount) {
+        uint256 actionCount = transaction.actions.length;
+
+        // Count the total number of tags in the transaction.
+        for (uint256 i = 0; i < actionCount; ++i) {
+            tagCount += transaction.actions[i].checkedActionTagCount();
+        }
+    }
+
+    /// @notice Checks and returns the action tag count that must be twice the number of compliance units.
+    /// @param action The action to check and return the tag count for.
+    /// @return actionTagCount The checked action tag count.
+    function checkedActionTagCount(Action calldata action) internal pure returns (uint256 actionTagCount) {
+        uint256 complianceUnitCount = action.complianceVerifierInputs.length;
+        actionTagCount = action.logicVerifierInputs.length;
+
+        // Check that the tag count in the action and compliance units matches.
+        if (actionTagCount != complianceUnitCount * 2) {
+            revert TagCountMismatch({expected: actionTagCount, actual: complianceUnitCount * 2});
+        }
+    }
+}

--- a/contracts/test/ProtocolAdapterMock.t.sol
+++ b/contracts/test/ProtocolAdapterMock.t.sol
@@ -10,6 +10,7 @@ import {Test, Vm} from "forge-std/Test.sol";
 import {IProtocolAdapter} from "../src/interfaces/IProtocolAdapter.sol";
 import {MerkleTree} from "../src/libs/MerkleTree.sol";
 import {SHA256} from "../src/libs/SHA256.sol";
+import {TagUtils} from "../src/libs/TagUtils.sol";
 
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 import {Compliance} from "../src/proving/Compliance.sol";
@@ -270,8 +271,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         uint256 expectedResourceCount = txn.actions[0].complianceVerifierInputs.length * 2;
 
         vm.expectRevert(
-            abi.encodeWithSelector(ProtocolAdapter.TagCountMismatch.selector, 0, expectedResourceCount),
-            address(_mockPa)
+            abi.encodeWithSelector(TagUtils.TagCountMismatch.selector, 0, expectedResourceCount), address(_mockPa)
         );
 
         _mockPa.execute(txn);
@@ -443,7 +443,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         // Expect revert based on wrong resource computation.
         vm.expectRevert(
             abi.encodeWithSelector(
-                ProtocolAdapter.TagCountMismatch.selector,
+                TagUtils.TagCountMismatch.selector,
                 txn.actions[actionIndex].logicVerifierInputs.length,
                 uint256(fakeComplianceCount) * 2
             )
@@ -479,7 +479,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         // Expect revert based on wrong resource computation.
         vm.expectRevert(
             abi.encodeWithSelector(
-                ProtocolAdapter.TagCountMismatch.selector,
+                TagUtils.TagCountMismatch.selector,
                 fakeLogicVerifierCount,
                 txn.actions[actionIndex].complianceVerifierInputs.length * 2
             )

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -5,6 +5,7 @@ import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.so
 import {VmSafe} from "forge-std/Vm.sol";
 import {MerkleTree} from "./../../src/libs/MerkleTree.sol";
 import {RiscZeroUtils} from "./../../src/libs/RiscZeroUtils.sol";
+
 import {SHA256} from "./../../src/libs/SHA256.sol";
 import {Aggregation} from "./../../src/proving/Aggregation.sol";
 import {Compliance} from "./../../src/proving/Compliance.sol";
@@ -339,14 +340,16 @@ library TxGen {
         }
     }
 
+    /// @dev This function is a duplicated from `TagUtils.sol` with the difference that it uses `memory`.
     function collectTags(Action memory action) internal pure returns (bytes32[] memory tags) {
         uint256 complianceUnitCount = action.complianceVerifierInputs.length;
 
         tags = new bytes32[](complianceUnitCount * 2);
 
         for (uint256 i = 0; i < complianceUnitCount; ++i) {
-            tags[i * 2] = action.complianceVerifierInputs[i].instance.consumed.nullifier;
-            tags[(i * 2) + 1] = action.complianceVerifierInputs[i].instance.created.commitment;
+            Compliance.Instance memory instance = action.complianceVerifierInputs[i].instance;
+            tags[(i * 2)] = instance.consumed.nullifier;
+            tags[(i * 2) + 1] = instance.created.commitment;
         }
     }
 

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -5,7 +5,6 @@ import {RiscZeroMockVerifier} from "@risc0-ethereum/test/RiscZeroMockVerifier.so
 import {VmSafe} from "forge-std/Vm.sol";
 import {MerkleTree} from "./../../src/libs/MerkleTree.sol";
 import {RiscZeroUtils} from "./../../src/libs/RiscZeroUtils.sol";
-
 import {SHA256} from "./../../src/libs/SHA256.sol";
 import {Aggregation} from "./../../src/proving/Aggregation.sol";
 import {Compliance} from "./../../src/proving/Compliance.sol";


### PR DESCRIPTION
This PR refactors and moves tag-related methods into a dedicated `TagUtils.sol` library.

This reduces the overall lines of code, in particular in the PA, and allows us to write `bytes32 actionTreeRoot = action.collectTags().computeRoot();`.
