### PR TITLE
doc: add implementation documentation tying the execution to the spec

### DIFF
--- a/contracts/src/proving/Compliance.sol
+++ b/contracts/src/proving/Compliance.sol
@@ -47,5 +47,7 @@ library Compliance {
 
     /// @notice The compliance verifying key.
     /// @dev The key is fixed as long as the compliance circuit binary is not changed.
+    /// The compliance circuit should ensure that the created resources use the consumed resource's nullifier
+    /// as nonce.
     bytes32 internal constant _VERIFYING_KEY = 0x2652d58ac2fba40aa5811adf2cee2314c4dc2168ae93dab069c8eb7496107c99;
 }


### PR DESCRIPTION
This PR ensures that we explicitly mention the assumption on the compliance circuit we are using, as well as how we ensure partition of the action by compliance units.