### PR TITLE
Hard-code deployment addresses into protocol adapter binding code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,6 +2783,7 @@ version = "1.0.0-rc.2"
 dependencies = [
  "alloy",
  "arm",
+ "reqwest",
  "serde",
  "tokio",
 ]

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -14,6 +14,9 @@ alloy = { version = "1.0.30", features = ["full", "eip712", "node-bindings"] }
 tokio = { version = "1.44", features = ["rt-multi-thread"] }
 serde = { version = "1.0.197", default-features = false }
 
+[dev-dependencies]
+reqwest = { version = "0.12", default-features = false }
+
 [features]
 # These features are enabled to generate test transactions and is not required for using the library.
 arm_risc0_dev = ["arm_risc0/groth16_prover", "arm_risc0/bonsai"]

--- a/simple_transfer/src/erc20_forwarder.rs
+++ b/simple_transfer/src/erc20_forwarder.rs
@@ -1,13 +1,13 @@
 use crate::keychain::KeyChain;
-use crate::permit2::{permit_witness_transfer_from_signature, Permit2Data};
+use crate::permit2::{Permit2Data, permit_witness_transfer_from_signature};
 use alloy::hex;
-use alloy::primitives::{address, Address, B256, U256};
+use alloy::primitives::{Address, B256, U256, address};
 use alloy::signers::local::PrivateKeySigner;
+use arm_risc0::Digest as ArmDigest;
 use arm_risc0::action_tree::MerkleTree;
 use arm_risc0::compliance::INITIAL_ROOT;
 use arm_risc0::evm::CallType;
 use arm_risc0::merkle_path::MerklePath;
-use arm_risc0::Digest as ArmDigest;
 use evm_protocol_adapter_bindings::conversion::ProtocolAdapter;
 use sha2::{Digest, Sha256};
 use simple_transfer_app::burn::construct_burn_tx;

--- a/simple_transfer/src/keychain.rs
+++ b/simple_transfer/src/keychain.rs
@@ -1,5 +1,5 @@
 use arm_risc0::authorization::{AuthorizationSigningKey, AuthorizationVerifyingKey};
-use arm_risc0::encryption::{random_keypair, AffinePoint, SecretKey};
+use arm_risc0::encryption::{AffinePoint, SecretKey, random_keypair};
 use arm_risc0::nullifier_key::{NullifierKey, NullifierKeyCommitment};
 
 #[allow(dead_code)]

--- a/simple_transfer/src/permit2.rs
+++ b/simple_transfer/src/permit2.rs
@@ -1,5 +1,5 @@
-use alloy::primitives::{address, Address, Signature, B256, U256};
-use alloy::signers::{local::PrivateKeySigner, Signer};
+use alloy::primitives::{Address, B256, Signature, U256, address};
+use alloy::signers::{Signer, local::PrivateKeySigner};
 use alloy::sol;
 use alloy::sol_types::eip712_domain;
 


### PR DESCRIPTION
This PR simply hard-codes protocol adapter contract deployment addresses into the protocol adapter's Rust bindings as public constants. Furthermore, to determine/demonstrate the actual ease/difficulty of directly using `alloy-rs` functions, this PR separates the logic to extract the private key signer and Alchemy API key from environment variables from the logic actually required to connect/bind to a deployed contract. The actual connection logic uses 4 lines of code.

A comment on versioning issues: given that the bindings live in the same repository as the protocol adapter smart contract, it should be easy to keep the deployment addresses synchronized with the smart contract versions. And at least initially, users of these bindings can simply use the public constant address associated with their target network. This seems to have been the approach taken by Uniswap (though they just hard-code a single factory address) and Boundless.

Some context: these changes came out of discussions about the difficulty of maintaining Elixir bindings for `arm-risc0` in the presence of an `evm-protocol-adapter` crate that also depends upon a version of `arm-risc0`. Further investigation there seems to indicate that bindigs and `arm-risc0` patching issues can most-likely be resolved without making changes to the `evm-protocol-adapter` bindings. This is why the change in this PR is very small.

https://github.com/shuhuiluo/uniswap-v3-sdk-rs/blob/c61b2905e83f2c20b25faa00c61067d92da7bb37/src/constants.rs#L7
https://github.com/boundless-xyz/boundless/blob/7e0245dc20420d1b990e63599ae770d43eeb5fb2/crates/boundless-market/src/deployments.rs#L109