### PR TITLE
Safe Merkle Proof Verification

### DIFF
--- a/contracts/src/interfaces/ICommitmentTree.sol
+++ b/contracts/src/interfaces/ICommitmentTree.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Resource} from "../Types.sol";
+
 /// @title ICommitmentTree
 /// @author Anoma Foundation, 2025
 /// @notice The interface of the commitment tree contract.
@@ -42,12 +44,12 @@ interface ICommitmentTree {
 
     /// @notice Verifies that a Merkle path (proof) and a commitment leaf reproduce a given root.
     /// @param commitmentTreeRoot The commitment tree root to reproduce.
-    /// @param commitment The commitment leaf to proof inclusion in the tree for.
+    /// @param resource The resource whose commitment leaf we prove inclusion in the tree for.
     /// @param path The siblings constituting the path from the leaf to the root.
     /// @param directionBits The direction bits indicating whether the siblings are left of right.
     function verifyMerkleProof(
         bytes32 commitmentTreeRoot,
-        bytes32 commitment,
+        Resource calldata resource,
         bytes32[] calldata path,
         uint256 directionBits
     ) external view;

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -429,6 +429,24 @@ library TxGen {
         });
     }
 
+    function defaultResource() internal pure returns (Resource memory resource) {
+        resource = Resource({
+                // forge-lint: disable-next-line(unsafe-typecast)
+            logicRef: bytes32(""),
+            // forge-lint: disable-next-line(unsafe-typecast)
+            labelRef: bytes32(""),
+            // forge-lint: disable-next-line(unsafe-typecast)
+            valueRef: bytes32(""),
+            // forge-lint: disable-next-line(unsafe-typecast)
+            nullifierKeyCommitment: bytes32(""),
+            quantity: 0,
+            // forge-lint: disable-next-line(unsafe-typecast)
+            nonce: bytes32(""),
+            randSeed: 0,
+            ephemeral: true
+        });
+    }
+
     function getTagIndex(Action memory action, bytes32 tag) internal pure returns (uint256 index) {
         uint256 logicVerifierInputCount = action.logicVerifierInputs.length;
 
@@ -442,7 +460,19 @@ library TxGen {
     }
 
     function commitment(Resource memory resource) internal pure returns (bytes32 hash) {
-        hash = sha256(abi.encode(resource));
+        bytes17 personalization = 0x52495343305f457870616e645365656401;
+        hash = sha256(
+            abi.encodePacked(
+                resource.logicRef,
+                resource.labelRef,
+                resource.quantity,
+                resource.valueRef,
+                resource.ephemeral,
+                resource.nonce,
+                resource.nullifierKeyCommitment,
+                sha256(abi.encodePacked(personalization, resource.randSeed, resource.nonce))
+            )
+        );
     }
 
     function nullifier(Resource memory resource, bytes32 nullifierKey) internal pure returns (bytes32 hash) {


### PR DESCRIPTION
Makes `verifyMerklePath` accept a resource datatype rather than a bytes32 making it statistically impossible to conduct a second-preimage attack.

This does require us testing that our implementation of the commitment generation is a correct one.