### PR TITLE
chore: use solc 0.8.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: forge --version
 
       - name: Run Forge Lint
-        run: forge lint --deny-warnings
+        run: forge lint --deny warnings
         working-directory: ./contracts
 
       - name: Install Bun

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -18,9 +18,9 @@ remappings = [
 cbor_metadata = false
 bytecode_hash = "none"
 
-solc = "0.8.30"
+solc = "0.8.31"
 auto_detect_solc = false
-evm_version = "prague"
+evm_version = "osaka"
 gas_reports = [
     "ProtocolAdapter",
     "CommitmentTreeMock",


### PR DESCRIPTION
This has to wait for foundry to release a new version (see https://github.com/foundry-rs/foundry/issues/12841) as well as `forge-std` to get rid of deprecated memory-safe-assembly warnings

```
Warning (2424): Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.
```