### PR TITLE
refactor: extract pure computation in favor of code smell reduction

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -298,7 +298,7 @@ contract ProtocolAdapter is
         // Phase 5: Event emission
         _emitAppDataBlobs(input);
 
-        updatedVars = vars;
+        return vars;
     }
 
     /// @notice Processes forwarder calls by verifying and executing them.


### PR DESCRIPTION
- Extract pure computation in `_validateAndComputeLogicTransition` to separate validation logic from side effects in `_processLogic`
- Eliminate code duplication in `_emitAppDataBlobs` by introducing `_emitFilteredBlobs` helper with `PayloadType` enum
- Add explicit phase comments in `_processLogic` to clarify execution flow

I'm curious whether this has any implications for gas metering, but at least I expect the bytecode resulting from this change to be smaller, which is good, right? 
- Also, I couldn't test this thoroughly, as I have an issue with Alchemy, which I plan to check during the week.