### PR TITLE
refactor: move `toStorage` method into `Parsing` library

### DIFF
--- a/contracts/test/ProtocolAdapter.t.sol
+++ b/contracts/test/ProtocolAdapter.t.sol
@@ -20,6 +20,7 @@ import {Parsing} from "./libs/Parsing.sol";
 import {DeployRiscZeroContracts} from "./script/DeployRiscZeroContracts.s.sol";
 
 contract ProtocolAdapterTest is Test {
+    using Parsing for Transaction;
     using Parsing for Vm;
     using SemVerLib for bytes32;
 
@@ -42,7 +43,7 @@ contract ProtocolAdapterTest is Test {
 
         _pa = new ProtocolAdapter(_router, _verifierSelector, _EMERGENCY_COMMITTEE);
 
-        _exampleTx = vm.parseTransaction("test/examples/transactions/test_tx_reg_01_01.bin");
+        _exampleTx.toStorage(vm.parseTransaction("test/examples/transactions/test_tx_reg_01_01.bin"));
     }
 
     function test_constructor_reverts_on_address_zero_router() public {

--- a/contracts/test/libs/Parsing.sol
+++ b/contracts/test/libs/Parsing.sol
@@ -3,9 +3,78 @@ pragma solidity ^0.8.30;
 
 import {Vm} from "forge-std-1.14.0/src/Vm.sol";
 
-import {Transaction} from "../../src/Types.sol";
+import {Compliance} from "../../src/libs/proving/Compliance.sol";
+import {Logic} from "../../src/libs/proving/Logic.sol";
+import {Transaction, Action} from "../../src/Types.sol";
 
 library Parsing {
+    function toStorage(Transaction storage stored, Transaction memory parsed) internal {
+        stored.deltaProof = parsed.deltaProof;
+        stored.aggregationProof = parsed.aggregationProof;
+
+        uint256 actionCount = parsed.actions.length;
+
+        for (uint256 i = 0; i < actionCount; ++i) {
+            stored.actions.push();
+            Action storage storedAction = stored.actions[i];
+            Action memory parsedAction = parsed.actions[i];
+
+            uint256 logicProofCount = parsedAction.logicVerifierInputs.length;
+            for (uint256 j = 0; j < logicProofCount; ++j) {
+                storedAction.logicVerifierInputs.push();
+                Logic.VerifierInput storage storedLp = storedAction.logicVerifierInputs[j];
+                Logic.VerifierInput memory parsedLp = parsedAction.logicVerifierInputs[j];
+
+                storedLp.tag = parsedLp.tag;
+                storedLp.verifyingKey = parsedLp.verifyingKey;
+                storedLp.proof = parsedLp.proof;
+
+                uint256 payloadLength = parsedLp.appData.resourcePayload.length;
+                for (uint256 k = 0; k < payloadLength; ++k) {
+                    storedLp.appData.resourcePayload.push();
+                    storedLp.appData.resourcePayload[k] = parsedLp.appData.resourcePayload[k];
+                }
+
+                payloadLength = parsedLp.appData.discoveryPayload.length;
+                for (uint256 k = 0; k < payloadLength; ++k) {
+                    storedLp.appData.discoveryPayload.push();
+                    storedLp.appData.discoveryPayload[k] = parsedLp.appData.discoveryPayload[k];
+                }
+
+                payloadLength = parsedLp.appData.externalPayload.length;
+                for (uint256 k = 0; k < payloadLength; ++k) {
+                    storedLp.appData.externalPayload.push();
+                    storedLp.appData.externalPayload[k] = parsedLp.appData.externalPayload[k];
+                }
+
+                payloadLength = parsedLp.appData.applicationPayload.length;
+                for (uint256 k = 0; k < payloadLength; ++k) {
+                    storedLp.appData.applicationPayload.push();
+                    storedLp.appData.applicationPayload[k] = parsedLp.appData.applicationPayload[k];
+                }
+            }
+
+            uint256 complianceUnitCount = parsedAction.complianceVerifierInputs.length;
+            for (uint256 j = 0; j < complianceUnitCount; ++j) {
+                storedAction.complianceVerifierInputs.push();
+                Compliance.VerifierInput storage storedCu = storedAction.complianceVerifierInputs[j];
+                Compliance.VerifierInput memory parsedCu = parsedAction.complianceVerifierInputs[j];
+
+                storedCu.proof = parsedCu.proof;
+
+                storedCu.instance.consumed.nullifier = parsedCu.instance.consumed.nullifier;
+                storedCu.instance.consumed.logicRef = parsedCu.instance.consumed.logicRef;
+                storedCu.instance.consumed.commitmentTreeRoot = parsedCu.instance.consumed.commitmentTreeRoot;
+
+                storedCu.instance.created.commitment = parsedCu.instance.created.commitment;
+                storedCu.instance.created.logicRef = parsedCu.instance.created.logicRef;
+
+                storedCu.instance.unitDeltaX = parsedCu.instance.unitDeltaX;
+                storedCu.instance.unitDeltaY = parsedCu.instance.unitDeltaY;
+            }
+        }
+    }
+
     function parseTransaction(Vm vm, string memory path) internal view returns (Transaction memory txn) {
         string memory fullPath = string.concat(vm.projectRoot(), "/", path);
         bytes memory data = vm.readFileBinary(fullPath);

--- a/contracts/test/proofs/ComplianceProof.t.sol
+++ b/contracts/test/proofs/ComplianceProof.t.sol
@@ -14,6 +14,7 @@ import {Parsing} from "../libs/Parsing.sol";
 import {DeployRiscZeroContracts} from "../script/DeployRiscZeroContracts.s.sol";
 
 contract ComplianceProofTest is Test {
+    using Parsing for Transaction;
     using Parsing for Vm;
     using RiscZeroUtils for Compliance.Instance;
 
@@ -25,7 +26,7 @@ contract ComplianceProofTest is Test {
     function setUp() public {
         (_router, _emergencyStop,) = new DeployRiscZeroContracts().run({admin: msg.sender, guardian: msg.sender});
 
-        _exampleTx = vm.parseTransaction("test/examples/transactions/test_tx_reg_01_01.bin");
+        _exampleTx.toStorage(vm.parseTransaction("test/examples/transactions/test_tx_reg_01_01.bin"));
     }
 
     function test_verify_example_compliance_proof() public view {

--- a/contracts/test/proofs/LogicProof.t.sol
+++ b/contracts/test/proofs/LogicProof.t.sol
@@ -16,6 +16,7 @@ import {Parsing} from "../libs/Parsing.sol";
 import {DeployRiscZeroContracts} from "../script/DeployRiscZeroContracts.s.sol";
 
 contract LogicProofTest is Test {
+    using Parsing for Transaction;
     using Parsing for Vm;
     using MerkleTree for bytes32[];
     using Logic for Logic.VerifierInput;
@@ -31,7 +32,7 @@ contract LogicProofTest is Test {
     function setUp() public {
         (_router, _emergencyStop,) = new DeployRiscZeroContracts().run({admin: msg.sender, guardian: msg.sender});
 
-        _exampleTx = vm.parseTransaction("test/examples/transactions/test_tx_reg_01_01.bin");
+        _exampleTx.toStorage(vm.parseTransaction("test/examples/transactions/test_tx_reg_01_01.bin"));
 
         {
             bytes32[] memory leaves = new bytes32[](2);


### PR DESCRIPTION
This resolves an issue that prevented running `forge coverage --no-match-coverage "(script|test)"`, which returned
```
Error: Compiler run failed:
Error (1834): Copying of type struct Action memory[] memory to storage is not supported in legacy (only supported by the IR pipeline). Hint: try compiling with `--via-ir` (CLI) or the equivalent `viaIR: true` (Standard JSON).
  --> test/ProtocolAdapter.t.sol:22:1:
```