### PR TITLE
Add record-deployment tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "anoma-rm-risc0",
  "dotenvy",
  "serde",
+ "serde_json",
  "thiserror 2.0.17",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5152,6 +5152,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "record-deployment"
+version = "0.0.0"
+dependencies = [
+ "alloy-chains",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ anoma-rm-risc0 = { version = "1.1.1", features = ["bonsai", "aggregation"] }
 anoma-rm-risc0-test-app = { version = "1.1.1", features = ["bonsai"] }
 dotenvy = { version = "0.15.7", features = ["cli"] }
 serde = { version = "1.0.228", default-features = false }
+serde_json = "1.0"
 thiserror = "2.0.17"
 tokio = { version = "1.49", features = ["rt-multi-thread"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bindings", "example-tx-generation"]
+members = ["bindings", "example-tx-generation", "record-deployment"]
 
 [workspace.package]
 keywords = ["anoma", "evm", "protocol-adapter"]

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -123,18 +123,19 @@ For each chain, you want to deploy to, do the following:
 
 ### 5. Update the Deployments Map and Create a new `contracts` and `bindings` GitHub Release
 
-- [ ] Add a deployment entry to [`./deployments.json`](./deployments.json) for each chain deployed. Example:
+- [ ] Record the deployment by running:
 
-  ```json
-  {
-    "network": "mainnet",
-    "chainId": 1,
-    "contractAddress": "0x...",
-    "version": "X.Y.Z"
-  }
+  ```sh
+  just record-deployment <CHAIN_NAME> <VERSION>
   ```
 
-  No extra tools or scripts are needed — the JSON is embedded at compile time by `addresses.rs`.
+  This reads the Foundry broadcast artifact, extracts the contract address, and updates `deployments.json`. No manual editing needed.
+
+  Alternatively, deploy and record in one step:
+
+  ```sh
+  just deploy-and-record deployer <CHAIN_NAME> <VERSION>
+  ```
 
 - [ ] Change the `bindings` package version number in the [`./bindings/Cargo.toml`](./bindings/Cargo.toml) file to `A.0.0`, where `A` is the last `MAJOR` version number incremented by 1.
 
@@ -278,18 +279,19 @@ For each **new** chain, you want to deploy to, do the following:
 
 ### 4. Update the Deployments Map and Create a new `bindings` GitHub Release
 
-- [ ] Add a deployment entry to [`./deployments.json`](./deployments.json) for each **new** chain deployed. Example:
+- [ ] Record each deployment by running:
 
-  ```json
-  {
-    "network": "base",
-    "chainId": 8453,
-    "contractAddress": "0x...",
-    "version": "X.Y.Z"
-  }
+  ```sh
+  just record-deployment <CHAIN_NAME> <VERSION>
   ```
 
-  No extra tools or scripts are needed — the JSON is embedded at compile time by `addresses.rs`.
+  This reads the Foundry broadcast artifact, extracts the contract address, and updates `deployments.json`. No manual editing needed.
+
+  Alternatively, deploy and record in one step:
+
+  ```sh
+  just deploy-and-record deployer <CHAIN_NAME> <VERSION>
+  ```
 
 - [ ] Change the `bindings` package version number in the `./bindings/Cargo.toml` file to `A.B.0`, where `A` is the last `MAJOR` version and `B` is the last `MINOR` version number incremented by 1.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -75,13 +75,7 @@ We distinguish between three release cases:
 
 - [ ] Bump the `_PROTOCOL_ADAPTER_VERSION` constant in [`./contracts/src/libs/Versioning.sol`](./contracts/src/libs/Versioning.sol) to the new version number following [SemVer](https://semver.org/spec/v2.0.0.html).
 
-- [ ] Remove all chain name and address pairs in the
-
-  ```rust
-  pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address>
-  ```
-
-  function in [`./bindings/src/addresses.rs`](./bindings/src/addresses.rs).
+- [ ] Remove all entries from [`./deployments.json`](./deployments.json) (replace the array contents with `[]`).
 
 ### 3. Build the Contracts
 
@@ -129,13 +123,18 @@ For each chain, you want to deploy to, do the following:
 
 ### 5. Update the Deployments Map and Create a new `contracts` and `bindings` GitHub Release
 
-- [ ] Add the **new** address and chain name pairs in the
+- [ ] Add a deployment entry to [`./deployments.json`](./deployments.json) for each chain deployed. Example:
 
-  ```rust
-  pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address>
+  ```json
+  {
+    "network": "mainnet",
+    "chainId": 1,
+    "contractAddress": "0x...",
+    "version": "X.Y.Z"
+  }
   ```
 
-  function in [`./bindings/src/addresses.rs`](./bindings/src/addresses.rs).
+  No extra tools or scripts are needed — the JSON is embedded at compile time by `addresses.rs`.
 
 - [ ] Change the `bindings` package version number in the [`./bindings/Cargo.toml`](./bindings/Cargo.toml) file to `A.0.0`, where `A` is the last `MAJOR` version number incremented by 1.
 
@@ -143,9 +142,9 @@ For each chain, you want to deploy to, do the following:
 
 - [ ] Regenerate the bindings with `just contracts-gen-bindings`.
 
-- [ ] Run `just bindings-build` and check that the `Cargo.lock` file reflects the version number change.
+- [ ] Run `just bindings-build` and check that the `Cargo.lock` file reflects the version number change. This also validates the JSON in `deployments.json` at compile time.
 
-- [ ] Run the tests with `just bindings-test`.
+- [ ] Run the tests with `just bindings-test`. This runs integrity checks on `deployments.json` (valid chain IDs, valid addresses, no duplicates).
 
 - [ ] After merging, create new tags for:
 
@@ -279,19 +278,24 @@ For each **new** chain, you want to deploy to, do the following:
 
 ### 4. Update the Deployments Map and Create a new `bindings` GitHub Release
 
-- [ ] Add the **new** address and chain name pairs in the
+- [ ] Add a deployment entry to [`./deployments.json`](./deployments.json) for each **new** chain deployed. Example:
 
-  ```rust
-  pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address>
+  ```json
+  {
+    "network": "base",
+    "chainId": 8453,
+    "contractAddress": "0x...",
+    "version": "X.Y.Z"
+  }
   ```
 
-  function in `./bindings/src/addresses.rs`.
+  No extra tools or scripts are needed — the JSON is embedded at compile time by `addresses.rs`.
 
 - [ ] Change the `bindings` package version number in the `./bindings/Cargo.toml` file to `A.B.0`, where `A` is the last `MAJOR` version and `B` is the last `MINOR` version number incremented by 1.
 
-- [ ] Run `just bindings-build` and check that the `Cargo.lock` file reflects the version number change.
+- [ ] Run `just bindings-build` and check that the `Cargo.lock` file reflects the version number change. This also validates the JSON in `deployments.json` at compile time.
 
-- [ ] Run the tests with `just bindings-test`.
+- [ ] Run the tests with `just bindings-test`. This runs integrity checks on `deployments.json` (valid chain IDs, valid addresses, no duplicates).
 
 - [ ] After merging, create a new `bindings/vA.B.0` tag, where `A` is the last `MAJOR` version and `B` is the last `MINOR` version number incremented by 1.
 

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -13,6 +13,7 @@ alloy = { workspace = true }
 alloy-chains = { workspace = true }
 anoma-rm-risc0 = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 dotenvy = { workspace = true }
 

--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -1,42 +1,37 @@
-use alloy::primitives::{Address, address};
+use alloy::primitives::Address;
 use alloy_chains::NamedChain;
+use serde::Deserialize;
 use std::collections::HashMap;
+use std::sync::LazyLock;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeploymentEntry {
+    chain_id: u64,
+    contract_address: String,
+}
+
+static DEPLOYMENTS: LazyLock<HashMap<NamedChain, Address>> = LazyLock::new(|| {
+    let entries: Vec<DeploymentEntry> =
+        serde_json::from_str(include_str!("../../deployments.json"))
+            .expect("deployments.json: invalid JSON");
+
+    entries
+        .into_iter()
+        .filter_map(|e| {
+            let chain = NamedChain::try_from(e.chain_id).ok()?;
+            let addr: Address = e.contract_address.parse().ok()?;
+            Some((chain, addr))
+        })
+        .collect()
+});
 
 /// Returns a map of protocol adapter deployments for all supported chains.
 pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address> {
-    HashMap::from([
-        (
-            NamedChain::Sepolia,
-            address!("0xf152BBA809d6cba122579cee997A54B8F3FBa417"),
-        ),
-        (
-            NamedChain::Mainnet,
-            address!("0x0eA3B55b68A3f307c8FE3fe66E443247c95F0CfF"),
-        ),
-        (
-            NamedChain::BaseSepolia,
-            address!("0x094FCC095323080e71a037b2B1e3519c07dd84F8"),
-        ),
-        (
-            NamedChain::Base,
-            address!("0x094FCC095323080e71a037b2B1e3519c07dd84F8"),
-        ),
-        (
-            NamedChain::Optimism,
-            address!("0x094FCC095323080e71a037b2B1e3519c07dd84F8"),
-        ),
-        (
-            NamedChain::Arbitrum,
-            address!("0x094FCC095323080e71a037b2B1e3519c07dd84F8"),
-        ),
-        (
-            NamedChain::BinanceSmartChain,
-            address!("0xFC44b66a39fe6923Ad8d3c93bFeC369728862B68"),
-        ),
-    ])
+    DEPLOYMENTS.clone()
 }
 
 /// Returns the address of the protocol adapter deployed on the provided chain, if any.
 pub fn protocol_adapter_address(chain: &NamedChain) -> Option<Address> {
-    protocol_adapter_deployments_map().get(chain).cloned()
+    DEPLOYMENTS.get(chain).cloned()
 }

--- a/bindings/tests/deployments.rs
+++ b/bindings/tests/deployments.rs
@@ -1,0 +1,84 @@
+use alloy::primitives::Address;
+use alloy_chains::NamedChain;
+use anoma_pa_evm_bindings::addresses::{
+    protocol_adapter_address, protocol_adapter_deployments_map,
+};
+use std::collections::HashSet;
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawEntry {
+    chain_id: u64,
+    contract_address: String,
+    network: String,
+}
+
+fn raw_entries() -> Vec<RawEntry> {
+    serde_json::from_str(include_str!("../../deployments.json"))
+        .expect("deployments.json: invalid JSON")
+}
+
+#[test]
+fn all_entries_have_valid_chain_ids() {
+    for entry in raw_entries() {
+        NamedChain::try_from(entry.chain_id).unwrap_or_else(|_| {
+            panic!(
+                "chain ID {} (network '{}') does not map to a known NamedChain variant",
+                entry.chain_id, entry.network
+            )
+        });
+    }
+}
+
+#[test]
+fn all_entries_have_valid_addresses() {
+    for entry in raw_entries() {
+        entry
+            .contract_address
+            .parse::<Address>()
+            .unwrap_or_else(|_| {
+                panic!(
+                    "invalid contract address '{}' for network '{}'",
+                    entry.contract_address, entry.network
+                )
+            });
+    }
+}
+
+#[test]
+fn no_duplicate_chain_ids() {
+    let entries = raw_entries();
+    let mut seen = HashSet::new();
+    for entry in &entries {
+        assert!(
+            seen.insert(entry.chain_id),
+            "duplicate chain ID {} (network '{}')",
+            entry.chain_id,
+            entry.network
+        );
+    }
+}
+
+#[test]
+fn deployments_map_has_expected_count() {
+    let map = protocol_adapter_deployments_map();
+    let entries = raw_entries();
+    assert_eq!(
+        map.len(),
+        entries.len(),
+        "deployments map size ({}) does not match JSON entries ({})",
+        map.len(),
+        entries.len()
+    );
+}
+
+#[test]
+fn each_chain_is_individually_addressable() {
+    let map = protocol_adapter_deployments_map();
+    for chain in map.keys() {
+        assert!(
+            protocol_adapter_address(chain).is_some(),
+            "protocol_adapter_address returned None for chain '{chain}'"
+        );
+    }
+}

--- a/deployments.json
+++ b/deployments.json
@@ -1,0 +1,44 @@
+[
+  {
+    "network": "mainnet",
+    "chainId": 1,
+    "contractAddress": "0x0eA3B55b68A3f307c8FE3fe66E443247c95F0CfF",
+    "version": "1.1.0"
+  },
+  {
+    "network": "sepolia",
+    "chainId": 11155111,
+    "contractAddress": "0xf152BBA809d6cba122579cee997A54B8F3FBa417",
+    "version": "1.1.0"
+  },
+  {
+    "network": "base-sepolia",
+    "chainId": 84532,
+    "contractAddress": "0x094FCC095323080e71a037b2B1e3519c07dd84F8",
+    "version": "1.1.0"
+  },
+  {
+    "network": "base",
+    "chainId": 8453,
+    "contractAddress": "0x094FCC095323080e71a037b2B1e3519c07dd84F8",
+    "version": "1.1.0"
+  },
+  {
+    "network": "optimism",
+    "chainId": 10,
+    "contractAddress": "0x094FCC095323080e71a037b2B1e3519c07dd84F8",
+    "version": "1.1.0"
+  },
+  {
+    "network": "arbitrum",
+    "chainId": 42161,
+    "contractAddress": "0x094FCC095323080e71a037b2B1e3519c07dd84F8",
+    "version": "1.1.0"
+  },
+  {
+    "network": "bsc",
+    "chainId": 56,
+    "contractAddress": "0xFC44b66a39fe6923Ad8d3c93bFeC369728862B68",
+    "version": "1.1.0"
+  }
+]

--- a/justfile
+++ b/justfile
@@ -119,6 +119,20 @@ bindings-check: contracts-gen-bindings
 bindings-publish *args:
     cd bindings && cargo publish {{ args }}
 
+# --- Record Deployment ---
+
+# Record deployment from broadcast artifact into deployments.json
+record-deployment chain version:
+    cargo run -p record-deployment -- {{chain}} {{version}}
+    @echo "==> Validating..."
+    @just bindings-build
+    @just bindings-test --test deployments
+
+# Deploy and record in one step
+deploy-and-record deployer chain version *args:
+    just contracts-deploy {{deployer}} {{chain}} {{args}}
+    just record-deployment {{chain}} {{version}}
+
 # --- All ---
 
 # Build all (contracts + bindings)

--- a/record-deployment/Cargo.toml
+++ b/record-deployment/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+publish = false
+name = "record-deployment"
+version = "0.0.0"
+description = "Update deployments.json from Foundry broadcast artifacts."
+keywords.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+edition.workspace = true
+
+[dependencies]
+alloy-chains = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tempfile = "3"

--- a/record-deployment/src/main.rs
+++ b/record-deployment/src/main.rs
@@ -1,0 +1,114 @@
+use alloy_chains::NamedChain;
+use serde::{Deserialize, Serialize};
+use std::{env, fs, process};
+
+/// A single entry in deployments.json.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeploymentEntry {
+    network: String,
+    chain_id: u64,
+    contract_address: String,
+    version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_hash: Option<String>,
+}
+
+/// Minimal subset of Foundry's broadcast run-latest.json.
+#[derive(Deserialize)]
+struct BroadcastArtifact {
+    transactions: Vec<BroadcastTransaction>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BroadcastTransaction {
+    transaction_type: String,
+    contract_name: Option<String>,
+    contract_address: Option<String>,
+    hash: Option<String>,
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <chain> <version>", args[0]);
+        eprintln!("Example: {} mainnet 1.1.0", args[0]);
+        process::exit(1);
+    }
+
+    let chain_name = &args[1];
+    let version = &args[2];
+
+    // Resolve chain ID from name.
+    let chain: NamedChain = chain_name.parse().unwrap_or_else(|_| {
+        eprintln!("Unknown chain: {chain_name}");
+        process::exit(1);
+    });
+    let chain_id: u64 = chain.into();
+
+    // Read broadcast artifact.
+    let script_name = "DeployProtocolAdapter.s.sol";
+    let contract_name = "ProtocolAdapter";
+    let artifact_path = format!("contracts/broadcast/{script_name}/{chain_id}/run-latest.json");
+
+    let artifact_json = fs::read_to_string(&artifact_path).unwrap_or_else(|_| {
+        eprintln!("Broadcast artifact not found: {artifact_path}");
+        eprintln!("Run `just contracts-deploy` first.");
+        process::exit(1);
+    });
+
+    let artifact: BroadcastArtifact = serde_json::from_str(&artifact_json).unwrap_or_else(|e| {
+        eprintln!("Failed to parse broadcast artifact: {e}");
+        process::exit(1);
+    });
+
+    // Find the CREATE/CREATE2 transaction for our contract.
+    let tx = artifact
+        .transactions
+        .iter()
+        .find(|t| {
+            matches!(t.transaction_type.as_str(), "CREATE" | "CREATE2")
+                && t.contract_name.as_deref() == Some(contract_name)
+        })
+        .unwrap_or_else(|| {
+            eprintln!("No {contract_name} deployment found in {artifact_path}");
+            process::exit(1);
+        });
+
+    let contract_address = tx.contract_address.as_ref().unwrap();
+    let tx_hash = tx.hash.clone();
+
+    // Read existing deployments.json.
+    let deployments_path = "deployments.json";
+    let mut entries: Vec<DeploymentEntry> = {
+        let json = fs::read_to_string(deployments_path).unwrap_or_else(|_| "[]".to_string());
+        serde_json::from_str(&json).unwrap_or_else(|e| {
+            eprintln!("Failed to parse {deployments_path}: {e}");
+            process::exit(1);
+        })
+    };
+
+    // Remove existing entry for this chain (if any) and add new one.
+    entries.retain(|e| e.chain_id != chain_id);
+    entries.push(DeploymentEntry {
+        network: chain_name.to_string(),
+        chain_id,
+        contract_address: contract_address.to_string(),
+        version: version.to_string(),
+        tx_hash: tx_hash.clone(),
+    });
+
+    // Sort by chain ID for deterministic output.
+    entries.sort_by_key(|e| e.chain_id);
+
+    // Write back.
+    let json = serde_json::to_string_pretty(&entries).expect("Failed to serialize deployments");
+    fs::write(deployments_path, json + "\n").expect("Failed to write deployments.json");
+
+    println!("Recorded {contract_name} deployment on {chain_name} (chain {chain_id}):");
+    println!("  address: {contract_address}");
+    if let Some(hash) = &tx_hash {
+        println!("  tx:      {hash}");
+    }
+}

--- a/record-deployment/tests/record.rs
+++ b/record-deployment/tests/record.rs
@@ -1,0 +1,239 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Build the binary once and return its path.
+fn binary_path() -> &'static Path {
+    // The binary is built by `cargo test -p record-deployment` automatically
+    // via the implicit dev-dependency on the package itself.
+    // We locate it relative to the test binary's directory.
+    static PATH: std::sync::LazyLock<std::path::PathBuf> = std::sync::LazyLock::new(|| {
+        let output = Command::new(env!("CARGO"))
+            .args(["build", "-p", "record-deployment", "--message-format=short"])
+            .output()
+            .expect("Failed to build record-deployment");
+        assert!(
+            output.status.success(),
+            "cargo build failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        // Locate the binary in the target directory.
+        let target_dir = std::env::var("CARGO_TARGET_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                // Walk up from the manifest dir to find the workspace target dir.
+                let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+                manifest_dir.parent().unwrap().join("target")
+            });
+        target_dir.join("debug").join("record-deployment")
+    });
+    PATH.as_path()
+}
+
+/// Minimal valid broadcast artifact for ProtocolAdapter.
+fn mock_broadcast(address: &str, tx_hash: &str) -> String {
+    format!(
+        r#"{{
+  "transactions": [
+    {{
+      "transactionType": "CREATE2",
+      "contractName": "ProtocolAdapter",
+      "contractAddress": "{address}",
+      "hash": "{tx_hash}"
+    }}
+  ]
+}}"#
+    )
+}
+
+/// Set up a temp directory mimicking the repo layout and return its path.
+fn setup_temp_dir(
+    chain_id: u64,
+    broadcast_json: Option<&str>,
+    deployments_json: Option<&str>,
+) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("Failed to create temp dir");
+
+    // Write deployments.json.
+    let deployments = deployments_json.unwrap_or("[]");
+    fs::write(tmp.path().join("deployments.json"), deployments)
+        .expect("Failed to write deployments.json");
+
+    // Write broadcast artifact if provided.
+    if let Some(json) = broadcast_json {
+        let artifact_dir = tmp
+            .path()
+            .join("contracts/broadcast/DeployProtocolAdapter.s.sol")
+            .join(chain_id.to_string());
+        fs::create_dir_all(&artifact_dir).expect("Failed to create broadcast dir");
+        fs::write(artifact_dir.join("run-latest.json"), json)
+            .expect("Failed to write broadcast artifact");
+    }
+
+    tmp
+}
+
+fn run_record(tmp: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(binary_path())
+        .args(args)
+        .current_dir(tmp)
+        .output()
+        .expect("Failed to run record-deployment")
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct Entry {
+    network: String,
+    chain_id: u64,
+    contract_address: String,
+    version: String,
+    tx_hash: Option<String>,
+}
+
+fn read_deployments(tmp: &Path) -> Vec<Entry> {
+    let json =
+        fs::read_to_string(tmp.join("deployments.json")).expect("Failed to read deployments.json");
+    serde_json::from_str(&json).expect("Failed to parse deployments.json")
+}
+
+#[test]
+fn writes_new_entry_to_empty_deployments() {
+    let address = "0x094FCC095323080e71a037b2B1e3519c07dd84F8";
+    let tx_hash = "0xabc123def456";
+    let broadcast = mock_broadcast(address, tx_hash);
+    let tmp = setup_temp_dir(1, Some(&broadcast), None);
+
+    let output = run_record(tmp.path(), &["mainnet", "1.1.0"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].network, "mainnet");
+    assert_eq!(entries[0].chain_id, 1);
+    assert_eq!(entries[0].contract_address, address);
+    assert_eq!(entries[0].version, "1.1.0");
+    assert_eq!(entries[0].tx_hash.as_deref(), Some(tx_hash));
+}
+
+#[test]
+fn replaces_existing_entry_for_same_chain() {
+    let old_json = r#"[{
+        "network": "mainnet",
+        "chainId": 1,
+        "contractAddress": "0xOLD",
+        "version": "1.0.0"
+    }]"#;
+    let new_address = "0x094FCC095323080e71a037b2B1e3519c07dd84F8";
+    let broadcast = mock_broadcast(new_address, "0xnewhash");
+    let tmp = setup_temp_dir(1, Some(&broadcast), Some(old_json));
+
+    let output = run_record(tmp.path(), &["mainnet", "1.1.0"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 1, "Should have exactly one entry, not two");
+    assert_eq!(entries[0].contract_address, new_address);
+    assert_eq!(entries[0].version, "1.1.0");
+}
+
+#[test]
+fn appends_without_clobbering_other_chains() {
+    let existing_json = r#"[{
+        "network": "mainnet",
+        "chainId": 1,
+        "contractAddress": "0x0eA3B55b68A3f307c8FE3fe66E443247c95F0CfF",
+        "version": "1.1.0"
+    }]"#;
+    let new_address = "0x094FCC095323080e71a037b2B1e3519c07dd84F8";
+    // Chain 10 = optimism.
+    let broadcast = mock_broadcast(new_address, "0xopthash");
+    let tmp = setup_temp_dir(10, Some(&broadcast), Some(existing_json));
+
+    let output = run_record(tmp.path(), &["optimism", "1.1.0"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 2);
+    // Mainnet (chain 1) should still be there.
+    assert_eq!(entries[0].chain_id, 1);
+    assert_eq!(
+        entries[0].contract_address,
+        "0x0eA3B55b68A3f307c8FE3fe66E443247c95F0CfF"
+    );
+    // Optimism (chain 10) should be appended.
+    assert_eq!(entries[1].chain_id, 10);
+    assert_eq!(entries[1].contract_address, new_address);
+}
+
+#[test]
+fn entries_are_sorted_by_chain_id() {
+    // Add chains in reverse order: arbitrum (42161), then mainnet (1).
+    let broadcast_arb = mock_broadcast("0xARB", "0xarbhash");
+    let tmp = setup_temp_dir(42161, Some(&broadcast_arb), None);
+
+    let output = run_record(tmp.path(), &["arbitrum", "1.1.0"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Now add mainnet (chain 1).
+    let broadcast_dir = tmp
+        .path()
+        .join("contracts/broadcast/DeployProtocolAdapter.s.sol/1");
+    fs::create_dir_all(&broadcast_dir).unwrap();
+    fs::write(
+        broadcast_dir.join("run-latest.json"),
+        mock_broadcast("0xMAIN", "0xmainhash"),
+    )
+    .unwrap();
+
+    let output = run_record(tmp.path(), &["mainnet", "1.1.0"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].chain_id, 1, "Mainnet should be first (sorted)");
+    assert_eq!(
+        entries[1].chain_id, 42161,
+        "Arbitrum should be second (sorted)"
+    );
+}
+
+#[test]
+fn fails_gracefully_on_missing_artifact() {
+    // No broadcast artifact provided.
+    let tmp = setup_temp_dir(1, None, None);
+
+    let output = run_record(tmp.path(), &["mainnet", "1.1.0"]);
+    assert!(
+        !output.status.success(),
+        "Should fail when artifact is missing"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Broadcast artifact not found"),
+        "Expected 'Broadcast artifact not found' in stderr, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Add a `record-deployment` Rust binary that reads Foundry broadcast artifacts
(e.g. `contracts/broadcast/DeployProtocolAdapter.s.sol/<chainId>/run-latest.json`)
and auto-updates `deployments.json` with the deployed contract address and tx hash.

This eliminates the need to manually copy addresses after running `just contracts-deploy`.

New just recipes:
- `just record-deployment <chain> <version>` — extract address from broadcast artifact, update JSON, validate via bindings-build + bindings-test
- `just deploy-and-record <deployer> <chain> <version>` — deploy and record in one step

The binary follows the `example-tx-generation` crate pattern: `publish = false`, workspace metadata, minimal deps (`alloy-chains`, `serde`, `serde_json`). Five integration tests cover new entry creation, replacement, append, sorting, and missing artifact error handling.