### PR TITLE
fix(contracts): correct etherscan and sourcify verification commands

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -10,3 +10,11 @@ export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
 export BONSAI_API_URL=<BONSAI_API_URL>
 ## The API key for the remote proving service.
 export BONSAI_API_KEY=<BONSAI_API_KEY>
+
+
+# Block Explorer Verification
+
+## The Etherscan API key (see https://etherscan.io/myapikey).
+## A single key works for all chains via Etherscan V2.
+## Required for Etherscan verification. Not needed for Sourcify.
+export ETHERSCAN_API_KEY=<ETHERSCAN_API_KEY>

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -117,22 +117,32 @@ forge script script/DeployProtocolAdapter.s.sol:DeployProtocolAdapter \
 Append the
 
 - `--broadcast` flag to deploy on sepolia
-- `--verify --slow` flags for subsequent contract verification on Etherscan (`--slow` adds 15 seconds of waiting time between verification attempts)
+- `--verify` flag for subsequent contract verification (Sourcify by default; set `ETHERSCAN_API_KEY` to also verify on Etherscan)
+- `--slow` flag to add 15 seconds of waiting time between verification attempts
 - `--account <ACCOUNT_NAME>` flag to use a previously imported keystore (see
   `cast wallet --help` for more info)
 
 #### Block Explorer Verification
 
-For post-deployment verification on Etherscan run
+For post-deployment verification on **Sourcify** run
 
 ```sh
 forge verify-contract \
    <ADDRESS> \
    src/ProtocolAdapter.sol:ProtocolAdapter \
-   --chain sepolia
+   --chain sepolia \
+   --verifier sourcify
 ```
 
-after replacing `<ADDRESS>` with the respective contract address.
+For **Etherscan** (requires `ETHERSCAN_API_KEY`) run
+
+```sh
+forge verify-contract \
+   <ADDRESS> \
+   src/ProtocolAdapter.sol:ProtocolAdapter \
+   --chain sepolia \
+   --verifier etherscan
+```
 
 ### Benchmarks
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -71,11 +71,3 @@ bsc = "https://bnb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 bsc-testnet = "https://bnb-testnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 
 localhost = "http://localhost:8545"
-
-[etherscan]
-mainnet = { key = "${ETHERSCAN_API_KEY}" }
-sepolia = { key = "${ETHERSCAN_API_KEY}" }
-base = { key = "${ETHERSCAN_API_KEY}" }
-base-sepolia = { key = "${ETHERSCAN_API_KEY}" }
-optimism = { key = "${ETHERSCAN_API_KEY}" }
-arbitrum = { key = "${ETHERSCAN_API_KEY}" }

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -71,3 +71,11 @@ bsc = "https://bnb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 bsc-testnet = "https://bnb-testnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 
 localhost = "http://localhost:8545"
+
+[etherscan]
+mainnet = { key = "${ETHERSCAN_API_KEY}" }
+sepolia = { key = "${ETHERSCAN_API_KEY}" }
+base = { key = "${ETHERSCAN_API_KEY}" }
+base-sepolia = { key = "${ETHERSCAN_API_KEY}" }
+optimism = { key = "${ETHERSCAN_API_KEY}" }
+arbitrum = { key = "${ETHERSCAN_API_KEY}" }

--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ contracts-deploy deployer chain *args:
 
 # Verify on sourcify
 contracts-verify-sourcify address chain *args:
-    cd contracts && forge verify-contract {{address}} \
+    cd contracts && env -u ETHERSCAN_API_KEY forge verify-contract {{address}} \
         src/ProtocolAdapter.sol:ProtocolAdapter \
         --chain {{chain}} --verifier sourcify {{ args }}
 

--- a/justfile
+++ b/justfile
@@ -54,13 +54,13 @@ contracts-deploy deployer chain *args:
 contracts-verify-sourcify address chain *args:
     cd contracts && env -u ETHERSCAN_API_KEY forge verify-contract {{address}} \
         src/ProtocolAdapter.sol:ProtocolAdapter \
-        --chain {{chain}} --verifier sourcify {{ args }}
+        --chain {{chain}} --verifier sourcify --watch {{ args }}
 
 # Verify on etherscan
 contracts-verify-etherscan address chain *args:
     cd contracts && forge verify-contract {{address}} \
         src/ProtocolAdapter.sol:ProtocolAdapter \
-        --chain {{chain}} --verifier etherscan {{ args }}
+        --chain {{chain}} --verifier etherscan --watch {{ args }}
 
 # Verify on both sourcify and etherscan
 contracts-verify address chain: (contracts-verify-sourcify address chain) (contracts-verify-etherscan address chain)


### PR DESCRIPTION
Work-in-progress investigation.

Closes #472

When `ETHERSCAN_API_KEY` is set, `forge verify-contract --verifier sourcify` silently reroutes to Etherscan because forge auto-populates the `-e` flag from the env var. Additionally, without an `[etherscan]` section in `foundry.toml`, forge may fail to resolve the correct explorer URL for L2 chains.

Changes:
- Strip `ETHERSCAN_API_KEY` from the `contracts-verify-sourcify` recipe environment via `env -u` so forge respects `--verifier sourcify`
- Add `[etherscan]` section to `contracts/foundry.toml` with per-chain API key config (a single Etherscan V2 key works across all chains)
- Rewrite the README verification section to document both Sourcify and Etherscan verification
- Add `ETHERSCAN_API_KEY` to `.env-example`

Upstream Foundry issues: foundry-rs/foundry#6192, foundry-rs/foundry#7466, foundry-rs/foundry#7699.