### PR TITLE
feat: deploy ProtocolAdapter to Aurora testnet

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: macos-latest
     env:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+      RPC_URL_AURORA_TESTNET: https://testnet.aurora.dev
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: macos-latest
     env:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+      RPC_URL_AURORA: https://mainnet.aurora.dev
       RPC_URL_AURORA_TESTNET: https://testnet.aurora.dev
 
     steps:

--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -29,6 +29,10 @@ pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address> {
             NamedChain::Arbitrum,
             address!("0x094FCC095323080e71a037b2B1e3519c07dd84F8"),
         ),
+        (
+            NamedChain::AuroraTestnet,
+            address!("0x24CEc6A74A0E39eE33C8356DB8655308112f587F"),
+        ),
     ])
 }
 

--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -33,6 +33,10 @@ pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address> {
             NamedChain::AuroraTestnet,
             address!("0x24CEc6A74A0E39eE33C8356DB8655308112f587F"),
         ),
+        (
+            NamedChain::Aurora,
+            address!("0xFC44b66a39fe6923Ad8d3c93bFeC369728862B68"),
+        ),
     ])
 }
 

--- a/bindings/src/helpers.rs
+++ b/bindings/src/helpers.rs
@@ -17,6 +17,12 @@ pub enum RpcError {
     UrlParsingError,
 }
 
+/// Returns whether the chain supports EIP-1559 transactions.
+/// Chains that don't (e.g. Aurora) require legacy transactions.
+pub fn supports_eip1559(chain: &NamedChain) -> bool {
+    !matches!(chain, NamedChain::Aurora | NamedChain::AuroraTestnet)
+}
+
 /// Maps a `NamedChain` to the suffix used for `RPC_URL_<SUFFIX>` env vars.
 fn chain_env_var_name(chain: &NamedChain) -> String {
     let s = format!("{chain:?}");

--- a/bindings/tests/contract.rs
+++ b/bindings/tests/contract.rs
@@ -8,7 +8,7 @@ use anoma_pa_evm_bindings::addresses::protocol_adapter_deployments_map;
 use anoma_pa_evm_bindings::contract::protocol_adapter;
 use anoma_pa_evm_bindings::generated::protocol_adapter;
 use anoma_pa_evm_bindings::generated::versioning_lib_external;
-use anoma_pa_evm_bindings::helpers::rpc_url;
+use anoma_pa_evm_bindings::helpers::{rpc_url, supports_eip1559};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -50,6 +50,10 @@ async fn versions_of_deployed_protocol_adapters_match_the_expected_version() {
 #[tokio::test]
 async fn call_executes_the_empty_tx_on_all_supported_chains() {
     for chain in protocol_adapter_deployments_map().keys() {
+        // Skip chains that don't support EIP-1559 (Anvil forks default to EIP-1559 txs).
+        if !supports_eip1559(chain) {
+            continue;
+        }
         let empty_tx = protocol_adapter::ProtocolAdapter::Transaction {
             actions: vec![],
             deltaProof: Default::default(),

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -67,5 +67,7 @@ base = "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 base-sepolia = "https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+aurora = "https://mainnet.aurora.dev"
+aurora-testnet = "https://testnet.aurora.dev"
 
 localhost = "http://localhost:8545"

--- a/contracts/script/DeployProtocolAdapter.s.sol
+++ b/contracts/script/DeployProtocolAdapter.s.sol
@@ -59,6 +59,12 @@ contract DeployProtocolAdapter is Script {
         _supportNetwork({
             name: "optimism", chainId: 10, riscZeroVerifierRouter: 0x0b144E07A0826182B6b59788c34b32Bfa86Fb711
         });
+
+        _supportNetwork({
+            name: "aurora-testnet",
+            chainId: 1313161555,
+            riscZeroVerifierRouter: 0x7C1B7b8fEB636eA9Ecd32152Bce2744a0EEf39C7
+        });
     }
 
     /// @notice Deploys the protocol adapter contract on supported networks and allows for test deployments.

--- a/contracts/script/DeployProtocolAdapter.s.sol
+++ b/contracts/script/DeployProtocolAdapter.s.sol
@@ -65,6 +65,10 @@ contract DeployProtocolAdapter is Script {
             chainId: 1313161555,
             riscZeroVerifierRouter: 0x7C1B7b8fEB636eA9Ecd32152Bce2744a0EEf39C7
         });
+
+        _supportNetwork({
+            name: "aurora", chainId: 1313161554, riscZeroVerifierRouter: 0x7C1B7b8fEB636eA9Ecd32152Bce2744a0EEf39C7
+        });
     }
 
     /// @notice Deploys the protocol adapter contract on supported networks and allows for test deployments.


### PR DESCRIPTION
Add Aurora support (mainnet + testnet RPC endpoints, deploy scripts, just recipes) and deploy the RISC Zero verifier stack + ProtocolAdapter to Aurora testnet.

After:
- #488 