### PR TITLE
feat(contracts, bindings): add BNB chain support

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: macos-latest
     env:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+      RPC_URL_BINANCE_SMART_CHAIN: https://bsc-dataseed.binance.org
+      RPC_URL_BINANCE_SMART_CHAIN_TESTNET: https://data-seed-prebsc-1-s1.bnbchain.org:8545
 
     steps:
       - name: Checkout repository

--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -29,6 +29,14 @@ pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address> {
             NamedChain::Arbitrum,
             address!("0x094FCC095323080e71a037b2B1e3519c07dd84F8"),
         ),
+        (
+            NamedChain::BinanceSmartChain,
+            address!("0xFC44b66a39fe6923Ad8d3c93bFeC369728862B68"),
+        ),
+        (
+            NamedChain::BinanceSmartChainTestnet,
+            address!("0x33d4F0c88ef555E105Ba5e5F1aFbF34d6f650964"),
+        ),
     ])
 }
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -67,5 +67,7 @@ base = "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 base-sepolia = "https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+bnb = "https://bsc-dataseed.binance.org"
+bnb-testnet = "https://data-seed-prebsc-1-s1.bnbchain.org:8545"
 
 localhost = "http://localhost:8545"

--- a/contracts/script/DeployProtocolAdapter.s.sol
+++ b/contracts/script/DeployProtocolAdapter.s.sol
@@ -59,6 +59,12 @@ contract DeployProtocolAdapter is Script {
         _supportNetwork({
             name: "optimism", chainId: 10, riscZeroVerifierRouter: 0x0b144E07A0826182B6b59788c34b32Bfa86Fb711
         });
+
+        _supportNetwork({
+            name: "bnb-testnet", chainId: 97, riscZeroVerifierRouter: 0x7C1B7b8fEB636eA9Ecd32152Bce2744a0EEf39C7
+        });
+
+        _supportNetwork({name: "bnb", chainId: 56, riscZeroVerifierRouter: 0x7C1B7b8fEB636eA9Ecd32152Bce2744a0EEf39C7});
     }
 
     /// @notice Deploys the protocol adapter contract on supported networks and allows for test deployments.


### PR DESCRIPTION
Add BNB Smart Chain support (mainnet + testnet RPC endpoints via Alchemy, Rust helpers).

The RISC Zero verifier stack needs to be self-deployed on BNB (not officially supported by RISC Zero) before uncommenting the deploy script entries and deploying the ProtocolAdapter.

After:
-  #488