### PR TITLE
feat: add just recipes for RISC Zero verifier deployment

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,6 +69,22 @@ contracts-verify address chain: (contracts-verify-sourcify address chain) (contr
 contracts-publish version *args:
     cd contracts && forge soldeer push anoma-pa-evm~{{version}} {{ args }}
 
+# --- RISC Zero Verifier ---
+
+# Simulate RISC Zero verifier deployment (dry-run)
+risczero-simulate admin guardian chain *args:
+    cd contracts && FOUNDRY_EVM_VERSION=cancun forge script \
+        test/script/DeployRiscZeroContracts.s.sol:DeployRiscZeroContracts \
+        --sig "run(address,address)" {{admin}} {{guardian}} \
+        --rpc-url {{chain}} {{ args }}
+
+# Deploy RISC Zero verifier (router + groth16 + emergency stop)
+risczero-deploy deployer admin guardian chain *args:
+    cd contracts && FOUNDRY_EVM_VERSION=cancun forge script \
+        test/script/DeployRiscZeroContracts.s.sol:DeployRiscZeroContracts \
+        --sig "run(address,address)" {{admin}} {{guardian}} \
+        --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
+
 # --- Bindings ---
 
 # Clean bindings

--- a/justfile
+++ b/justfile
@@ -85,6 +85,18 @@ risczero-deploy deployer admin guardian chain *args:
         --sig "run(address,address)" {{admin}} {{guardian}} \
         --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
 
+# Verify RISC Zero verifier contracts on Sourcify
+risczero-verify groth16 estop router chain *args:
+    cd contracts && FOUNDRY_EVM_VERSION=cancun forge verify-contract {{groth16}} \
+        dependencies/risc0-risc0-ethereum-3.0.1/contracts/src/groth16/RiscZeroGroth16Verifier.sol:RiscZeroGroth16Verifier \
+        --chain {{chain}} --verifier sourcify {{ args }}
+    cd contracts && FOUNDRY_EVM_VERSION=cancun forge verify-contract {{estop}} \
+        dependencies/risc0-risc0-ethereum-3.0.1/contracts/src/RiscZeroVerifierEmergencyStop.sol:RiscZeroVerifierEmergencyStop \
+        --chain {{chain}} --verifier sourcify {{ args }}
+    cd contracts && FOUNDRY_EVM_VERSION=cancun forge verify-contract {{router}} \
+        dependencies/risc0-risc0-ethereum-3.0.1/contracts/src/RiscZeroVerifierRouter.sol:RiscZeroVerifierRouter \
+        --chain {{chain}} --verifier sourcify {{ args }}
+
 # --- Bindings ---
 
 # Clean bindings


### PR DESCRIPTION
Add risczero-simulate, risczero-deploy, and risczero-verify just recipes for deploying the RISC Zero verifier stack (Groth16Verifier, EmergencyStop, Router) to chains where RISC Zero doesn't have official deployments. Uses FOUNDRY_EVM_VERSION=cancun override for chains that don't support osaka.