### PR TITLE
feat: generalize RPC helpers beyond Alchemy

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,7 +1,15 @@
 # RPC Provider
 
 ## The Alchemy API key (see https://www.alchemy.com/)
+## Used as the default RPC provider for supported chains.
 export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
+
+## Chain-specific RPC URL overrides (optional).
+## These take priority over Alchemy when set.
+## Example:
+# export RPC_URL_MAINNET=https://your-rpc-provider.com/v1/your-key
+# export RPC_URL_SEPOLIA=https://your-rpc-provider.com/v1/your-key
+# export RPC_URL_AURORA=https://mainnet.aurora.dev
 
 
 # Remote Proving service

--- a/bindings/src/helpers.rs
+++ b/bindings/src/helpers.rs
@@ -47,9 +47,8 @@ pub fn rpc_url(chain: &NamedChain) -> RpcResult<Url> {
     }
 
     // Tier 2: Alchemy fallback for supported chains
-    let subdomain = alchemy_subdomain(chain).ok_or_else(|| {
-        RpcError::RpcUrlNotConfigured(format!("{chain:?}"), env_var_name.clone())
-    })?;
+    let subdomain = alchemy_subdomain(chain)
+        .ok_or_else(|| RpcError::RpcUrlNotConfigured(format!("{chain:?}"), env_var_name.clone()))?;
 
     let api_key = env::var("ALCHEMY_API_KEY").map_err(|_| RpcError::ApiKeyNotSet)?;
 
@@ -94,10 +93,7 @@ mod tests {
 
     #[test]
     fn chain_env_var_name_compound() {
-        assert_eq!(
-            chain_env_var_name(&NamedChain::BaseSepolia),
-            "BASE_SEPOLIA"
-        );
+        assert_eq!(chain_env_var_name(&NamedChain::BaseSepolia), "BASE_SEPOLIA");
         assert_eq!(
             chain_env_var_name(&NamedChain::ArbitrumSepolia),
             "ARBITRUM_SEPOLIA"
@@ -106,10 +102,7 @@ mod tests {
             chain_env_var_name(&NamedChain::OptimismSepolia),
             "OPTIMISM_SEPOLIA"
         );
-        assert_eq!(
-            chain_env_var_name(&NamedChain::PolygonAmoy),
-            "POLYGON_AMOY"
-        );
+        assert_eq!(chain_env_var_name(&NamedChain::PolygonAmoy), "POLYGON_AMOY");
     }
 
     #[test]

--- a/bindings/src/helpers.rs
+++ b/bindings/src/helpers.rs
@@ -3,51 +3,125 @@ use alloy_chains::NamedChain;
 use std::env;
 use thiserror::Error;
 
-pub type AlchemyResult<T> = Result<T, AlchemyError>;
+pub type RpcResult<T> = Result<T, RpcError>;
 
 #[derive(Error, Debug, Clone)]
-pub enum AlchemyError {
-    #[error("The alchemy subdomain was not found for this chain.")]
-    SubdomainNotFound,
+pub enum RpcError {
+    #[error(
+        "No RPC URL configured for chain '{0}'. Set {1} or provide ALCHEMY_API_KEY for supported chains."
+    )]
+    RpcUrlNotConfigured(String, String),
     #[error("The Alchemy API key is not set in the environment.")]
-    ApiKeyEnvVarNotSet,
+    ApiKeyNotSet,
     #[error("The url could not be parsed.")]
     UrlParsingError,
 }
 
-/// Returns the Alchemy RPC URL for the given chain.
-pub fn alchemy_url(chain: &NamedChain) -> AlchemyResult<Url> {
-    dotenvy::dotenv().ok();
-
-    format!(
-        "https://{subdomain}.g.alchemy.com/v2/{api_key}",
-        subdomain = alchemy_subdomain(chain)?,
-        api_key = env::var("ALCHEMY_API_KEY").map_err(|_| AlchemyError::ApiKeyEnvVarNotSet)?
-    )
-    .parse()
-    .map_err(|_| AlchemyError::UrlParsingError)
+/// Maps a `NamedChain` to the suffix used for `RPC_URL_<SUFFIX>` env vars.
+fn chain_env_var_name(chain: &NamedChain) -> String {
+    let s = format!("{chain:?}");
+    // Convert CamelCase to UPPER_SNAKE_CASE
+    let mut result = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            result.push('_');
+        }
+        result.push(ch.to_ascii_uppercase());
+    }
+    result
 }
 
-/// Returns the Alchemy subdomain for the given chain.
-pub fn alchemy_subdomain(chain: &NamedChain) -> AlchemyResult<&'static str> {
+/// Returns the RPC URL for the given chain using a two-tier resolution:
+///
+/// 1. Check for a chain-specific env var `RPC_URL_<CHAIN>` (e.g., `RPC_URL_MAINNET`)
+/// 2. Fall back to constructing an Alchemy URL from `ALCHEMY_API_KEY`
+pub fn rpc_url(chain: &NamedChain) -> RpcResult<Url> {
+    dotenvy::dotenv().ok();
+
+    let env_var_suffix = chain_env_var_name(chain);
+    let env_var_name = format!("RPC_URL_{env_var_suffix}");
+
+    // Tier 1: chain-specific env var override
+    if let Ok(url) = env::var(&env_var_name) {
+        return url.parse().map_err(|_| RpcError::UrlParsingError);
+    }
+
+    // Tier 2: Alchemy fallback for supported chains
+    let subdomain = alchemy_subdomain(chain).ok_or_else(|| {
+        RpcError::RpcUrlNotConfigured(format!("{chain:?}"), env_var_name.clone())
+    })?;
+
+    let api_key = env::var("ALCHEMY_API_KEY").map_err(|_| RpcError::ApiKeyNotSet)?;
+
+    format!("https://{subdomain}.g.alchemy.com/v2/{api_key}")
+        .parse()
+        .map_err(|_| RpcError::UrlParsingError)
+}
+
+/// Returns the Alchemy subdomain for supported chains.
+fn alchemy_subdomain(chain: &NamedChain) -> Option<&'static str> {
     use NamedChain::*;
 
     match chain {
-        Mainnet => Ok("eth-mainnet"),
-        Sepolia => Ok("eth-sepolia"),
+        Mainnet => Some("eth-mainnet"),
+        Sepolia => Some("eth-sepolia"),
         //
-        Arbitrum => Ok("arb-mainnet"),
-        ArbitrumSepolia => Ok("arb-sepolia"),
+        Arbitrum => Some("arb-mainnet"),
+        ArbitrumSepolia => Some("arb-sepolia"),
         //
-        Optimism => Ok("opt-mainnet"),
-        OptimismSepolia => Ok("opt-sepolia"),
+        Optimism => Some("opt-mainnet"),
+        OptimismSepolia => Some("opt-sepolia"),
         //
-        Base => Ok("base-mainnet"),
-        BaseSepolia => Ok("base-sepolia"),
+        Base => Some("base-mainnet"),
+        BaseSepolia => Some("base-sepolia"),
         //
-        Polygon => Ok("polygon-mainnet"),
-        PolygonAmoy => Ok("polygon-amoy"),
+        Polygon => Some("polygon-mainnet"),
+        PolygonAmoy => Some("polygon-amoy"),
 
-        _ => Err(AlchemyError::SubdomainNotFound),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_env_var_name_simple() {
+        assert_eq!(chain_env_var_name(&NamedChain::Mainnet), "MAINNET");
+        assert_eq!(chain_env_var_name(&NamedChain::Sepolia), "SEPOLIA");
+    }
+
+    #[test]
+    fn chain_env_var_name_compound() {
+        assert_eq!(
+            chain_env_var_name(&NamedChain::BaseSepolia),
+            "BASE_SEPOLIA"
+        );
+        assert_eq!(
+            chain_env_var_name(&NamedChain::ArbitrumSepolia),
+            "ARBITRUM_SEPOLIA"
+        );
+        assert_eq!(
+            chain_env_var_name(&NamedChain::OptimismSepolia),
+            "OPTIMISM_SEPOLIA"
+        );
+        assert_eq!(
+            chain_env_var_name(&NamedChain::PolygonAmoy),
+            "POLYGON_AMOY"
+        );
+    }
+
+    #[test]
+    fn rpc_url_uses_env_var_override() {
+        let chain = NamedChain::Mainnet;
+        let env_var = format!("RPC_URL_{}", chain_env_var_name(&chain));
+        let test_url = "https://custom-rpc.example.com/v1/key123";
+
+        // SAFETY: This test is single-threaded and we restore the env var after.
+        unsafe { env::set_var(&env_var, test_url) };
+        let result = rpc_url(&chain).expect("should parse custom URL");
+        assert_eq!(result.as_str(), test_url);
+        unsafe { env::remove_var(&env_var) };
     }
 }

--- a/bindings/tests/contract.rs
+++ b/bindings/tests/contract.rs
@@ -8,7 +8,7 @@ use anoma_pa_evm_bindings::addresses::protocol_adapter_deployments_map;
 use anoma_pa_evm_bindings::contract::protocol_adapter;
 use anoma_pa_evm_bindings::generated::protocol_adapter;
 use anoma_pa_evm_bindings::generated::versioning_lib_external;
-use anoma_pa_evm_bindings::helpers::alchemy_url;
+use anoma_pa_evm_bindings::helpers::rpc_url;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -78,7 +78,7 @@ async fn call_executes_the_empty_tx_on_all_supported_chains() {
 async fn pa_instance(
     chain: &NamedChain,
 ) -> protocol_adapter::ProtocolAdapter::ProtocolAdapterInstance<DynProvider> {
-    let rpc_url = alchemy_url(chain).expect("Couldn't get RPC URL for chain");
+    let rpc_url = rpc_url(chain).expect("Couldn't get RPC URL for chain");
 
     let provider = ProviderBuilder::new()
         .connect_anvil_with_wallet_and_config(|a| a.fork(rpc_url))

--- a/contracts/.env-example
+++ b/contracts/.env-example
@@ -1,7 +1,15 @@
 # RPC Providers
 
 ## The Alchemy API key (see https://www.alchemy.com/)
+## Used as the default RPC provider for supported chains.
 export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
+
+## Chain-specific RPC URL overrides (optional).
+## These take priority over Alchemy when set.
+## Example:
+# export RPC_URL_MAINNET=https://your-rpc-provider.com/v1/your-key
+# export RPC_URL_SEPOLIA=https://your-rpc-provider.com/v1/your-key
+# export RPC_URL_AURORA=https://mainnet.aurora.dev
 
 
 # Block Explorers

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -59,13 +59,13 @@ fuzz = { runs = 1_000 }
 verbosity = 3
 
 [rpc_endpoints]
-mainnet = "${RPC_URL_MAINNET-https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
-sepolia = "${RPC_URL_SEPOLIA-https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
-arbitrum = "${RPC_URL_ARBITRUM-https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
-arbitrum-sepolia = "${RPC_URL_ARBITRUM_SEPOLIA-https://arb-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
-base = "${RPC_URL_BASE-https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
-base-sepolia = "${RPC_URL_BASE_SEPOLIA-https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
-optimism = "${RPC_URL_OPTIMISM-https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
-optimism-sepolia = "${RPC_URL_OPTIMISM_SEPOLIA-https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+sepolia = "https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+arbitrum = "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+arbitrum-sepolia = "https://arb-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+base = "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+base-sepolia = "https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 
 localhost = "http://localhost:8545"

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -59,13 +59,13 @@ fuzz = { runs = 1_000 }
 verbosity = 3
 
 [rpc_endpoints]
-mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-sepolia = "https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-arbitrum = "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-arbitrum-sepolia = "https://arb-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-base = "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-base-sepolia = "https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+mainnet = "${RPC_URL_MAINNET-https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+sepolia = "${RPC_URL_SEPOLIA-https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+arbitrum = "${RPC_URL_ARBITRUM-https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+arbitrum-sepolia = "${RPC_URL_ARBITRUM_SEPOLIA-https://arb-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+base = "${RPC_URL_BASE-https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+base-sepolia = "${RPC_URL_BASE_SEPOLIA-https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+optimism = "${RPC_URL_OPTIMISM-https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
+optimism-sepolia = "${RPC_URL_OPTIMISM_SEPOLIA-https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}}"
 
 localhost = "http://localhost:8545"


### PR DESCRIPTION
Introduces a generic `rpc_url(chain)` function that uses a two-tier resolution: chain-specific env var override (`RPC_URL_<CHAIN>`) checked first, then Alchemy fallback. This lets us add chains like Aurora and BNB that aren't on Alchemy, while staying fully backwards-compatible for existing setups with only `ALCHEMY_API_KEY`.

- Refs #487

I suggest squashing and merging this PR in particular.