### PR TITLE
ci: justfile and workflow harmonization

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,13 +3,3 @@
 ## The Alchemy API key (see https://www.alchemy.com/)
 
 export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
-
-# Remote Proving service
-
-## The URL of the remote proving service.
-
-export BONSAI_API_URL=<BONSAI_API_URL>
-
-## The API key for the remote proving service.
-
-export BONSAI_API_KEY=<BONSAI_API_KEY>

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -43,16 +43,13 @@ jobs:
           restore-keys: rust-
 
       - name: Run rustfmt
-        run: cargo fmt -- --check
+        run: just bindings-fmt-check
 
       - name: Build Bindings
         run: just bindings-build
 
       - name: Run clippy
-        run: cargo clippy --no-deps -- -Dwarnings
-
-      - name: Run Clippy on test
-        run: cargo clippy --no-deps  --tests -- -Dwarnings
+        run: just bindings-clippy
 
       - name: Run Tests
         run: just bindings-test

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Build Bindings
         run: just bindings-build
 
-      - name: Run clippy
-        run: just bindings-clippy
+      - name: Lint Bindings
+        run: just bindings-lint
 
       - name: Run Tests
         run: just bindings-test

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -33,8 +33,7 @@ jobs:
         run: forge soldeer version
 
       - name: Run Forge Lint
-        run: forge lint --deny warnings
-        working-directory: ./contracts
+        run: just contracts-lint
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
@@ -47,20 +46,8 @@ jobs:
         run: bun install solhint
         working-directory: ./contracts
 
-      - name: Run Solhint in `src`
-        run: bunx --bun solhint --config .solhint.json 'src/**/*.sol'
-        working-directory: ./contracts
-        id: solhint-src
-
-      - name: Run Solhint in `test` dir
-        run: bunx --bun solhint --config .solhint.other.json 'test/**/*.sol'
-        working-directory: ./contracts
-        id: solhint-test
-
-      - name: Run Solhint in `script` dir
-        run: bunx --bun solhint --config .solhint.other.json 'script/**/*.sol'
-        working-directory: ./contracts
-        id: solhint-script
+      - name: Run Solhint
+        run: just contracts-solhint
 
       - name: Install Slither
         run: pip install slither-analyzer
@@ -74,9 +61,7 @@ jobs:
         id: slither
 
       - name: Run Forge fmt
-        run: forge fmt --check
-        working-directory: ./contracts
-        id: fmt
+        run: just contracts-fmt-check
 
       - name: Check that bindings are up-to-date
         run: just bindings-check

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -23,17 +23,14 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install dependencies
-        run: just contracts-deps
-
       - name: Show Foundry version
         run: forge --version
 
       - name: Show Soldeer version
         run: forge soldeer version
 
-      - name: Run Forge Lint
-        run: just contracts-lint
+      - name: Install dependencies
+        run: just contracts-deps
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
@@ -46,8 +43,8 @@ jobs:
         run: bun install solhint
         working-directory: ./contracts
 
-      - name: Run Solhint
-        run: just contracts-solhint
+      - name: Run Forge Lint
+        run: just contracts-lint
 
       - name: Install Slither
         run: pip install slither-analyzer
@@ -55,10 +52,8 @@ jobs:
       - name: Show Slither version
         run: slither --version
 
-      - name: Run Slither
-        run: slither . && just contracts-clean
-        working-directory: ./contracts
-        id: slither
+      - name: Run Slither Static Analyzer
+        run: just contracts-static-analysis
 
       - name: Run Forge fmt
         run: just contracts-fmt-check

--- a/contracts/.env-example
+++ b/contracts/.env-example
@@ -1,4 +1,4 @@
-# RPC Providers
+# RPC Provider
 
 ## The Alchemy API key (see https://www.alchemy.com/)
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -55,7 +55,7 @@ remappings_version = true
 runs = 1_000
 
 [profile.ci]
-fuzz = { runs = 10_000 }
+fuzz = { runs = 1_000 }
 verbosity = 3
 
 [rpc_endpoints]

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -55,7 +55,7 @@ remappings_version = true
 runs = 1_000
 
 [profile.ci]
-fuzz = { runs = 1_000 }
+fuzz = { runs = 10_000 }
 verbosity = 3
 
 [rpc_endpoints]

--- a/justfile
+++ b/justfile
@@ -68,6 +68,12 @@ contracts-deploy deployer chain *args:
         --sig "run(bool,address)" $IS_TEST_DEPLOYMENT $EMERGENCY_STOP_CALLER \
         --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
 
+# Execute a transaction binary on a deployed protocol adapter
+contracts-execute-tx deployer pa-address filepath chain *args:
+    cd contracts && forge script script/ExecuteTransaction.s.sol:ExecuteTransaction \
+        --sig "run(address,string)" {{pa-address}} {{filepath}} \
+        --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
+
 # Verify on sourcify
 contracts-verify-sourcify address chain *args:
     cd contracts && env -u ETHERSCAN_API_KEY forge verify-contract {{address}} \

--- a/justfile
+++ b/justfile
@@ -158,6 +158,29 @@ bindings-clippy:
 
 # --- All ---
 
+# Lint all (contracts + bindings)
+all-lint:
+    @echo "==> Linting contracts (forge lint)..."
+    @just contracts-lint
+    @echo "==> Linting contracts (solhint)..."
+    @just contracts-solhint
+    @echo "==> Linting bindings (clippy)..."
+    @just bindings-clippy
+
+# Format all (contracts + bindings)
+all-fmt:
+    @echo "==> Formatting contracts..."
+    @just contracts-fmt
+    @echo "==> Formatting bindings..."
+    @just bindings-fmt
+
+# Check formatting for all (contracts + bindings)
+all-fmt-check:
+    @echo "==> Checking contract formatting..."
+    @just contracts-fmt-check
+    @echo "==> Checking bindings formatting..."
+    @just bindings-fmt-check
+
 # Build all (contracts + bindings)
 all-build:
     @echo "==> Building contracts..."
@@ -172,8 +195,12 @@ all-test:
     @echo "==> Testing bindings..."
     @just bindings-test
 
-# Prerequisites check
+# Prerequisites check (mirrors CI)
 all-check:
     git status
+    @echo "==> Checking formatting..."
+    @just all-fmt-check
+    @echo "==> Linting..."
+    @just all-lint
     @echo "==> Checking bindings are up-to-date..."
     @just bindings-check

--- a/justfile
+++ b/justfile
@@ -23,16 +23,9 @@ contracts-clean:
 contracts-build *args:
     cd contracts && forge build {{ args }}
 
-# Run contract tests
-contracts-test *args:
-    cd contracts && forge test {{ args }}
-
-# Lint contracts (forge lint)
+# Lint contracts (forge lint + solhint)
 contracts-lint:
     cd contracts && forge lint --deny warnings
-
-# Run solhint on contracts
-contracts-solhint:
     cd contracts && bunx --bun solhint --config .solhint.json 'src/**/*.sol'
     cd contracts && bunx --bun solhint --config .solhint.other.json 'test/**/*.sol'
     cd contracts && bunx --bun solhint --config .solhint.other.json 'script/**/*.sol'
@@ -44,12 +37,16 @@ contracts-static-analysis:
     forge clean
 
 # Format contracts
-contracts-fmt:
-    cd contracts && forge fmt
+contracts-fmt *args:
+    cd contracts && forge fmt {{ args }}
 
 # Check contract formatting
 contracts-fmt-check:
     cd contracts && forge fmt --check
+
+# Run contract tests
+contracts-test *args:
+    cd contracts && forge test {{ args }}
 
 # Regenerate Rust bindings from contracts
 contracts-gen-bindings:
@@ -149,29 +146,27 @@ bindings-check: contracts-gen-bindings
 bindings-publish *args:
     cd bindings && cargo publish {{ args }}
 
-# Format Rust code
+# Lint bindings (clippy)
+bindings-lint:
+    cd bindings && cargo clippy --no-deps -- -Dwarnings
+    cd bindings && cargo clippy --no-deps --tests -- -Dwarnings
+
+# Format bindings
 bindings-fmt:
     cargo fmt
 
-# Check Rust formatting
+# Check bindings formatting
 bindings-fmt-check:
     cargo fmt -- --check
-
-# Lint Rust code with clippy
-bindings-clippy:
-    cargo clippy --no-deps -- -Dwarnings
-    cargo clippy --no-deps --tests -- -Dwarnings
 
 # --- All ---
 
 # Lint all (contracts + bindings)
 all-lint:
-    @echo "==> Linting contracts (forge lint)..."
+    @echo "==> Linting contracts..."
     @just contracts-lint
-    @echo "==> Linting contracts (solhint)..."
-    @just contracts-solhint
-    @echo "==> Linting bindings (clippy)..."
-    @just bindings-clippy
+    @echo "==> Linting bindings..."
+    @just bindings-lint
 
 # Format all (contracts + bindings)
 all-fmt:

--- a/justfile
+++ b/justfile
@@ -27,6 +27,24 @@ contracts-build *args:
 contracts-test *args:
     cd contracts && forge test {{ args }}
 
+# Lint contracts (forge lint)
+contracts-lint:
+    cd contracts && forge lint --deny warnings
+
+# Run solhint on contracts
+contracts-solhint:
+    cd contracts && bunx --bun solhint --config .solhint.json 'src/**/*.sol'
+    cd contracts && bunx --bun solhint --config .solhint.other.json 'test/**/*.sol'
+    cd contracts && bunx --bun solhint --config .solhint.other.json 'script/**/*.sol'
+
+# Format contracts
+contracts-fmt:
+    cd contracts && forge fmt
+
+# Check contract formatting
+contracts-fmt-check:
+    cd contracts && forge fmt --check
+
 # Regenerate Rust bindings from contracts
 contracts-gen-bindings:
     cd contracts && forge clean && forge bind \
@@ -118,6 +136,19 @@ bindings-check: contracts-gen-bindings
 # Publish bindings
 bindings-publish *args:
     cd bindings && cargo publish {{ args }}
+
+# Format Rust code
+bindings-fmt:
+    cargo fmt
+
+# Check Rust formatting
+bindings-fmt-check:
+    cargo fmt -- --check
+
+# Lint Rust code with clippy
+bindings-clippy:
+    cargo clippy --no-deps -- -Dwarnings
+    cargo clippy --no-deps --tests -- -Dwarnings
 
 # --- All ---
 

--- a/justfile
+++ b/justfile
@@ -37,6 +37,12 @@ contracts-solhint:
     cd contracts && bunx --bun solhint --config .solhint.other.json 'test/**/*.sol'
     cd contracts && bunx --bun solhint --config .solhint.other.json 'script/**/*.sol'
 
+# Run slither on contracts
+contracts-static-analysis:
+    cd contracts && slither .
+    @echo "Removing slither compilation artifacts..."
+    forge clean
+
 # Format contracts
 contracts-fmt:
     cd contracts && forge fmt
@@ -198,6 +204,8 @@ all-test:
 # Prerequisites check (mirrors CI)
 all-check:
     git status
+    @echo "==> Static analysis with slither..."
+    @just contracts-static-analysis
     @echo "==> Checking formatting..."
     @just all-fmt-check
     @echo "==> Linting..."


### PR DESCRIPTION
Port maintainability fixes from anomapay-erc20-forwarder:

- Bump CI fuzz runs from 1,000 → 10,000 (was identical to default, making the CI profile pointless)
- Consolidate two .env-example files into one at the root
- Add lint/fmt recipes: contracts-lint, contracts-solhint, contracts-fmt, contracts-fmt-check, bindings-fmt, bindings-fmt-check, bindings-clippy
- Add contracts-execute-tx recipe for ExecuteTransaction.s.sol
- Add aggregate recipes: all-lint, all-fmt, all-fmt-check
- CI workflows now use just recipes instead of direct tool invocations
- harmonizes the workflows and justfile with the anoma/anomapay-erc20-forwarder (see https://github.com/anoma/pa-evm/pull/504)