### PR TITLE
chore: bump bindings version to 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "anoma-pa-evm-bindings"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anoma-pa-evm-bindings"
-version = "2.1.0"
+version = "2.1.1"
 description = "The Anoma EVM protocol adapter contract bindings and deployments."
 keywords.workspace = true
 authors.workspace = true


### PR DESCRIPTION
This patch corrects the wrong BSC testnet address from #479.