### PR TITLE
fix(bindings): remove BSC testnet address

### DIFF
--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -33,10 +33,6 @@ pub fn protocol_adapter_deployments_map() -> HashMap<NamedChain, Address> {
             NamedChain::BinanceSmartChain,
             address!("0xFC44b66a39fe6923Ad8d3c93bFeC369728862B68"),
         ),
-        (
-            NamedChain::BinanceSmartChainTestnet,
-            address!("0xFC44b66a39fe6923Ad8d3c93bFeC369728862B68"),
-        ),
     ])
 }
 


### PR DESCRIPTION
safe{wallet} is not supported on BSC testnet so the emergency stop caller cannot be deployed.