### PR TITLE
refactor: rename IS_TEST_DEPLOYMENT to DETERMINISTIC_DEPLOYMENT

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -47,10 +47,10 @@ We distinguish between three release cases:
   cast wallet import deployer --mnemonic <MNEMONICC>
   ```
 
-- [ ] Set `IS_TEST_DEPLOYMENT` to `false` to deterministically deploy the protocol adapter.
+- [ ] Set `DETERMINISTIC_DEPLOYMENT` to `true` to deploy the protocol adapter deterministically.
 
   ```sh
-  export IS_TEST_DEPLOYMENT=false
+  export DETERMINISTIC_DEPLOYMENT=true
   ```
 
 - [ ] Check that the emergency caller address is set up correctly and export it with
@@ -210,10 +210,10 @@ For each chain, you want to deploy to, do the following:
   cast wallet import deployer --mnemonic <MNEMONICC>
   ```
 
-- [ ] Set `IS_TEST_DEPLOYMENT` to `false` to deterministically deploy the protocol adapter.
+- [ ] Set `DETERMINISTIC_DEPLOYMENT` to `true` to deploy the protocol adapter deterministically.
 
   ```sh
-  export IS_TEST_DEPLOYMENT=false
+  export DETERMINISTIC_DEPLOYMENT=true
   ```
 
 - [ ] Check that the emergency caller address is set up correctly and export it with

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -110,7 +110,7 @@ To simulate deployment on sepolia, run
 
 ```sh
 forge script script/DeployProtocolAdapter.s.sol:DeployProtocolAdapter \
-  --sig "run(bool,address)" <IS_TEST_DEPLOYMENT> <EMERGENCY_STOP_CALLER> \
+  --sig "run(bool,address)" <DETERMINISTIC_DEPLOYMENT> <EMERGENCY_STOP_CALLER> \
   --rpc-url sepolia
 ```
 

--- a/contracts/script/DeployProtocolAdapter.s.sol
+++ b/contracts/script/DeployProtocolAdapter.s.sol
@@ -66,12 +66,12 @@ contract DeployProtocolAdapter is Script {
         _supportNetwork({name: "bsc", chainId: 56, riscZeroVerifierRouter: 0x7C1B7b8fEB636eA9Ecd32152Bce2744a0EEf39C7});
     }
 
-    /// @notice Deploys the protocol adapter contract on supported networks and allows for test deployments.
-    /// @param isTestDeployment Whether the deployment is a test deployment or not. If set to `false`, the protocol
-    /// adapter is deployed deterministically.
+    /// @notice Deploys the protocol adapter contract on supported networks.
+    /// @param deterministic Whether to deploy the protocol adapter deterministically using CREATE2 with a salt.
     /// @param emergencyStopCaller The emergency stop caller that can stop the protocol adapter in an emergency.
-    /// @dev If `isTestDeployment` is set to `false`, the protocol adapter is deployed deterministically.
-    function run(bool isTestDeployment, address emergencyStopCaller) public returns (address protocolAdapter) {
+    /// @dev If `deterministic` is set to `true`, the protocol adapter is deployed using CREATE2 with a version-derived
+    /// salt, producing a predictable address. If set to `false`, the contract is deployed regularly.
+    function run(bool deterministic, address emergencyStopCaller) public returns (address protocolAdapter) {
         // Lookup the RISC Zero router address from the supported networks.
         RiscZeroVerifierRouter riscZeroVerifierRouter = _riscZeroVerifierRouters[_supportedNetworks[block.chainid]];
 
@@ -81,16 +81,7 @@ contract DeployProtocolAdapter is Script {
 
         vm.startBroadcast();
 
-        if (isTestDeployment) {
-            // Deploy regularly.
-            protocolAdapter = address(
-                new ProtocolAdapter({
-                    riscZeroVerifierRouter: riscZeroVerifierRouter,
-                    riscZeroVerifierSelector: Versioning._RISC_ZERO_VERIFIER_SELECTOR,
-                    emergencyStopCaller: emergencyStopCaller
-                })
-            );
-        } else {
+        if (deterministic) {
             // Deploy deterministically.
             protocolAdapter = address(
                 new ProtocolAdapter{
@@ -98,6 +89,15 @@ contract DeployProtocolAdapter is Script {
                         bytes(string.concat("ProtocolAdapter", Versioning._PROTOCOL_ADAPTER_VERSION.fromSmallString()))
                     )
                 }({
+                    riscZeroVerifierRouter: riscZeroVerifierRouter,
+                    riscZeroVerifierSelector: Versioning._RISC_ZERO_VERIFIER_SELECTOR,
+                    emergencyStopCaller: emergencyStopCaller
+                })
+            );
+        } else {
+            // Deploy regularly.
+            protocolAdapter = address(
+                new ProtocolAdapter({
                     riscZeroVerifierRouter: riscZeroVerifierRouter,
                     riscZeroVerifierSelector: Versioning._RISC_ZERO_VERIFIER_SELECTOR,
                     emergencyStopCaller: emergencyStopCaller

--- a/contracts/test/DeployProtocolAdapter.t.sol
+++ b/contracts/test/DeployProtocolAdapter.t.sol
@@ -11,21 +11,21 @@ contract DeployProtocolAdapterTest is Test {
     }
 
     // forge-lint: disable-next-line(mixed-case-function)
-    function tableNetworksTest_DeployProtocolAdapter_test_deployment_succeeds_on_all_supported_networks(TestCase memory network)
+    function tableNetworksTest_DeployProtocolAdapter_regular_deployment_succeeds_on_all_supported_networks(TestCase memory network)
         public
     {
         vm.selectFork(vm.createFork(network.name));
 
-        new DeployProtocolAdapter().run({isTestDeployment: true, emergencyStopCaller: msg.sender});
+        new DeployProtocolAdapter().run({deterministic: false, emergencyStopCaller: msg.sender});
     }
 
     // forge-lint: disable-next-line(mixed-case-function)
-    function tableNetworksTest_DeployProtocolAdapter_prod_deployment_succeeds_on_all_supported_networks(TestCase memory network)
+    function tableNetworksTest_DeployProtocolAdapter_deterministic_deployment_succeeds_on_all_supported_networks(TestCase memory network)
         public
     {
         vm.selectFork(vm.createFork(network.name));
 
-        new DeployProtocolAdapter().run({isTestDeployment: false, emergencyStopCaller: msg.sender});
+        new DeployProtocolAdapter().run({deterministic: true, emergencyStopCaller: msg.sender});
     }
 
     function fixtureNetwork() public pure returns (TestCase[] memory network) {

--- a/justfile
+++ b/justfile
@@ -59,16 +59,16 @@ contracts-gen-bindings:
 
 # Simulate deployment (dry-run)
 contracts-simulate chain *args:
-    @echo "IS_TEST_DEPLOYMENT: $IS_TEST_DEPLOYMENT"
+    @echo "DETERMINISTIC_DEPLOYMENT: $DETERMINISTIC_DEPLOYMENT"
     @echo "EMERGENCY_STOP_CALLER: $EMERGENCY_STOP_CALLER"
     cd contracts && forge script script/DeployProtocolAdapter.s.sol:DeployProtocolAdapter \
-        --sig "run(bool,address)" $IS_TEST_DEPLOYMENT $EMERGENCY_STOP_CALLER \
+        --sig "run(bool,address)" $DETERMINISTIC_DEPLOYMENT $EMERGENCY_STOP_CALLER \
         --rpc-url {{chain}} {{ args }}
 
 # Deploy protocol adapter
 contracts-deploy deployer chain *args:
     cd contracts && forge script script/DeployProtocolAdapter.s.sol:DeployProtocolAdapter \
-        --sig "run(bool,address)" $IS_TEST_DEPLOYMENT $EMERGENCY_STOP_CALLER \
+        --sig "run(bool,address)" $DETERMINISTIC_DEPLOYMENT $EMERGENCY_STOP_CALLER \
         --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
 
 # Execute a transaction binary on a deployed protocol adapter


### PR DESCRIPTION
The old name `IS_TEST_DEPLOYMENT` (and Solidity param `isTestDeployment`) was misleading — it implied a test vs. production environment distinction, but the flag actually controls whether the contract is deployed deterministically via CREATE2 with a version-derived salt.

This renames it to `DETERMINISTIC_DEPLOYMENT` / `deterministic` and flips the boolean so `true` means deterministic (CREATE2). Updated across the deploy script, tests, justfile, README, and release checklist.

Other smart contract projects that adopted the same `IS_TEST_DEPLOYMENT` convention should apply equivalent updates.