### PR TITLE
fix(justfile): guard contracts-publish against non-semver version

### DIFF
--- a/justfile
+++ b/justfile
@@ -100,8 +100,10 @@ contracts-verify-custom address chain verifier-url *args:
 # Verify on both sourcify and etherscan
 contracts-verify address chain: (contracts-verify-sourcify address chain) (contracts-verify-etherscan address chain)
 
-# Publish contracts
+# Publish contracts to soldeer. VERSION must be semver (e.g. 1.2.0).
+# Flags such as --dry-run go AFTER the version: `just contracts-publish 1.2.0 --dry-run`.
 contracts-publish version *args:
+    @[[ "{{version}}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]] || { echo "error: invalid version '{{version}}'. Expected semver like 1.2.0. Usage: just contracts-publish <version> [flags] (put --dry-run AFTER the version)." >&2; exit 1; }
     cd contracts && forge soldeer push anoma-pa-evm~{{version}} {{ args }}
 
 # --- Bindings ---


### PR DESCRIPTION
Running `just contracts-publish --dry-run` used to bind `--dry-run` to the required `version` argument, so it ran `forge soldeer push anoma-pa-evm~--dry-run` — a real publish with a garbage version tag.

This adds a semver check on `version` in the `contracts-publish` recipe that fails fast with a usage hint (flags like --dry-run go after the version). No behavior change for correct usage like `just contracts-publish 1.2.0 --dry-run`.

Note: the Bindings CI job is red from a pre-existing anvil fork-startup flake, unrelated to this justfile-only change. Fixed separately by #547 (raise fork timeout).