### PR TITLE
ci(bindings): fix rust cache with Swatinem/rust-cache

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -35,13 +35,8 @@ jobs:
       - name: Show Foundry version
         run: forge --version
 
-      - name: Restore dependencies cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            target
-          key: rust-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: rust-
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run rustfmt
         run: just bindings-fmt-check


### PR DESCRIPTION
Swap the hand-rolled `actions/cache` for `Swatinem/rust-cache@v2`. The old step cached only the workspace `target/` and never restored `~/.cargo`, so it seldom hit; Swatinem caches `target/` plus the cargo registry/git, keyed on Cargo.lock and the toolchain.

Retry-on-flaky was split out and dropped. The bindings job here depends on the anvil fork-startup timeout fix (#547) and stays red until that reaches this base; land #547 first (or rebase this on top of it), then bindings goes green.