### PR TITLE
test(bindings): raise anvil fork startup timeout to 120s

### DIFF
--- a/bindings/tests/contract.rs
+++ b/bindings/tests/contract.rs
@@ -88,8 +88,9 @@ async fn pa_instance(
 ) -> protocol_adapter::ProtocolAdapter::ProtocolAdapterInstance<DynProvider> {
     let rpc_url = alchemy_url(chain).expect("Couldn't get RPC URL for chain");
 
+    // Raise anvil's 10s fork-startup default; slow RPCs Timeout as chains grow.
     let provider = ProviderBuilder::new()
-        .connect_anvil_with_wallet_and_config(|a| a.fork(rpc_url))
+        .connect_anvil_with_wallet_and_config(|a| a.fork(rpc_url).timeout(120_000))
         .expect("Couldn't create anvil provider");
     protocol_adapter(&provider.erased())
         .await


### PR DESCRIPTION
The bindings tests fork a node per chain. Unlike the generic-call-forwarder fix (#26), these can't drop forking: the protocol adapter constructor calls into the risc0 verifier router (`isEmergencyStopped`), and the execute test sends a real transaction against the deployed adapter, both of which need a forked node.

Anvil only reports ready after it fetches fork state from the RPC, so a slow or rate-limited RPC blows past anvil's 10s startup default and the test panics with `Timeout` (and it gets worse as chains are added). Raise the fork startup timeout to 120s.