### PR TITLE
refactor: gather the protocol adapter types in a Types library

### DIFF
--- a/contracts/src/ProtocolAdapter.sol
+++ b/contracts/src/ProtocolAdapter.sol
@@ -17,7 +17,7 @@ import {VerifyingKeys} from "./libs/proving/VerifyingKeys.sol";
 import {RiscZeroUtils} from "./libs/RiscZeroUtils.sol";
 import {CommitmentTree} from "./state/CommitmentTree.sol";
 import {NullifierSet} from "./state/NullifierSet.sol";
-import {Action, Consumed, Created, Transaction} from "./Types.sol";
+import {Types} from "./Types.sol";
 
 /// @title ProtocolAdapter
 /// @author Anoma Foundation, 2025
@@ -34,8 +34,8 @@ contract ProtocolAdapter is
     CommitmentTree,
     NullifierSet
 {
-    using Delta for Delta.Point;
-    using RiscZeroUtils for Transaction;
+    using Delta for Types.Delta;
+    using RiscZeroUtils for Types.Transaction;
 
     /// @custom:storage-location erc7201:anoma.storage.ProtocolAdapter
     struct ProtocolAdapterStorage {
@@ -104,12 +104,15 @@ contract ProtocolAdapter is
     }
 
     /// @inheritdoc IProtocolAdapter
-    function execute(Transaction calldata transaction) external override {
+    function execute(Types.Transaction calldata transaction) external override {
         _execute({transaction: transaction, skipRiscZeroProofVerification: false});
     }
 
     /// @inheritdoc IProtocolAdapter
-    function simulateExecute(Transaction calldata transaction, bool skipRiscZeroProofVerification) external override {
+    function simulateExecute(Types.Transaction calldata transaction, bool skipRiscZeroProofVerification)
+        external
+        override
+    {
         uint256 gasStart = gasleft();
 
         _execute({transaction: transaction, skipRiscZeroProofVerification: skipRiscZeroProofVerification});
@@ -166,7 +169,7 @@ contract ProtocolAdapter is
     /// @dev This function cannot be called anymore once `emergencyStop()` has been called.
     // NOTE: The state writes and reads after the forwarder calls are protected by the `nonReentrant` modifier.
     // slither-disable-next-line reentrancy-no-eth,reentrancy-benign
-    function _execute(Transaction calldata transaction, bool skipRiscZeroProofVerification)
+    function _execute(Types.Transaction calldata transaction, bool skipRiscZeroProofVerification)
         internal
         nonReentrant
         whenNotPaused
@@ -177,11 +180,11 @@ contract ProtocolAdapter is
         require(actionCount != 0, EmptyTransactionNotAllowed());
 
         bytes32[] memory actionTreeRoots = new bytes32[](actionCount);
-        Delta.Point memory transactionDelta = Delta.zero();
+        Types.Delta memory transactionDelta = Delta.zero();
         bytes32 updatedCommitmentTreeRoot = bytes32(0);
 
         for (uint256 i = 0; i < actionCount; ++i) {
-            Action calldata action = transaction.actions[i];
+            Types.Action calldata action = transaction.actions[i];
 
             bytes32 newRoot = _processAction(action);
             if (newRoot != bytes32(0)) {
@@ -226,13 +229,13 @@ contract ProtocolAdapter is
     // NOTE: The nullifier and commitment writes around the forwarder calls are protected by the `nonReentrant`
     // modifier on the calling `_execute`.
     // slither-disable-next-line reentrancy-no-eth
-    function _processAction(Action calldata action) internal returns (bytes32 updatedCommitmentTreeRoot) {
+    function _processAction(Types.Action calldata action) internal returns (bytes32 updatedCommitmentTreeRoot) {
         uint256 consumedCount = action.consumed.length;
         bytes32[] memory nullifiers = new bytes32[](consumedCount);
         bytes32[] memory consumedLogicRefs = new bytes32[](consumedCount);
 
         for (uint256 i = 0; i < consumedCount; ++i) {
-            Consumed calldata consumed = action.consumed[i];
+            Types.Consumed calldata consumed = action.consumed[i];
 
             // Check that the referenced commitment tree root is part of the historical roots.
             require(
@@ -255,7 +258,7 @@ contract ProtocolAdapter is
         bytes32[] memory createdLogicRefs = new bytes32[](createdCount);
 
         for (uint256 i = 0; i < createdCount; ++i) {
-            Created calldata created = action.created[i];
+            Types.Created calldata created = action.created[i];
 
             // `_addCommitment` does not error if a repeating leaf is added to the tree.
             // Uniqueness of commitments is granted by the compliance circuit, assuming that nullifiers are unique.
@@ -371,9 +374,9 @@ contract ProtocolAdapter is
     /// @param skipRiscZeroProofVerification Whether to skip RISC Zero proof verification or not.
     /// @return transactionId The delta verifying key doubling as the transaction ID.
     function _verifyGlobalProofs(
-        Transaction calldata transaction,
+        Types.Transaction calldata transaction,
         bytes32[] memory actionTreeRoots,
-        Delta.Point memory transactionDelta,
+        Types.Delta memory transactionDelta,
         bool skipRiscZeroProofVerification
     ) internal view returns (bytes32 transactionId) {
         // The delta proof signs the Keccak-256 hash of the concatenated action tree roots.

--- a/contracts/src/Types.sol
+++ b/contracts/src/Types.sol
@@ -1,72 +1,85 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Delta} from "./libs/proving/Delta.sol";
 import {Logic} from "./libs/proving/Logic.sol";
 
-/// @notice The resource object constituting the atomic unit of state in the Anoma protocol.
-/// @param  logicRef The hash of the resource logic function.
-/// @param  labelRef The hash of the resource label, which can contain arbitrary data.
-/// @param  valueRef The hash of the resource value, which can contain arbitrary data.
-/// @param  nullifierKeyCommitment The commitment to the nullifier key.
-/// @param  quantity The quantity that the resource represents.
-/// @param  nonce The nonce guaranteeing the resource's uniqueness.
-/// @param  randSeed The randomness seed that can be used to derive pseudo-randomness for applications.
-/// @param  ephemeral The resource's ephemerality.
-struct Resource {
-    bytes32 logicRef;
-    bytes32 labelRef;
-    bytes32 valueRef;
-    bytes32 nullifierKeyCommitment;
-    bytes32 nonce;
-    bytes32 randSeed;
-    uint128 quantity;
-    bool ephemeral;
-}
+/// @title Types
+/// @author Anoma Foundation, 2025
+/// @notice A library containing the type definitions of the protocol adapter.
+/// @custom:security-contact security@anoma.foundation
+library Types {
+    /// @notice The resource object constituting the atomic unit of state in the Anoma protocol.
+    /// @param  logicRef The hash of the resource logic function.
+    /// @param  labelRef The hash of the resource label, which can contain arbitrary data.
+    /// @param  valueRef The hash of the resource value, which can contain arbitrary data.
+    /// @param  nullifierKeyCommitment The commitment to the nullifier key.
+    /// @param  quantity The quantity that the resource represents.
+    /// @param  nonce The nonce guaranteeing the resource's uniqueness.
+    /// @param  randSeed The randomness seed that can be used to derive pseudo-randomness for applications.
+    /// @param  ephemeral The resource's ephemerality.
+    struct Resource {
+        bytes32 logicRef;
+        bytes32 labelRef;
+        bytes32 valueRef;
+        bytes32 nullifierKeyCommitment;
+        bytes32 nonce;
+        bytes32 randSeed;
+        uint128 quantity;
+        bool ephemeral;
+    }
 
-/// @notice The transaction object containing all required data to conduct a RM state transition
-/// in which resources get consumed and created.
-/// @param actions The list of actions to be executed.
-/// @param deltaProof The proof for the transaction delta value.
-/// @param aggregationProof The recursive proof of all compliance and resource logics in the transaction — the only
-/// RISC Zero proof being verified.
-struct Transaction {
-    Action[] actions;
-    bytes deltaProof;
-    bytes aggregationProof;
-}
+    /// @notice The transaction object containing all required data to conduct a RM state transition
+    /// in which resources get consumed and created.
+    /// @param actions The list of actions to be executed.
+    /// @param deltaProof The proof for the transaction delta value.
+    /// @param aggregationProof The recursive proof of all compliance and resource logics in the transaction — the only
+    /// RISC Zero proof being verified.
+    struct Transaction {
+        Action[] actions;
+        bytes deltaProof;
+        bytes aggregationProof;
+    }
 
-/// @notice The action object providing context separation between non-intersecting sets of resources. An action
-/// corresponds to one compliance unit constraining its consumed and created resources.
-/// @param consumed The public data of the consumed resources.
-/// @param created The public data of the created resources.
-/// @param delta The action's delta value obtained from the underlying compliance unit.
-/// @param actionTreeRoot The root of the tree containing the tags of all resources present in the action.
-struct Action {
-    Consumed[] consumed;
-    Created[] created;
-    Delta.Point delta;
-    bytes32 actionTreeRoot;
-}
+    /// @notice The action object providing context separation between non-intersecting sets of resources. An action
+    /// corresponds to one compliance unit constraining its consumed and created resources.
+    /// @param consumed The public data of the consumed resources.
+    /// @param created The public data of the created resources.
+    /// @param delta The action's delta value obtained from the underlying compliance unit.
+    /// @param actionTreeRoot The root of the tree containing the tags of all resources present in the action.
+    struct Action {
+        Consumed[] consumed;
+        Created[] created;
+        Delta delta;
+        bytes32 actionTreeRoot;
+    }
 
-/// @notice The public data of a consumed resource.
-/// @param nullifier The nullifier of the resource.
-/// @param logicRef The reference to (the verifying key of) the resource logic.
-/// @param commitmentTreeRoot The historical commitment tree root the resource's inclusion is proven against.
-/// @param appData The application data associated with the resource.
-struct Consumed {
-    bytes32 nullifier;
-    bytes32 logicRef;
-    bytes32 commitmentTreeRoot;
-    Logic.AppData appData;
-}
+    /// @notice The public data of a consumed resource.
+    /// @param nullifier The nullifier of the resource.
+    /// @param logicRef The reference to (the verifying key of) the resource logic.
+    /// @param commitmentTreeRoot The historical commitment tree root the resource's inclusion is proven against.
+    /// @param appData The application data associated with the resource.
+    struct Consumed {
+        bytes32 nullifier;
+        bytes32 logicRef;
+        bytes32 commitmentTreeRoot;
+        Logic.AppData appData;
+    }
 
-/// @notice The public data of a created resource.
-/// @param commitment The commitment of the resource.
-/// @param logicRef The reference to (the verifying key of) the resource logic.
-/// @param appData The application data associated with the resource.
-struct Created {
-    bytes32 commitment;
-    bytes32 logicRef;
-    Logic.AppData appData;
+    /// @notice The public data of a created resource.
+    /// @param commitment The commitment of the resource.
+    /// @param logicRef The reference to (the verifying key of) the resource logic.
+    /// @param appData The application data associated with the resource.
+    struct Created {
+        bytes32 commitment;
+        bytes32 logicRef;
+        Logic.AppData appData;
+    }
+
+    /// @notice An elliptic curve point representing a delta value.
+    /// @param x The x component of the point.
+    /// @param y The y component of the point.
+    struct Delta {
+        uint256 x;
+        uint256 y;
+    }
 }

--- a/contracts/src/interfaces/IProtocolAdapter.sol
+++ b/contracts/src/interfaces/IProtocolAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Transaction} from "../Types.sol";
+import {Types} from "../Types.sol";
 
 /// @title IProtocolAdapter
 /// @author Anoma Foundation, 2025
@@ -65,13 +65,13 @@ interface IProtocolAdapter {
     /// @notice Executes a transaction by adding the commitments and nullifiers to the commitment tree and nullifier
     /// set, respectively.
     /// @param transaction The transaction to execute.
-    function execute(Transaction calldata transaction) external;
+    function execute(Types.Transaction calldata transaction) external;
 
     /// @notice Simulates a transaction and returns the gas after reverting.
     /// @param transaction The transaction to simulate execution for.
     /// @param skipRiscZeroProofVerification Whether to skip RISC Zero proof verification or not.
     /// @dev This transaction will always revert.
-    function simulateExecute(Transaction calldata transaction, bool skipRiscZeroProofVerification) external;
+    function simulateExecute(Types.Transaction calldata transaction, bool skipRiscZeroProofVerification) external;
 
     /// @notice Stops the protocol adapter permanently in case of an emergency.
     function emergencyStop() external;

--- a/contracts/src/libs/RiscZeroUtils.sol
+++ b/contracts/src/libs/RiscZeroUtils.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {reverseByteOrderUint32} from "risc0-risc0-ethereum-3.0.1/contracts/src/Util.sol";
 
-import {Action, Consumed, Created, Transaction} from "../Types.sol";
+import {Types} from "../Types.sol";
 import {Logic} from "./proving/Logic.sol";
 
 /// @title RiscZeroUtils
@@ -13,7 +13,7 @@ import {Logic} from "./proving/Logic.sol";
 /// digests as raw 32 bytes.
 /// @custom:security-contact security@anoma.foundation
 library RiscZeroUtils {
-    using RiscZeroUtils for Action;
+    using RiscZeroUtils for Types.Action;
     using RiscZeroUtils for Logic.AppData;
 
     /// @notice Converts a transaction to the RISC Zero journal of the aggregation instance.
@@ -23,7 +23,7 @@ library RiscZeroUtils {
     /// @return journal The resulting RISC Zero journal.
     /// @dev Element counts can safely be assumed to not exceed `type(uint32).max` as this would exceed Ethereum's
     /// block gas limit.
-    function toJournal(Transaction calldata transaction, bytes32 complianceKey, bytes32 kindTableCommitment)
+    function toJournal(Types.Transaction calldata transaction, bytes32 complianceKey, bytes32 kindTableCommitment)
         internal
         pure
         returns (bytes memory journal)
@@ -45,13 +45,13 @@ library RiscZeroUtils {
     /// @notice Converts an action to its part of the aggregation journal — the arm `ActionAggregated` encoding.
     /// @param action The action to encode.
     /// @return journal The resulting journal part.
-    function toJournal(Action calldata action) internal pure returns (bytes memory journal) {
+    function toJournal(Types.Action calldata action) internal pure returns (bytes memory journal) {
         uint256 consumedCount = action.consumed.length;
         // forge-lint: disable-next-line(unsafe-typecast)
         journal = abi.encodePacked(reverseByteOrderUint32(uint32(consumedCount)));
 
         for (uint256 i = 0; i < consumedCount; ++i) {
-            Consumed calldata consumed = action.consumed[i];
+            Types.Consumed calldata consumed = action.consumed[i];
             journal = abi.encodePacked(
                 journal,
                 consumed.nullifier,
@@ -66,7 +66,7 @@ library RiscZeroUtils {
         journal = abi.encodePacked(journal, reverseByteOrderUint32(uint32(createdCount)));
 
         for (uint256 i = 0; i < createdCount; ++i) {
-            Created calldata created = action.created[i];
+            Types.Created calldata created = action.created[i];
             journal = abi.encodePacked(journal, created.commitment, created.logicRef, created.appData.toJournal());
         }
 

--- a/contracts/src/libs/proving/Delta.sol
+++ b/contracts/src/libs/proving/Delta.sol
@@ -5,20 +5,14 @@ import {ECDSA} from "@openzeppelin-contracts-5.6.1/utils/cryptography/ECDSA.sol"
 import {EllipticCurve} from "elliptic-curve-solidity-0.2.5/contracts/EllipticCurve.sol";
 import {EfficientHashLib} from "solady-0.1.26/src/utils/EfficientHashLib.sol";
 
+import {Types} from "../../Types.sol";
+
 /// @title Delta
 /// @author Anoma Foundation, 2025
 /// @notice A library containing methods of the delta proving system.
 /// @custom:security-contact security@anoma.foundation
 library Delta {
-    using Delta for Point;
-
-    /// @notice An elliptic curve point representing a delta value.
-    /// @param x The x component of the point.
-    /// @param y The y component of the point.
-    struct Point {
-        uint256 x;
-        uint256 y;
-    }
+    using Delta for Types.Delta;
 
     /// @notice The x-coordinate of the curve generator point.
     uint256 internal constant _GX = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
@@ -39,12 +33,12 @@ library Delta {
     error DeltaMismatch(address expected, address actual);
 
     /// @notice Thrown when a provided point is not on the curve.
-    error PointNotOnCurve(Point point);
+    error PointNotOnCurve(Types.Delta point);
 
     /// @notice Returns the elliptic curve point representing the zero delta.
     /// @return zeroDelta The zero delta.
-    function zero() internal pure returns (Point memory zeroDelta) {
-        zeroDelta = Point({x: 0, y: 0});
+    function zero() internal pure returns (Types.Delta memory zeroDelta) {
+        zeroDelta = Types.Delta({x: 0, y: 0});
     }
 
     /// @notice Adds two delta points and returns the sum.
@@ -54,7 +48,7 @@ library Delta {
     /// @dev Note that only the right-hand side point is checked to allow adding the zero delta from the left. This is
     /// done due to the delta points being added sequentially starting from the zero delta in the
     /// `ProtocolAdapter.execute()` function.
-    function add(Point memory lhs, Point memory rhs) internal pure returns (Point memory sum) {
+    function add(Types.Delta memory lhs, Types.Delta memory rhs) internal pure returns (Types.Delta memory sum) {
         require(EllipticCurve.isOnCurve({_x: rhs.x, _y: rhs.y, _aa: _AA, _bb: _BB, _pp: _PP}), PointNotOnCurve(rhs));
 
         (sum.x, sum.y) = EllipticCurve.ecAdd({_x1: lhs.x, _y1: lhs.y, _x2: rhs.x, _y2: rhs.y, _aa: _AA, _pp: _PP});
@@ -63,7 +57,7 @@ library Delta {
     /// @notice Converts an elliptic curve point to an Ethereum account address.
     /// @param delta The elliptic curve point.
     /// @return account The associated account.
-    function toAccount(Point memory delta) internal pure returns (address account) {
+    function toAccount(Types.Delta memory delta) internal pure returns (address account) {
         // Hash the public key with Keccak-256.
         bytes32 hashedKey = EfficientHashLib.hash(delta.x, delta.y);
 
@@ -83,7 +77,7 @@ library Delta {
     /// @param proof The delta proof.
     /// @param instance The transaction delta.
     /// @param verifyingKey The Keccak-256 hash of all action tree roots as ordered in the transaction.
-    function verify(bytes memory proof, Point memory instance, bytes32 verifyingKey) internal pure {
+    function verify(bytes memory proof, Types.Delta memory instance, bytes32 verifyingKey) internal pure {
         // Verify the delta proof using the ECDSA.recover API to obtain the address
         address recovered = ECDSA.recover({hash: verifyingKey, signature: proof});
 

--- a/contracts/test/KindTableCommitment.t.sol
+++ b/contracts/test/KindTableCommitment.t.sol
@@ -13,7 +13,7 @@ import {RiscZeroMockVerifier} from "risc0-risc0-ethereum-3.0.1/contracts/src/tes
 
 import {IProtocolAdapter} from "../src/interfaces/IProtocolAdapter.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
-import {Transaction} from "../src/Types.sol";
+import {Types} from "../src/Types.sol";
 import {TxGen} from "./libs/TxGen.sol";
 
 contract KindTableCommitmentStorageTest is Test, ProtocolAdapter {
@@ -76,7 +76,7 @@ contract KindTableCommitmentTest is Test {
     /// @dev A transaction proven against the previous kind table is unencodable after a rotation: the journal the
     /// protocol adapter reconstructs embeds the stored commitment, so the proven digest no longer matches.
     function test_execute_reverts_for_transactions_proven_against_a_different_kind_table() public {
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -96,7 +96,7 @@ contract KindTableCommitmentTest is Test {
         vm.prank(_OWNER);
         _mockPa.setKindTableCommitment(newCommitment);
 
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})

--- a/contracts/test/ProtocolAdapter.unit.t.sol
+++ b/contracts/test/ProtocolAdapter.unit.t.sol
@@ -22,7 +22,7 @@ import {RiscZeroMockVerifier} from "risc0-risc0-ethereum-3.0.1/contracts/src/tes
 import {SemVerLib} from "solady-0.1.26/src/utils/SemVerLib.sol";
 
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
-import {Transaction} from "../src/Types.sol";
+import {Types} from "../src/Types.sol";
 import {TxGen} from "./libs/TxGen.sol";
 
 contract ProtocolAdapterTest is Test {
@@ -41,7 +41,7 @@ contract ProtocolAdapterTest is Test {
     ProtocolAdapter internal _pa;
     bytes4 internal _verifierSelector;
 
-    Transaction internal _emptyTx;
+    Types.Transaction internal _emptyTx;
 
     function setUp() public {
         (_router, _emergencyStop, _verifier) =
@@ -69,7 +69,7 @@ contract ProtocolAdapterTest is Test {
     }
 
     function test_execute_reverts_if_the_aggregation_proof_has_been_generated_with_another_unstopped_verifier() public {
-        (Transaction memory txnWithMockProof,) = vm.transaction({
+        (Types.Transaction memory txnWithMockProof,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})

--- a/contracts/test/ProtocolAdapter.upgrade.t.sol
+++ b/contracts/test/ProtocolAdapter.upgrade.t.sol
@@ -15,7 +15,7 @@ import {RiscZeroVerifierRouter} from "risc0-risc0-ethereum-3.0.1/contracts/src/R
 import {RiscZeroMockVerifier} from "risc0-risc0-ethereum-3.0.1/contracts/src/test/RiscZeroMockVerifier.sol";
 
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
-import {Transaction} from "../src/Types.sol";
+import {Types} from "../src/Types.sol";
 import {TxGen} from "./libs/TxGen.sol";
 import {ProtocolAdapterResumableMock} from "./mocks/ProtocolAdapterResumable.m.sol";
 
@@ -44,7 +44,7 @@ contract ProtocolAdapterUpgradeTest is Test {
 
     function test_upgrade_allows_replacing_the_risc_zero_verifier_selector_after_an_emergency_stop() public {
         // Execute a transaction proven against the old verifier.
-        (Transaction memory oldTxn, bytes32 nonce) = vm.transaction({
+        (Types.Transaction memory oldTxn, bytes32 nonce) = vm.transaction({
             mockVerifier: _verifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -63,7 +63,7 @@ contract ProtocolAdapterUpgradeTest is Test {
         // A fresh transaction proven against the stopped verifier reverts on proof verification. A fresh
         // transaction is needed because the state transition — rejecting the replayed nullifiers of `oldTxn` —
         // precedes proof verification.
-        (Transaction memory secondOldTxn,) = vm.transaction({
+        (Types.Transaction memory secondOldTxn,) = vm.transaction({
             mockVerifier: _verifier,
             nonce: nonce,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -95,7 +95,7 @@ contract ProtocolAdapterUpgradeTest is Test {
         assertEq(_pa.commitmentCount(), commitmentCountBeforeUpgrade, "the commitment count should survive the upgrade");
 
         // Transactions proven against the new verifier execute.
-        (Transaction memory newTxn,) = vm.transaction({
+        (Types.Transaction memory newTxn,) = vm.transaction({
             mockVerifier: newVerifier,
             nonce: bytes32(uint256(1000)),
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -117,7 +117,7 @@ contract ProtocolAdapterUpgradeTest is Test {
     /// upgrade to an implementation carrying a recovery path.
     function test_upgrade_allows_lifting_the_pause_set_by_an_emergency_stop() public {
         // Execute a transaction while the protocol adapter is operational.
-        (Transaction memory txnBeforeStop, bytes32 nonce) = vm.transaction({
+        (Types.Transaction memory txnBeforeStop, bytes32 nonce) = vm.transaction({
             mockVerifier: _verifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -135,7 +135,7 @@ contract ProtocolAdapterUpgradeTest is Test {
 
         // Execution is halted. The `whenNotPaused` modifier rejects the transaction before it touches any state, so
         // this very transaction can be replayed once the pause is lifted.
-        (Transaction memory txnAfterStop,) = vm.transaction({
+        (Types.Transaction memory txnAfterStop,) = vm.transaction({
             mockVerifier: _verifier,
             nonce: nonce,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})

--- a/contracts/test/ProtocolAdapterMock.unit.t.sol
+++ b/contracts/test/ProtocolAdapterMock.unit.t.sol
@@ -30,13 +30,13 @@ import {SHA256} from "../src/libs/SHA256.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 import {CommitmentTree} from "../src/state/CommitmentTree.sol";
 import {NullifierSet} from "../src/state/NullifierSet.sol";
-import {Transaction, Action} from "../src/Types.sol";
+import {Types} from "../src/Types.sol";
 import {TxGen} from "./libs/TxGen.sol";
 import {CommitmentTreeMock} from "./mocks/CommitmentTree.m.sol";
 
 contract ProtocolAdapterMockVerifierTest is Test {
-    using TxGen for Action[];
-    using TxGen for Action;
+    using TxGen for Types.Action[];
+    using TxGen for Types.Action;
     using TxGen for Vm;
 
     address internal constant _OWNER = address(uint160(1));
@@ -78,7 +78,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         actionCount = uint8(bound(actionCount, 1, 10));
         resourcePairCount = uint8(bound(resourcePairCount, 1, 10));
 
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -100,7 +100,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         consumedCount = uint8(bound(consumedCount, 1, 5));
         createdCount = uint8(bound(createdCount, 1, 5));
 
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -127,7 +127,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
-        Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
+        Types.Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -142,7 +142,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
-        Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
+        Types.Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -165,7 +165,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
 
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
-        Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
+        Types.Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
 
         vm.expectEmit(address(_mockPa));
         emit IProtocolAdapter.ForwarderCallExecuted({
@@ -187,7 +187,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         configs[0] = TxGen.ActionConfig({consumedCount: 1, createdCount: 1});
         configs[1] = TxGen.ActionConfig({consumedCount: 0, createdCount: 0});
 
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
+        (Types.Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
 
         vm.expectPartialRevert(Delta.PointNotOnCurve.selector);
         _mockPa.execute(txn);
@@ -204,7 +204,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
             createdCount: uint8(bound(createdCount, 1, 5))
         });
 
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
+        (Types.Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
         _mockPa.execute(txn);
     }
 
@@ -215,7 +215,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
             createdCount: uint8(bound(resourcePairCount, 1, 5))
         });
 
-        (Transaction memory txn, bytes32 updatedNonce) =
+        (Types.Transaction memory txn, bytes32 updatedNonce) =
             vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
         _mockPa.execute(txn);
 
@@ -230,7 +230,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         TxGen.ActionConfig[] memory configs = new TxGen.ActionConfig[](1);
         configs[0] = TxGen.ActionConfig({consumedCount: 2, createdCount: 0});
 
-        (Transaction memory txn, bytes32 updatedNonce) =
+        (Types.Transaction memory txn, bytes32 updatedNonce) =
             vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
         _mockPa.execute(txn);
 
@@ -250,7 +250,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         TxGen.ActionConfig[] memory configs = new TxGen.ActionConfig[](1);
         configs[0] = TxGen.ActionConfig({consumedCount: 1, createdCount: 0});
 
-        (Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
+        (Types.Transaction memory txn,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
 
         vm.recordLogs();
         _mockPa.execute(txn);
@@ -266,7 +266,8 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     function test_execute_reverts_on_the_empty_transaction() public {
-        Transaction memory txn = Transaction({actions: new Action[](0), deltaProof: "", aggregationProof: ""});
+        Types.Transaction memory txn =
+            Types.Transaction({actions: new Types.Action[](0), deltaProof: "", aggregationProof: ""});
 
         vm.expectRevert(ProtocolAdapter.EmptyTransactionNotAllowed.selector, address(_mockPa));
         _mockPa.execute(txn);
@@ -276,7 +277,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         TxGen.ActionConfig[] memory configs =
             TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1});
 
-        (Transaction memory tx1,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
+        (Types.Transaction memory tx1,) = vm.transaction({mockVerifier: _mockVerifier, nonce: 0, configs: configs});
         bytes32 preExistingNf = tx1.actions[0].consumed[0].nullifier;
         _mockPa.execute(tx1);
 
@@ -301,7 +302,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         (actionCount, resourcePairCount, actionIndex, resourceIndex) =
             _bindParameters(actionCount, resourcePairCount, actionIndex, resourceIndex);
 
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -325,7 +326,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     ) public {
         (actionCount, resourcePairCount, actionIndex,) = _bindParameters(actionCount, resourcePairCount, actionIndex, 0);
 
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -350,7 +351,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         (actionCount, resourcePairCount, actionIndex, resourceIndex) =
             _bindParameters(actionCount, resourcePairCount, actionIndex, resourceIndex);
 
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -377,7 +378,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
 
         // Create a transaction with two resources, the created calling the forwarder.
-        Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
+        Types.Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
 
         // Expect output mismatch.
         vm.expectRevert(
@@ -398,7 +399,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         TxGen.ResourceLists[] memory resourceLists = new TxGen.ResourceLists[](1);
         resourceLists[0] = TxGen.ResourceLists({consumed: consumed, created: created});
 
-        Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
+        Types.Transaction memory txn = vm.transaction(_mockVerifier, resourceLists);
         vm.expectPartialRevert(Delta.DeltaMismatch.selector);
         _mockPa.execute(txn);
     }
@@ -406,7 +407,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     function testFuzz_execute_updates_root(uint8 actionCount, uint8 resourcePairCount) public {
         (actionCount, resourcePairCount,,) = _bindParameters(actionCount, resourcePairCount, 0, 0);
         bytes32 oldRoot = _mockPa.latestCommitmentTreeRoot();
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -426,7 +427,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
         uint8 resourcePairCount
     ) public {
         (actionCount, resourcePairCount,,) = _bindParameters(actionCount, resourcePairCount, 0, 0);
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -463,7 +464,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     ) public {
         (actionCount, resourcePairCount,,) = _bindParameters(actionCount, resourcePairCount, 0, 0);
         assertEq(_mockPa.nullifierCount(), 0, "initial nullifier count should be 0");
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({
@@ -483,7 +484,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     function test_execute_calls_the_risc_zero_verifier_router_exactly_once() public {
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -494,7 +495,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     function test_execute_reverts_on_vulnerable_risc_zero_verifier() public {
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -508,7 +509,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     function test_simulateExecute_reverts_on_invalid_aggregation_proof_if_proof_verification_is_not_skipped() public {
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -523,7 +524,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     function test_simulateExecute_reverts_with_Simulated_if_proof_verification_is_not_skipped() public {
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})
@@ -534,7 +535,7 @@ contract ProtocolAdapterMockVerifierTest is Test {
     }
 
     function test_simulateExecute_skips_the_verification_of_an_invalid_aggregation_proof() public {
-        (Transaction memory txn,) = vm.transaction({
+        (Types.Transaction memory txn,) = vm.transaction({
             mockVerifier: _mockVerifier,
             nonce: 0,
             configs: TxGen.generateActionConfigs({actionCount: 1, consumedCount: 1, createdCount: 1})

--- a/contracts/test/libs/DeltaGen.sol
+++ b/contracts/test/libs/DeltaGen.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {VmSafe} from "forge-std-1.16.1/src/Vm.sol";
 
-import {Delta} from "../../src/libs/proving/Delta.sol";
+import {Types} from "../../src/Types.sol";
 
 library DeltaGen {
     using DeltaGen for uint256;
@@ -47,7 +47,7 @@ library DeltaGen {
     /// @return instance The mocked curve point.
     /// @dev `vm.createWallet` performs the scalar multiplication: it treats the pre-delta as a private key and
     /// exposes the corresponding public key — the curve point we want.
-    function generateInstance(VmSafe vm, InstanceInputs memory inputs) internal returns (Delta.Point memory instance) {
+    function generateInstance(VmSafe vm, InstanceInputs memory inputs) internal returns (Types.Delta memory instance) {
         // computePreDelta tolerates unreduced inputs (mulmod/addmod handle reduction), and the only failure mode
         // for `vm.createWallet` is a zero pre-delta, which `generateInstanceFromPreDelta` rejects with a named error.
         instance = generateInstanceFromPreDelta(vm, computePreDelta(inputs));
@@ -57,14 +57,14 @@ library DeltaGen {
     /// @param vm The Forge VM interface.
     /// @param preDelta The pre-delta scalar, reduced modulo `SECP256K1_ORDER` and required to be non-zero.
     /// @return instance The mocked curve point.
-    function generateInstanceFromPreDelta(VmSafe vm, uint256 preDelta) internal returns (Delta.Point memory instance) {
+    function generateInstanceFromPreDelta(VmSafe vm, uint256 preDelta) internal returns (Types.Delta memory instance) {
         // A zero pre-delta is not a valid ECDSA private key, so reject it explicitly rather than letting the cheatcode
         // fail with a less informative error.
         require(preDelta != 0, PreDeltaZero());
 
         // Use the pre-delta as a private key; the resulting public key coordinates are the delta point.
         VmSafe.Wallet memory wallet = vm.createWallet(preDelta);
-        instance = Delta.Point({x: wallet.publicKeyX, y: wallet.publicKeyY});
+        instance = Types.Delta({x: wallet.publicKeyX, y: wallet.publicKeyY});
     }
 
     /// @notice Mocks a delta proof by signing the verifying key with the value commitment randomness via ECDSA on

--- a/contracts/test/libs/EllipticCurve.t.sol
+++ b/contracts/test/libs/EllipticCurve.t.sol
@@ -5,6 +5,7 @@ import {EllipticCurve} from "elliptic-curve-solidity-0.2.5/contracts/EllipticCur
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {Delta} from "../../src/libs/proving/Delta.sol";
+import {Types} from "../../src/Types.sol";
 
 /**
  * @title EllipticCurvePropertiesTest
@@ -108,7 +109,7 @@ contract EllipticCurvePropertiesTest is Test {
             EllipticCurve.ecAdd({_x1: x, _y1: y, _x2: invX, _y2: invY, _aa: Delta._AA, _pp: Delta._PP});
 
         assertTrue(
-            _isPointAtInfinity(Delta.Point(resultX, resultY)), "GROUP PROPERTY: P + (-P) must equal point at infinity"
+            _isPointAtInfinity(Types.Delta(resultX, resultY)), "GROUP PROPERTY: P + (-P) must equal point at infinity"
         );
     }
 
@@ -186,7 +187,7 @@ contract EllipticCurvePropertiesTest is Test {
             EllipticCurve.ecAdd({_x1: x1, _y1: y1, _x2: x2, _y2: y2, _aa: Delta._AA, _pp: Delta._PP});
 
         // Result must be on curve or at infinity
-        bool atInfinity = _isPointAtInfinity(Delta.Point(resultX, resultY));
+        bool atInfinity = _isPointAtInfinity(Types.Delta(resultX, resultY));
         bool onCurve =
             EllipticCurve.isOnCurve({_x: resultX, _y: resultY, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP});
 
@@ -206,7 +207,7 @@ contract EllipticCurvePropertiesTest is Test {
 
         // P + (-P) should equal point at infinity
         assertTrue(
-            _isPointAtInfinity(Delta.Point(rx, ry)),
+            _isPointAtInfinity(Types.Delta(rx, ry)),
             "With REDUCED coordinates: (3,5) + (3,2) correctly gives point at infinity"
         );
     }
@@ -254,7 +255,7 @@ contract EllipticCurvePropertiesTest is Test {
         (uint256 rx, uint256 ry) =
             EllipticCurve.ecAdd({_x1: Delta._GX, _y1: Delta._GY, _x2: invX, _y2: invY, _aa: Delta._AA, _pp: Delta._PP});
 
-        assertTrue(_isPointAtInfinity(Delta.Point(rx, ry)), "G + (-G) should be point at infinity");
+        assertTrue(_isPointAtInfinity(Types.Delta(rx, ry)), "G + (-G) should be point at infinity");
     }
 
     /// @notice Concrete: (G + 2G) + 3G = G + (2G + 3G) = 6G
@@ -293,7 +294,7 @@ contract EllipticCurvePropertiesTest is Test {
     /// @notice Returns whether a point is at infinity or not..
     /// @param p The point to check.
     /// @return isAtInfinity Whether the point is at infinity or not.
-    function _isPointAtInfinity(Delta.Point memory p) internal pure returns (bool isAtInfinity) {
+    function _isPointAtInfinity(Types.Delta memory p) internal pure returns (bool isAtInfinity) {
         isAtInfinity = p.x == 0 && p.y == 0;
     }
 }

--- a/contracts/test/libs/JournalEncoder.sol
+++ b/contracts/test/libs/JournalEncoder.sol
@@ -3,16 +3,16 @@ pragma solidity ^0.8.30;
 
 import {Logic} from "../../src/libs/proving/Logic.sol";
 import {RiscZeroUtils} from "../../src/libs/RiscZeroUtils.sol";
-import {Transaction} from "../../src/Types.sol";
+import {Types} from "../../src/Types.sol";
 
 /// @notice Re-exposes the calldata-only journal encoders behind an external boundary, letting tests encode
 /// memory-built structures — the ABI encoding at the call boundary turns memory into calldata. External library
 /// functions keep the boundary free of per-call deployments: forge links and deploys the library once.
 library JournalEncoder {
-    using RiscZeroUtils for Transaction;
+    using RiscZeroUtils for Types.Transaction;
     using RiscZeroUtils for Logic.AppData;
 
-    function toJournal(Transaction calldata transaction, bytes32 complianceKey, bytes32 kindTableCommitment)
+    function toJournal(Types.Transaction calldata transaction, bytes32 complianceKey, bytes32 kindTableCommitment)
         external
         pure
         returns (bytes memory journal)

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -9,7 +9,7 @@ import {Delta} from "../../src/libs/proving/Delta.sol";
 import {Logic} from "../../src/libs/proving/Logic.sol";
 import {VerifyingKeys} from "../../src/libs/proving/VerifyingKeys.sol";
 import {SHA256} from "../../src/libs/SHA256.sol";
-import {Transaction, Action, Consumed, Created, Resource} from "./../../src/Types.sol";
+import {Types} from "./../../src/Types.sol";
 import {DeltaGen} from "./DeltaGen.sol";
 import {JournalEncoder} from "./JournalEncoder.sol";
 
@@ -22,7 +22,7 @@ library TxGen {
     }
 
     struct ResourceAndAppData {
-        Resource resource;
+        Types.Resource resource;
         Logic.AppData appData;
     }
 
@@ -36,25 +36,25 @@ library TxGen {
     /// the transaction.
     function createAction(VmSafe vm, ResourceAndAppData[] memory consumed, ResourceAndAppData[] memory created)
         internal
-        returns (Action memory action)
+        returns (Types.Action memory action)
     {
         uint256 consumedCount = consumed.length;
         uint256 createdCount = created.length;
 
-        Consumed[] memory consumedData = new Consumed[](consumedCount);
-        Created[] memory createdData = new Created[](createdCount);
+        Types.Consumed[] memory consumedData = new Types.Consumed[](consumedCount);
+        Types.Created[] memory createdData = new Types.Created[](createdCount);
 
-        Delta.Point memory actionDelta;
+        Types.Delta memory actionDelta;
 
         for (uint256 i = 0; i < consumedCount; ++i) {
-            consumedData[i] = Consumed({
+            consumedData[i] = Types.Consumed({
                 nullifier: nullifier(consumed[i].resource, 0),
                 logicRef: consumed[i].resource.logicRef,
                 commitmentTreeRoot: initialRoot(),
                 appData: consumed[i].appData
             });
 
-            Delta.Point memory resourceDelta = DeltaGen.generateInstance(
+            Types.Delta memory resourceDelta = DeltaGen.generateInstance(
                 vm,
                 DeltaGen.InstanceInputs({
                     kind: kind(consumed[i].resource),
@@ -67,13 +67,13 @@ library TxGen {
         }
 
         for (uint256 i = 0; i < createdCount; ++i) {
-            createdData[i] = Created({
+            createdData[i] = Types.Created({
                 commitment: commitment(created[i].resource),
                 logicRef: created[i].resource.logicRef,
                 appData: created[i].appData
             });
 
-            Delta.Point memory resourceDelta = DeltaGen.generateInstance(
+            Types.Delta memory resourceDelta = DeltaGen.generateInstance(
                 vm,
                 DeltaGen.InstanceInputs({
                     kind: kind(created[i].resource),
@@ -85,7 +85,7 @@ library TxGen {
             actionDelta = (consumedCount == 0 && i == 0) ? resourceDelta : Delta.add(actionDelta, resourceDelta);
         }
 
-        action = Action({
+        action = Types.Action({
             consumed: consumedData,
             created: createdData,
             delta: actionDelta,
@@ -98,7 +98,7 @@ library TxGen {
     /// each created resource quantity `consumedCount`.
     function createDefaultAction(VmSafe vm, bytes32 nonce, uint256 consumedCount, uint256 createdCount)
         internal
-        returns (Action memory action, bytes32 updatedNonce)
+        returns (Types.Action memory action, bytes32 updatedNonce)
     {
         updatedNonce = nonce;
 
@@ -142,9 +142,9 @@ library TxGen {
 
     function transaction(VmSafe vm, RiscZeroMockVerifier mockVerifier, ResourceLists[] memory actionResources)
         internal
-        returns (Transaction memory txn)
+        returns (Types.Transaction memory txn)
     {
-        Action[] memory actions = new Action[](actionResources.length);
+        Types.Action[] memory actions = new Types.Action[](actionResources.length);
 
         uint256 resourceCount = 0;
         for (uint256 i = 0; i < actionResources.length; ++i) {
@@ -161,11 +161,11 @@ library TxGen {
 
     function transaction(VmSafe vm, RiscZeroMockVerifier mockVerifier, bytes32 nonce, ActionConfig[] memory configs)
         internal
-        returns (Transaction memory txn, bytes32 updatedNonce)
+        returns (Types.Transaction memory txn, bytes32 updatedNonce)
     {
         updatedNonce = nonce;
 
-        Action[] memory actions = new Action[](configs.length);
+        Types.Action[] memory actions = new Types.Action[](configs.length);
         uint256 resourceCount = 0;
         for (uint256 i = 0; i < configs.length; ++i) {
             (actions[i], updatedNonce) = createDefaultAction({
@@ -185,9 +185,9 @@ library TxGen {
 
     /// @dev Assembles the transaction and its delta proof. Each resource contributed a value commitment randomness
     /// of 1, so the summed randomness is the resource count.
-    function transactionFromActions(VmSafe vm, Action[] memory actions, uint256 resourceCount)
+    function transactionFromActions(VmSafe vm, Types.Action[] memory actions, uint256 resourceCount)
         internal
-        returns (Transaction memory txn)
+        returns (Types.Transaction memory txn)
     {
         bytes memory proof = "";
         if (resourceCount != 0) {
@@ -200,7 +200,7 @@ library TxGen {
             );
         }
 
-        txn = Transaction({actions: actions, deltaProof: proof, aggregationProof: ""});
+        txn = Types.Transaction({actions: actions, deltaProof: proof, aggregationProof: ""});
     }
 
     /// @dev Mock-proves the aggregation: the seal commits to the journal reconstructed with the same compliance key
@@ -208,9 +208,9 @@ library TxGen {
     /// `JournalEncoder` boundary because the encoders read calldata.
     function transactionAggregation(
         RiscZeroMockVerifier mockVerifier,
-        Transaction memory txn,
+        Types.Transaction memory txn,
         bytes32 kindTableCommitment
-    ) internal view returns (Transaction memory aggregatedTxn) {
+    ) internal view returns (Types.Transaction memory aggregatedTxn) {
         aggregatedTxn = txn;
 
         aggregatedTxn.aggregationProof =
@@ -240,81 +240,81 @@ library TxGen {
         commitmentOfEmptyTable = sha256("");
     }
 
-    function transactionId(Transaction memory txn) internal pure returns (bytes32 id) {
+    function transactionId(Types.Transaction memory txn) internal pure returns (bytes32 id) {
         id = Delta.computeVerifyingKey(actionTreeRoots(txn.actions));
     }
 
-    function actionTreeRoots(Action[] memory actions) internal pure returns (bytes32[] memory roots) {
+    function actionTreeRoots(Types.Action[] memory actions) internal pure returns (bytes32[] memory roots) {
         roots = new bytes32[](actions.length);
         for (uint256 i = 0; i < actions.length; ++i) {
             roots[i] = actions[i].actionTreeRoot;
         }
     }
 
-    function countResources(Action[] memory actions) internal pure returns (uint256 resourceCount) {
+    function countResources(Types.Action[] memory actions) internal pure returns (uint256 resourceCount) {
         for (uint256 i = 0; i < actions.length; ++i) {
             resourceCount += actions[i].consumed.length + actions[i].created.length;
         }
     }
 
-    function collectNullifiers(Transaction memory txn) internal pure returns (bytes32[] memory nullifiers) {
+    function collectNullifiers(Types.Transaction memory txn) internal pure returns (bytes32[] memory nullifiers) {
         nullifiers = new bytes32[](countConsumed(txn.actions));
 
         uint256 n = 0;
         for (uint256 i = 0; i < txn.actions.length; ++i) {
-            Consumed[] memory consumed = txn.actions[i].consumed;
+            Types.Consumed[] memory consumed = txn.actions[i].consumed;
             for (uint256 j = 0; j < consumed.length; ++j) {
                 nullifiers[n++] = consumed[j].nullifier;
             }
         }
     }
 
-    function collectCommitments(Transaction memory txn) internal pure returns (bytes32[] memory commitments) {
+    function collectCommitments(Types.Transaction memory txn) internal pure returns (bytes32[] memory commitments) {
         commitments = new bytes32[](countCreated(txn.actions));
 
         uint256 n = 0;
         for (uint256 i = 0; i < txn.actions.length; ++i) {
-            Created[] memory created = txn.actions[i].created;
+            Types.Created[] memory created = txn.actions[i].created;
             for (uint256 j = 0; j < created.length; ++j) {
                 commitments[n++] = created[j].commitment;
             }
         }
     }
 
-    function countConsumed(Action[] memory actions) internal pure returns (uint256 consumedCount) {
+    function countConsumed(Types.Action[] memory actions) internal pure returns (uint256 consumedCount) {
         for (uint256 i = 0; i < actions.length; ++i) {
             consumedCount += actions[i].consumed.length;
         }
     }
 
-    function countCreated(Action[] memory actions) internal pure returns (uint256 createdCount) {
+    function countCreated(Types.Action[] memory actions) internal pure returns (uint256 createdCount) {
         for (uint256 i = 0; i < actions.length; ++i) {
             createdCount += actions[i].created.length;
         }
     }
 
-    function actionNullifiers(Action memory action) internal pure returns (bytes32[] memory nullifiers) {
+    function actionNullifiers(Types.Action memory action) internal pure returns (bytes32[] memory nullifiers) {
         nullifiers = new bytes32[](action.consumed.length);
         for (uint256 i = 0; i < action.consumed.length; ++i) {
             nullifiers[i] = action.consumed[i].nullifier;
         }
     }
 
-    function actionConsumedLogicRefs(Action memory action) internal pure returns (bytes32[] memory logicRefs) {
+    function actionConsumedLogicRefs(Types.Action memory action) internal pure returns (bytes32[] memory logicRefs) {
         logicRefs = new bytes32[](action.consumed.length);
         for (uint256 i = 0; i < action.consumed.length; ++i) {
             logicRefs[i] = action.consumed[i].logicRef;
         }
     }
 
-    function actionCommitments(Action memory action) internal pure returns (bytes32[] memory commitments) {
+    function actionCommitments(Types.Action memory action) internal pure returns (bytes32[] memory commitments) {
         commitments = new bytes32[](action.created.length);
         for (uint256 i = 0; i < action.created.length; ++i) {
             commitments[i] = action.created[i].commitment;
         }
     }
 
-    function actionCreatedLogicRefs(Action memory action) internal pure returns (bytes32[] memory logicRefs) {
+    function actionCreatedLogicRefs(Types.Action memory action) internal pure returns (bytes32[] memory logicRefs) {
         logicRefs = new bytes32[](action.created.length);
         for (uint256 i = 0; i < action.created.length; ++i) {
             logicRefs[i] = action.created[i].logicRef;
@@ -324,9 +324,9 @@ library TxGen {
     function mockResource(bytes32 nonce, bytes32 logicRef, bytes32 labelRef, uint128 quantity)
         internal
         pure
-        returns (Resource memory mock)
+        returns (Types.Resource memory mock)
     {
-        mock = Resource({
+        mock = Types.Resource({
             logicRef: logicRef,
             labelRef: labelRef,
             valueRef: bytes32(0),
@@ -347,15 +347,15 @@ library TxGen {
         });
     }
 
-    function commitment(Resource memory resource) internal pure returns (bytes32 hash) {
+    function commitment(Types.Resource memory resource) internal pure returns (bytes32 hash) {
         hash = sha256(abi.encode(resource));
     }
 
-    function nullifier(Resource memory resource, bytes32 nullifierKey) internal pure returns (bytes32 hash) {
+    function nullifier(Types.Resource memory resource, bytes32 nullifierKey) internal pure returns (bytes32 hash) {
         hash = sha256(abi.encode(resource, nullifierKey));
     }
 
-    function kind(Resource memory resource) internal pure returns (uint256 hash) {
+    function kind(Types.Resource memory resource) internal pure returns (uint256 hash) {
         hash = uint256(sha256(abi.encode(resource.logicRef, resource.labelRef)));
     }
 
@@ -375,7 +375,7 @@ library TxGen {
 
     /// @dev The action tree leaves are the consumed nullifiers followed by the created commitments — the canonical
     /// tag order.
-    function computeActionTreeRoot(Consumed[] memory consumed, Created[] memory created)
+    function computeActionTreeRoot(Types.Consumed[] memory consumed, Types.Created[] memory created)
         internal
         pure
         returns (bytes32 root)

--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -6,6 +6,7 @@ import {EllipticCurve} from "elliptic-curve-solidity-0.2.5/contracts/EllipticCur
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {Delta} from "../../src/libs/proving/Delta.sol";
+import {Types} from "../../src/Types.sol";
 
 import {DeltaGen} from "../libs/DeltaGen.sol";
 
@@ -17,13 +18,13 @@ library DeltaFuzzing {
     }
 
     /// @dev This function exposes `Delta.verify` for the fuzzer.
-    function verify(bytes memory proof, Delta.Point memory instance, bytes32 verifyingKey) public pure {
+    function verify(bytes memory proof, Types.Delta memory instance, bytes32 verifyingKey) public pure {
         Delta.verify({proof: proof, instance: instance, verifyingKey: verifyingKey});
     }
 }
 
 contract DeltaProofTest is Test {
-    using Delta for Delta.Point;
+    using Delta for Types.Delta;
     using DeltaGen for DeltaGen.InstanceInputs[];
     using DeltaGen for DeltaGen.InstanceInputs;
     using DeltaGen for uint256;
@@ -60,12 +61,12 @@ contract DeltaProofTest is Test {
         vm.assume(expectedPreDelta != 0);
 
         // Generate a delta proof and instance from the above tags and preimage
-        Delta.Point memory instance1 = DeltaGen.generateInstance(vm, deltaInputs1);
-        Delta.Point memory instance2 = DeltaGen.generateInstance(vm, deltaInputs2);
-        Delta.Point memory expectedDelta = DeltaGen.generateInstanceFromPreDelta(vm, expectedPreDelta);
+        Types.Delta memory instance1 = DeltaGen.generateInstance(vm, deltaInputs1);
+        Types.Delta memory instance2 = DeltaGen.generateInstance(vm, deltaInputs2);
+        Types.Delta memory expectedDelta = DeltaGen.generateInstanceFromPreDelta(vm, expectedPreDelta);
 
         // Verify that the deltas add correctly
-        Delta.Point memory computedDelta = Delta.add(instance1, instance2);
+        Types.Delta memory computedDelta = Delta.add(instance1, instance2);
 
         assertEq(computedDelta.x, expectedDelta.x, "computed delta x should match expected");
         assertEq(computedDelta.y, expectedDelta.y, "computed delta y should match expected");
@@ -84,7 +85,7 @@ contract DeltaProofTest is Test {
         vm.assume(deltaInstanceInputs.computePreDelta() != 0);
 
         // Generate a delta proof and instance from the above tags and preimage
-        Delta.Point memory instance = DeltaGen.generateInstance(vm, deltaInstanceInputs);
+        Types.Delta memory instance = DeltaGen.generateInstance(vm, deltaInstanceInputs);
 
         // Construct delta proof inputs from the above parameters
         DeltaGen.ProofInputs memory deltaProofInputs = DeltaGen.ProofInputs({
@@ -115,7 +116,7 @@ contract DeltaProofTest is Test {
             kind: kind, quantity: 0, consumed: consumed, valueCommitmentRandomness: valueCommitmentRandomness1
         });
         vm.assume(deltaInputs.computePreDelta() != 0);
-        Delta.Point memory instanceRcv1 = DeltaGen.generateInstance(vm, deltaInputs);
+        Types.Delta memory instanceRcv1 = DeltaGen.generateInstance(vm, deltaInputs);
 
         bytes memory proofRcv2 = DeltaGen.generateProof(
             vm,
@@ -145,7 +146,7 @@ contract DeltaProofTest is Test {
             kind: kind, quantity: 0, consumed: consumed, valueCommitmentRandomness: valueCommitmentRandomness
         });
         vm.assume(deltaInputs.computePreDelta() != 0);
-        Delta.Point memory instance = DeltaGen.generateInstance(vm, deltaInputs);
+        Types.Delta memory instance = DeltaGen.generateInstance(vm, deltaInputs);
 
         bytes memory proofForVk1 = DeltaGen.generateProof(
             vm,
@@ -179,7 +180,7 @@ contract DeltaProofTest is Test {
         });
 
         // Generate a delta instance from the above inputs
-        Delta.Point memory instance = DeltaGen.generateInstance(vm, deltaInstanceInputs);
+        Types.Delta memory instance = DeltaGen.generateInstance(vm, deltaInstanceInputs);
 
         // Generate a delta proof from the above inputs
         bytes memory proof = DeltaGen.generateProof(vm, deltaProofInputs);
@@ -208,13 +209,13 @@ contract DeltaProofTest is Test {
         vm.assume(totalRandomness != 0);
 
         // Generate and accumulate delta instances
-        Delta.Point memory deltaAcc = Delta.zero();
+        Types.Delta memory deltaAcc = Delta.zero();
         for (uint256 i = 0; i < pairedInputs.length; i++) {
             // Normalize and validate each input
             pairedInputs[i].valueCommitmentRandomness = pairedInputs[i].valueCommitmentRandomness.modOrder();
             vm.assume(pairedInputs[i].computePreDelta() != 0);
 
-            Delta.Point memory instance = DeltaGen.generateInstance(vm, pairedInputs[i]);
+            Types.Delta memory instance = DeltaGen.generateInstance(vm, pairedInputs[i]);
             deltaAcc = deltaAcc.add(instance);
         }
 
@@ -227,12 +228,12 @@ contract DeltaProofTest is Test {
         DeltaFuzzing.verify({proof: proof, instance: deltaAcc, verifyingKey: verifyingKey});
     }
 
-    function testFuzz_add_reverts_when_adding_a_non_curve_from_the_right(uint32 k, Delta.Point memory rhs) public {
+    function testFuzz_add_reverts_when_adding_a_non_curve_from_the_right(uint32 k, Types.Delta memory rhs) public {
         // Ensure that `rhs` is not on the curve.
         vm.assume(!EllipticCurve.isOnCurve({_x: rhs.x, _y: rhs.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}));
 
         // Generate a random point on the curve.
-        Delta.Point memory lhs = _mul({p: Delta.Point({x: Delta._GX, y: Delta._GY}), k: k});
+        Types.Delta memory lhs = _mul({p: Types.Delta({x: Delta._GX, y: Delta._GY}), k: k});
         assertTrue(
             EllipticCurve.isOnCurve({_x: lhs.x, _y: lhs.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Left-hand side point must be on the curve."
@@ -245,13 +246,13 @@ contract DeltaProofTest is Test {
 
     function testFuzz_add_reverts_when_adding_zero_from_the_right(uint32 k) public {
         // Generate a random point on the curve.
-        Delta.Point memory lhs = _mul({p: Delta.Point({x: Delta._GX, y: Delta._GY}), k: k});
+        Types.Delta memory lhs = _mul({p: Types.Delta({x: Delta._GX, y: Delta._GY}), k: k});
         assertTrue(
             EllipticCurve.isOnCurve({_x: lhs.x, _y: lhs.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Left-hand side point must be on the curve."
         );
 
-        Delta.Point memory zero = Delta.zero();
+        Types.Delta memory zero = Delta.zero();
 
         // Add the two points.
         vm.expectRevert(abi.encodeWithSelector(Delta.PointNotOnCurve.selector, zero), address(this));
@@ -259,17 +260,17 @@ contract DeltaProofTest is Test {
     }
 
     function testFuzz_add_adding_zero_from_the_left_produces_a_curve_point(uint32 k) public pure {
-        Delta.Point memory zero = Delta.zero();
+        Types.Delta memory zero = Delta.zero();
 
         // Generate a random point on the curve.
-        Delta.Point memory rhs = _mul({p: Delta.Point({x: Delta._GX, y: Delta._GY}), k: k});
+        Types.Delta memory rhs = _mul({p: Types.Delta({x: Delta._GX, y: Delta._GY}), k: k});
         assertTrue(
             EllipticCurve.isOnCurve({_x: rhs.x, _y: rhs.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Right-hand side point must be on the curve."
         );
 
         // Add the two points and check that the sum is a curve point.
-        Delta.Point memory sum = zero.add(rhs);
+        Types.Delta memory sum = zero.add(rhs);
         assertTrue(
             EllipticCurve.isOnCurve({_x: sum.x, _y: sum.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Sum must be on the curve."
@@ -277,37 +278,37 @@ contract DeltaProofTest is Test {
     }
 
     function testFuzz_add_adding_zero_from_the_left_is_the_identity_operation(uint32 k) public pure {
-        Delta.Point memory zero = Delta.zero();
+        Types.Delta memory zero = Delta.zero();
 
         // Generate a random point on the curve.
-        Delta.Point memory rhs = _mul({p: Delta.Point({x: Delta._GX, y: Delta._GY}), k: k});
+        Types.Delta memory rhs = _mul({p: Types.Delta({x: Delta._GX, y: Delta._GY}), k: k});
         assertTrue(
             EllipticCurve.isOnCurve({_x: rhs.x, _y: rhs.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Right-hand side point must be on the curve."
         );
 
         // Add the two points and check that the sum is a curve point.
-        Delta.Point memory sum = zero.add(rhs);
+        Types.Delta memory sum = zero.add(rhs);
         assertEq(sum.x, rhs.x, "zero + rhs x should equal rhs x");
         assertEq(sum.y, rhs.y, "zero + rhs y should equal rhs y");
     }
 
     function testFuzz_add_adding_two_curve_points_produces_a_curve_point(uint32 k1, uint32 k2) public pure {
         // Generate two random points on the curve.
-        Delta.Point memory lhs = _mul({p: Delta.Point({x: Delta._GX, y: Delta._GY}), k: k1});
+        Types.Delta memory lhs = _mul({p: Types.Delta({x: Delta._GX, y: Delta._GY}), k: k1});
         assertTrue(
             EllipticCurve.isOnCurve({_x: lhs.x, _y: lhs.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Left-hand side point must be on the curve."
         );
 
-        Delta.Point memory rhs = _mul({p: Delta.Point({x: Delta._GX, y: Delta._GY}), k: k2});
+        Types.Delta memory rhs = _mul({p: Types.Delta({x: Delta._GX, y: Delta._GY}), k: k2});
         assertTrue(
             EllipticCurve.isOnCurve({_x: rhs.x, _y: rhs.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Right-hand side must be on the curve."
         );
 
         // Add the two points and check that the sum is a curve point.
-        Delta.Point memory sum = lhs.add(rhs);
+        Types.Delta memory sum = lhs.add(rhs);
         assertTrue(
             EllipticCurve.isOnCurve({_x: sum.x, _y: sum.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "Sum must be on the curve."
@@ -315,7 +316,7 @@ contract DeltaProofTest is Test {
     }
 
     function test_zero_is_not_on_the_curve() public pure {
-        Delta.Point memory p2 = Delta.zero();
+        Types.Delta memory p2 = Delta.zero();
         assertFalse(
             EllipticCurve.isOnCurve({_x: p2.x, _y: p2.y, _aa: Delta._AA, _bb: Delta._BB, _pp: Delta._PP}),
             "zero point should not be on the curve"
@@ -346,7 +347,7 @@ contract DeltaProofTest is Test {
         }
     }
 
-    function _mul(Delta.Point memory p, uint256 k) internal pure returns (Delta.Point memory product) {
+    function _mul(Types.Delta memory p, uint256 k) internal pure returns (Types.Delta memory product) {
         (product.x, product.y) = EllipticCurve.ecMul({_k: k, _x: p.x, _y: p.y, _aa: Delta._AA, _pp: Delta._PP});
     }
 }

--- a/crates/bindings/src/conversion.rs
+++ b/crates/bindings/src/conversion.rs
@@ -7,7 +7,7 @@ use anoma_rm_risc0::proving_system::encode_seal;
 use anoma_rm_risc0::transaction::{Delta as ArmDelta, Transaction};
 use anoma_rm_risc0::utils::words_to_bytes;
 
-use crate::generated::protocol_adapter::{Delta, Logic, ProtocolAdapter};
+use crate::generated::protocol_adapter::{Logic, Types};
 
 impl From<ExpirableBlob> for Logic::ExpirableBlob {
     fn from(expirable_blob: ExpirableBlob) -> Self {
@@ -45,7 +45,7 @@ impl From<AppData> for Logic::AppData {
     }
 }
 
-impl From<ConsumedResourceAggregated> for ProtocolAdapter::Consumed {
+impl From<ConsumedResourceAggregated> for Types::Consumed {
     fn from(consumed: ConsumedResourceAggregated) -> Self {
         Self {
             nullifier: B256::from_slice(consumed.resource_nullifier.as_bytes()),
@@ -56,7 +56,7 @@ impl From<ConsumedResourceAggregated> for ProtocolAdapter::Consumed {
     }
 }
 
-impl From<CreatedResourceAggregated> for ProtocolAdapter::Created {
+impl From<CreatedResourceAggregated> for Types::Created {
     fn from(created: CreatedResourceAggregated) -> Self {
         Self {
             commitment: B256::from_slice(created.resource_commitment.as_bytes()),
@@ -66,10 +66,10 @@ impl From<CreatedResourceAggregated> for ProtocolAdapter::Created {
     }
 }
 
-impl From<ActionAggregated> for ProtocolAdapter::Action {
+impl From<ActionAggregated> for Types::Action {
     fn from(action: ActionAggregated) -> Self {
         Self {
-            delta: Delta::Point {
+            delta: Types::Delta {
                 x: U256::from_be_slice(words_to_bytes(&action.delta_x)),
                 y: U256::from_be_slice(words_to_bytes(&action.delta_y)),
             },
@@ -77,18 +77,18 @@ impl From<ActionAggregated> for ProtocolAdapter::Action {
             consumed: action
                 .consumed_publics
                 .into_iter()
-                .map(ProtocolAdapter::Consumed::from)
+                .map(Types::Consumed::from)
                 .collect(),
             created: action
                 .created_publics
                 .into_iter()
-                .map(ProtocolAdapter::Created::from)
+                .map(Types::Created::from)
                 .collect(),
         }
     }
 }
 
-impl From<Transaction> for ProtocolAdapter::Transaction {
+impl From<Transaction> for Types::Transaction {
     fn from(tx: Transaction) -> Self {
         let delta_proof = match &tx.delta_proof {
             ArmDelta::Witness(_) => panic!("Unbalanced Transactions cannot be converted"),
@@ -104,7 +104,7 @@ impl From<Transaction> for ProtocolAdapter::Transaction {
                 .instance
                 .actions
                 .into_iter()
-                .map(ProtocolAdapter::Action::from)
+                .map(Types::Action::from)
                 .collect(),
             deltaProof: Bytes::from(delta_proof),
             aggregationProof: Bytes::from(encode_seal(&aggregation.proof).unwrap()),

--- a/crates/bindings/src/generated/i_protocol_adapter.rs
+++ b/crates/bindings/src/generated/i_protocol_adapter.rs
@@ -2,356 +2,6 @@
 /**
 
 ```solidity
-library Delta {
-    struct Point { uint256 x; uint256 y; }
-}
-```*/
-#[allow(
-    non_camel_case_types,
-    non_snake_case,
-    clippy::pub_underscore_fields,
-    clippy::style,
-    clippy::empty_structs_with_brackets
-)]
-pub mod Delta {
-    use super::*;
-    use alloy::sol_types as alloy_sol_types;
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[derive(Default, Debug, PartialEq, Eq, Hash)]
-    /**```solidity
-struct Point { uint256 x; uint256 y; }
-```*/
-    #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
-    #[derive(Clone)]
-    pub struct Point {
-        #[allow(missing_docs)]
-        pub x: alloy::sol_types::private::primitives::aliases::U256,
-        #[allow(missing_docs)]
-        pub y: alloy::sol_types::private::primitives::aliases::U256,
-    }
-    #[allow(
-        non_camel_case_types,
-        non_snake_case,
-        clippy::pub_underscore_fields,
-        clippy::style
-    )]
-    const _: () = {
-        use alloy::sol_types as alloy_sol_types;
-        #[doc(hidden)]
-        #[allow(dead_code)]
-        type UnderlyingSolTuple<'a> = (
-            alloy::sol_types::sol_data::Uint<256>,
-            alloy::sol_types::sol_data::Uint<256>,
-        );
-        #[doc(hidden)]
-        type UnderlyingRustTuple<'a> = (
-            alloy::sol_types::private::primitives::aliases::U256,
-            alloy::sol_types::private::primitives::aliases::U256,
-        );
-        #[cfg(test)]
-        #[allow(dead_code, unreachable_patterns)]
-        fn _type_assertion(
-            _t: alloy_sol_types::private::AssertTypeEq<UnderlyingRustTuple>,
-        ) {
-            match _t {
-                alloy_sol_types::private::AssertTypeEq::<
-                    <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
-            }
-        }
-        #[automatically_derived]
-        #[doc(hidden)]
-        impl ::core::convert::From<Point> for UnderlyingRustTuple<'_> {
-            fn from(value: Point) -> Self {
-                (value.x, value.y)
-            }
-        }
-        #[automatically_derived]
-        #[doc(hidden)]
-        impl ::core::convert::From<UnderlyingRustTuple<'_>> for Point {
-            fn from(tuple: UnderlyingRustTuple<'_>) -> Self {
-                Self { x: tuple.0, y: tuple.1 }
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::SolValue for Point {
-            type SolType = Self;
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::private::SolTypeValue<Self> for Point {
-            #[inline]
-            fn stv_to_tokens(&self) -> <Self as alloy_sol_types::SolType>::Token<'_> {
-                (
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::tokenize(&self.x),
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::tokenize(&self.y),
-                )
-            }
-            #[inline]
-            fn stv_abi_encoded_size(&self) -> usize {
-                if let Some(size) = <Self as alloy_sol_types::SolType>::ENCODED_SIZE {
-                    return size;
-                }
-                let tuple = <UnderlyingRustTuple<
-                    '_,
-                > as ::core::convert::From<Self>>::from(self.clone());
-                <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::abi_encoded_size(&tuple)
-            }
-            #[inline]
-            fn stv_eip712_data_word(&self) -> alloy_sol_types::Word {
-                <Self as alloy_sol_types::SolStruct>::eip712_hash_struct(self)
-            }
-            #[inline]
-            fn stv_abi_encode_packed_to(
-                &self,
-                out: &mut alloy_sol_types::private::Vec<u8>,
-            ) {
-                let tuple = <UnderlyingRustTuple<
-                    '_,
-                > as ::core::convert::From<Self>>::from(self.clone());
-                <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::abi_encode_packed_to(&tuple, out)
-            }
-            #[inline]
-            fn stv_abi_packed_encoded_size(&self) -> usize {
-                if let Some(size) = <Self as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE {
-                    return size;
-                }
-                let tuple = <UnderlyingRustTuple<
-                    '_,
-                > as ::core::convert::From<Self>>::from(self.clone());
-                <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::abi_packed_encoded_size(&tuple)
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::SolType for Point {
-            type RustType = Self;
-            type Token<'a> = <UnderlyingSolTuple<
-                'a,
-            > as alloy_sol_types::SolType>::Token<'a>;
-            const SOL_NAME: &'static str = <Self as alloy_sol_types::SolStruct>::NAME;
-            const ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
-                '_,
-            > as alloy_sol_types::SolType>::ENCODED_SIZE;
-            const PACKED_ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
-                '_,
-            > as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE;
-            #[inline]
-            fn valid_token(token: &Self::Token<'_>) -> bool {
-                <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::valid_token(token)
-            }
-            #[inline]
-            fn detokenize(token: Self::Token<'_>) -> Self::RustType {
-                let tuple = <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::detokenize(token);
-                <Self as ::core::convert::From<UnderlyingRustTuple<'_>>>::from(tuple)
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::SolStruct for Point {
-            const NAME: &'static str = "Point";
-            #[inline]
-            fn eip712_root_type() -> alloy_sol_types::private::Cow<'static, str> {
-                alloy_sol_types::private::Cow::Borrowed("Point(uint256 x,uint256 y)")
-            }
-            #[inline]
-            fn eip712_components() -> alloy_sol_types::private::Vec<
-                alloy_sol_types::private::Cow<'static, str>,
-            > {
-                alloy_sol_types::private::Vec::new()
-            }
-            #[inline]
-            fn eip712_encode_type() -> alloy_sol_types::private::Cow<'static, str> {
-                <Self as alloy_sol_types::SolStruct>::eip712_root_type()
-            }
-            #[inline]
-            fn eip712_encode_data(&self) -> alloy_sol_types::private::Vec<u8> {
-                [
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::eip712_data_word(&self.x)
-                        .0,
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::eip712_data_word(&self.y)
-                        .0,
-                ]
-                    .concat()
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::EventTopic for Point {
-            #[inline]
-            fn topic_preimage_length(rust: &Self::RustType) -> usize {
-                0usize
-                    + <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.x)
-                    + <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.y)
-            }
-            #[inline]
-            fn encode_topic_preimage(
-                rust: &Self::RustType,
-                out: &mut alloy_sol_types::private::Vec<u8>,
-            ) {
-                out.reserve(
-                    <Self as alloy_sol_types::EventTopic>::topic_preimage_length(rust),
-                );
-                <alloy::sol_types::sol_data::Uint<
-                    256,
-                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.x, out);
-                <alloy::sol_types::sol_data::Uint<
-                    256,
-                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.y, out);
-            }
-            #[inline]
-            fn encode_topic(
-                rust: &Self::RustType,
-            ) -> alloy_sol_types::abi::token::WordToken {
-                let mut out = alloy_sol_types::private::Vec::new();
-                <Self as alloy_sol_types::EventTopic>::encode_topic_preimage(
-                    rust,
-                    &mut out,
-                );
-                alloy_sol_types::abi::token::WordToken(
-                    alloy_sol_types::private::keccak256(out),
-                )
-            }
-        }
-    };
-    use alloy::contract as alloy_contract;
-    /**Creates a new wrapper around an on-chain [`Delta`](self) contract instance.
-
-See the [wrapper's documentation](`DeltaInstance`) for more details.*/
-    #[inline]
-    pub const fn new<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    >(address: alloy_sol_types::private::Address, __provider: P) -> DeltaInstance<P, N> {
-        DeltaInstance::<P, N>::new(address, __provider)
-    }
-    /**A [`Delta`](self) instance.
-
-Contains type-safe methods for interacting with an on-chain instance of the
-[`Delta`](self) contract located at a given `address`, using a given
-provider `P`.
-
-If the contract bytecode is available (see the [`sol!`](alloy_sol_types::sol!)
-documentation on how to provide it), the `deploy` and `deploy_builder` methods can
-be used to deploy a new instance of the contract.
-
-See the [module-level documentation](self) for all the available methods.*/
-    #[derive(Clone)]
-    pub struct DeltaInstance<P, N = alloy_contract::private::Ethereum> {
-        address: alloy_sol_types::private::Address,
-        provider: P,
-        _network: ::core::marker::PhantomData<N>,
-    }
-    #[automatically_derived]
-    impl<P, N> ::core::fmt::Debug for DeltaInstance<P, N> {
-        #[inline]
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-            f.debug_tuple("DeltaInstance").field(&self.address).finish()
-        }
-    }
-    /// Instantiation and getters/setters.
-    impl<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    > DeltaInstance<P, N> {
-        /**Creates a new wrapper around an on-chain [`Delta`](self) contract instance.
-
-See the [wrapper's documentation](`DeltaInstance`) for more details.*/
-        #[inline]
-        pub const fn new(
-            address: alloy_sol_types::private::Address,
-            __provider: P,
-        ) -> Self {
-            Self {
-                address,
-                provider: __provider,
-                _network: ::core::marker::PhantomData,
-            }
-        }
-        /// Returns a reference to the address.
-        #[inline]
-        pub const fn address(&self) -> &alloy_sol_types::private::Address {
-            &self.address
-        }
-        /// Sets the address.
-        #[inline]
-        pub fn set_address(&mut self, address: alloy_sol_types::private::Address) {
-            self.address = address;
-        }
-        /// Sets the address and returns `self`.
-        pub fn at(mut self, address: alloy_sol_types::private::Address) -> Self {
-            self.set_address(address);
-            self
-        }
-        /// Returns a reference to the provider.
-        #[inline]
-        pub const fn provider(&self) -> &P {
-            &self.provider
-        }
-    }
-    impl<P: ::core::clone::Clone, N> DeltaInstance<&P, N> {
-        /// Clones the provider and returns a new instance with the cloned provider.
-        #[inline]
-        pub fn with_cloned_provider(self) -> DeltaInstance<P, N> {
-            DeltaInstance {
-                address: self.address,
-                provider: ::core::clone::Clone::clone(&self.provider),
-                _network: ::core::marker::PhantomData,
-            }
-        }
-    }
-    /// Function calls.
-    impl<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    > DeltaInstance<P, N> {
-        /// Creates a new call builder using this contract instance's provider and address.
-        ///
-        /// Note that the call can be any function call, not just those defined in this
-        /// contract. Prefer using the other methods for building type-safe contract calls.
-        pub fn call_builder<C: alloy_sol_types::SolCall>(
-            &self,
-            call: &C,
-        ) -> alloy_contract::SolCallBuilder<&P, C, N> {
-            alloy_contract::SolCallBuilder::new_sol(&self.provider, &self.address, call)
-        }
-    }
-    /// Event filters.
-    impl<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    > DeltaInstance<P, N> {
-        /// Creates a new event filter using this contract instance's provider and address.
-        ///
-        /// Note that the type can be any event, not just those defined in this contract.
-        /// Prefer using the other methods for building type-safe event filters.
-        pub fn event_filter<E: alloy_sol_types::SolEvent>(
-            &self,
-        ) -> alloy_contract::Event<&P, E, N> {
-            alloy_contract::Event::new_sol(&self.provider, &self.address)
-        }
-    }
-}
-///Module containing a contract's types and functions.
-/**
-
-```solidity
 library Logic {
     type DeletionCriterion is uint8;
     struct AppData { ExpirableBlob[] resourcePayload; ExpirableBlob[] discoveryPayload; ExpirableBlob[] externalPayload; ExpirableBlob[] applicationPayload; }
@@ -1177,830 +827,17 @@ See the [wrapper's documentation](`LogicInstance`) for more details.*/
         }
     }
 }
+///Module containing a contract's types and functions.
 /**
 
-Generated by the following Solidity interface...
 ```solidity
-library Delta {
-    struct Point {
-        uint256 x;
-        uint256 y;
-    }
+library Types {
+    struct Action { Consumed[] consumed; Created[] created; Delta delta; bytes32 actionTreeRoot; }
+    struct Consumed { bytes32 nullifier; bytes32 logicRef; bytes32 commitmentTreeRoot; Logic.AppData appData; }
+    struct Created { bytes32 commitment; bytes32 logicRef; Logic.AppData appData; }
+    struct Delta { uint256 x; uint256 y; }
+    struct Transaction { Action[] actions; bytes deltaProof; bytes aggregationProof; }
 }
-
-library Logic {
-    type DeletionCriterion is uint8;
-    struct AppData {
-        ExpirableBlob[] resourcePayload;
-        ExpirableBlob[] discoveryPayload;
-        ExpirableBlob[] externalPayload;
-        ExpirableBlob[] applicationPayload;
-    }
-    struct ExpirableBlob {
-        DeletionCriterion deletionCriterion;
-        bytes blob;
-    }
-}
-
-interface IProtocolAdapter {
-    struct Action {
-        Consumed[] consumed;
-        Created[] created;
-        Delta.Point delta;
-        bytes32 actionTreeRoot;
-    }
-    struct Consumed {
-        bytes32 nullifier;
-        bytes32 logicRef;
-        bytes32 commitmentTreeRoot;
-        Logic.AppData appData;
-    }
-    struct Created {
-        bytes32 commitment;
-        bytes32 logicRef;
-        Logic.AppData appData;
-    }
-    struct Transaction {
-        Action[] actions;
-        bytes deltaProof;
-        bytes aggregationProof;
-    }
-
-    event ActionExecuted(bytes32 actionTreeRoot, bytes32[] nullifiers, bytes32[] consumedLogicRefs, bytes32[] commitments, bytes32[] createdLogicRefs);
-    event ApplicationPayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event DiscoveryPayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event ExternalPayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event ForwarderCallExecuted(address indexed untrustedForwarder, bytes input, bytes output);
-    event KindTableCommitmentUpdated(bytes32 indexed kindTableCommitment);
-    event ResourcePayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event TransactionExecuted(bytes32 indexed transactionId);
-
-    function emergencyStop() external;
-    function execute(Transaction memory transaction) external;
-    function getKindTableCommitment() external view returns (bytes32 kindTableCommitment);
-    function getRiscZeroVerifierRouter() external view returns (address verifierRouter);
-    function getRiscZeroVerifierSelector() external view returns (bytes4 verifierSelector);
-    function isEmergencyStopped() external view returns (bool isStopped);
-    function setKindTableCommitment(bytes32 newKindTableCommitment) external;
-    function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofVerification) external;
-}
-```
-
-...which was generated by the following JSON ABI:
-```json
-[
-  {
-    "type": "function",
-    "name": "emergencyStop",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "execute",
-    "inputs": [
-      {
-        "name": "transaction",
-        "type": "tuple",
-        "internalType": "struct Transaction",
-        "components": [
-          {
-            "name": "actions",
-            "type": "tuple[]",
-            "internalType": "struct Action[]",
-            "components": [
-              {
-                "name": "consumed",
-                "type": "tuple[]",
-                "internalType": "struct Consumed[]",
-                "components": [
-                  {
-                    "name": "nullifier",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "commitmentTreeRoot",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "created",
-                "type": "tuple[]",
-                "internalType": "struct Created[]",
-                "components": [
-                  {
-                    "name": "commitment",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "delta",
-                "type": "tuple",
-                "internalType": "struct Delta.Point",
-                "components": [
-                  {
-                    "name": "x",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "y",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  }
-                ]
-              },
-              {
-                "name": "actionTreeRoot",
-                "type": "bytes32",
-                "internalType": "bytes32"
-              }
-            ]
-          },
-          {
-            "name": "deltaProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          },
-          {
-            "name": "aggregationProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "getKindTableCommitment",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "kindTableCommitment",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getRiscZeroVerifierRouter",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "verifierRouter",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getRiscZeroVerifierSelector",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "verifierSelector",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "isEmergencyStopped",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "isStopped",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "setKindTableCommitment",
-    "inputs": [
-      {
-        "name": "newKindTableCommitment",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "simulateExecute",
-    "inputs": [
-      {
-        "name": "transaction",
-        "type": "tuple",
-        "internalType": "struct Transaction",
-        "components": [
-          {
-            "name": "actions",
-            "type": "tuple[]",
-            "internalType": "struct Action[]",
-            "components": [
-              {
-                "name": "consumed",
-                "type": "tuple[]",
-                "internalType": "struct Consumed[]",
-                "components": [
-                  {
-                    "name": "nullifier",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "commitmentTreeRoot",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "created",
-                "type": "tuple[]",
-                "internalType": "struct Created[]",
-                "components": [
-                  {
-                    "name": "commitment",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "delta",
-                "type": "tuple",
-                "internalType": "struct Delta.Point",
-                "components": [
-                  {
-                    "name": "x",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "y",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  }
-                ]
-              },
-              {
-                "name": "actionTreeRoot",
-                "type": "bytes32",
-                "internalType": "bytes32"
-              }
-            ]
-          },
-          {
-            "name": "deltaProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          },
-          {
-            "name": "aggregationProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      },
-      {
-        "name": "skipRiscZeroProofVerification",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "event",
-    "name": "ActionExecuted",
-    "inputs": [
-      {
-        "name": "actionTreeRoot",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "nullifiers",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      },
-      {
-        "name": "consumedLogicRefs",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      },
-      {
-        "name": "commitments",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      },
-      {
-        "name": "createdLogicRefs",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ApplicationPayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "DiscoveryPayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ExternalPayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ForwarderCallExecuted",
-    "inputs": [
-      {
-        "name": "untrustedForwarder",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "input",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      },
-      {
-        "name": "output",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "KindTableCommitmentUpdated",
-    "inputs": [
-      {
-        "name": "kindTableCommitment",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ResourcePayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "TransactionExecuted",
-    "inputs": [
-      {
-        "name": "transactionId",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  }
-]
 ```*/
 #[allow(
     non_camel_case_types,
@@ -2009,33 +846,13 @@ interface IProtocolAdapter {
     clippy::style,
     clippy::empty_structs_with_brackets
 )]
-pub mod IProtocolAdapter {
+pub mod Types {
     use super::*;
     use alloy::sol_types as alloy_sol_types;
-    /// The creation / init bytecode of the contract.
-    ///
-    /// ```text
-    ///0x
-    /// ```
-    #[rustfmt::skip]
-    #[allow(clippy::all)]
-    pub static BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
-        b"",
-    );
-    /// The runtime bytecode of the contract, as deployed on the network.
-    ///
-    /// ```text
-    ///0x
-    /// ```
-    #[rustfmt::skip]
-    #[allow(clippy::all)]
-    pub static DEPLOYED_BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
-        b"",
-    );
     #[derive(serde::Serialize, serde::Deserialize)]
     #[derive()]
     /**```solidity
-struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes32 actionTreeRoot; }
+struct Action { Consumed[] consumed; Created[] created; Delta delta; bytes32 actionTreeRoot; }
 ```*/
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
@@ -2049,7 +866,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
             <Created as alloy::sol_types::SolType>::RustType,
         >,
         #[allow(missing_docs)]
-        pub delta: <Delta::Point as alloy::sol_types::SolType>::RustType,
+        pub delta: <Delta as alloy::sol_types::SolType>::RustType,
         #[allow(missing_docs)]
         pub actionTreeRoot: alloy::sol_types::private::FixedBytes<32>,
     }
@@ -2066,7 +883,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
         type UnderlyingSolTuple<'a> = (
             alloy::sol_types::sol_data::Array<Consumed>,
             alloy::sol_types::sol_data::Array<Created>,
-            Delta::Point,
+            Delta,
             alloy::sol_types::sol_data::FixedBytes<32>,
         );
         #[doc(hidden)]
@@ -2077,7 +894,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
             alloy::sol_types::private::Vec<
                 <Created as alloy::sol_types::SolType>::RustType,
             >,
-            <Delta::Point as alloy::sol_types::SolType>::RustType,
+            <Delta as alloy::sol_types::SolType>::RustType,
             alloy::sol_types::private::FixedBytes<32>,
         );
         #[cfg(test)]
@@ -2125,7 +942,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                     <alloy::sol_types::sol_data::Array<
                         Created,
                     > as alloy_sol_types::SolType>::tokenize(&self.created),
-                    <Delta::Point as alloy_sol_types::SolType>::tokenize(&self.delta),
+                    <Delta as alloy_sol_types::SolType>::tokenize(&self.delta),
                     <alloy::sol_types::sol_data::FixedBytes<
                         32,
                     > as alloy_sol_types::SolType>::tokenize(&self.actionTreeRoot),
@@ -2203,7 +1020,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
             #[inline]
             fn eip712_root_type() -> alloy_sol_types::private::Cow<'static, str> {
                 alloy_sol_types::private::Cow::Borrowed(
-                    "Action(Consumed[] consumed,Created[] created,Point delta,bytes32 actionTreeRoot)",
+                    "Action(Consumed[] consumed,Created[] created,Delta delta,bytes32 actionTreeRoot)",
                 )
             }
             #[inline]
@@ -2224,13 +1041,9 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                         <Created as alloy_sol_types::SolStruct>::eip712_components(),
                     );
                 components
-                    .push(
-                        <Delta::Point as alloy_sol_types::SolStruct>::eip712_root_type(),
-                    );
+                    .push(<Delta as alloy_sol_types::SolStruct>::eip712_root_type());
                 components
-                    .extend(
-                        <Delta::Point as alloy_sol_types::SolStruct>::eip712_components(),
-                    );
+                    .extend(<Delta as alloy_sol_types::SolStruct>::eip712_components());
                 components
             }
             #[inline]
@@ -2244,10 +1057,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                         Created,
                     > as alloy_sol_types::SolType>::eip712_data_word(&self.created)
                         .0,
-                    <Delta::Point as alloy_sol_types::SolType>::eip712_data_word(
-                            &self.delta,
-                        )
-                        .0,
+                    <Delta as alloy_sol_types::SolType>::eip712_data_word(&self.delta).0,
                     <alloy::sol_types::sol_data::FixedBytes<
                         32,
                     > as alloy_sol_types::SolType>::eip712_data_word(
@@ -2273,7 +1083,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                     > as alloy_sol_types::EventTopic>::topic_preimage_length(
                         &rust.created,
                     )
-                    + <Delta::Point as alloy_sol_types::EventTopic>::topic_preimage_length(
+                    + <Delta as alloy_sol_types::EventTopic>::topic_preimage_length(
                         &rust.delta,
                     )
                     + <alloy::sol_types::sol_data::FixedBytes<
@@ -2302,7 +1112,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                     &rust.created,
                     out,
                 );
-                <Delta::Point as alloy_sol_types::EventTopic>::encode_topic_preimage(
+                <Delta as alloy_sol_types::EventTopic>::encode_topic_preimage(
                     &rust.delta,
                     out,
                 );
@@ -2861,6 +1671,220 @@ struct Created { bytes32 commitment; bytes32 logicRef; Logic.AppData appData; }
         }
     };
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(Default, Debug, PartialEq, Eq, Hash)]
+    /**```solidity
+struct Delta { uint256 x; uint256 y; }
+```*/
+    #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
+    #[derive(Clone)]
+    pub struct Delta {
+        #[allow(missing_docs)]
+        pub x: alloy::sol_types::private::primitives::aliases::U256,
+        #[allow(missing_docs)]
+        pub y: alloy::sol_types::private::primitives::aliases::U256,
+    }
+    #[allow(
+        non_camel_case_types,
+        non_snake_case,
+        clippy::pub_underscore_fields,
+        clippy::style
+    )]
+    const _: () = {
+        use alloy::sol_types as alloy_sol_types;
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        type UnderlyingSolTuple<'a> = (
+            alloy::sol_types::sol_data::Uint<256>,
+            alloy::sol_types::sol_data::Uint<256>,
+        );
+        #[doc(hidden)]
+        type UnderlyingRustTuple<'a> = (
+            alloy::sol_types::private::primitives::aliases::U256,
+            alloy::sol_types::private::primitives::aliases::U256,
+        );
+        #[cfg(test)]
+        #[allow(dead_code, unreachable_patterns)]
+        fn _type_assertion(
+            _t: alloy_sol_types::private::AssertTypeEq<UnderlyingRustTuple>,
+        ) {
+            match _t {
+                alloy_sol_types::private::AssertTypeEq::<
+                    <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
+                >(_) => {}
+            }
+        }
+        #[automatically_derived]
+        #[doc(hidden)]
+        impl ::core::convert::From<Delta> for UnderlyingRustTuple<'_> {
+            fn from(value: Delta) -> Self {
+                (value.x, value.y)
+            }
+        }
+        #[automatically_derived]
+        #[doc(hidden)]
+        impl ::core::convert::From<UnderlyingRustTuple<'_>> for Delta {
+            fn from(tuple: UnderlyingRustTuple<'_>) -> Self {
+                Self { x: tuple.0, y: tuple.1 }
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::SolValue for Delta {
+            type SolType = Self;
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::private::SolTypeValue<Self> for Delta {
+            #[inline]
+            fn stv_to_tokens(&self) -> <Self as alloy_sol_types::SolType>::Token<'_> {
+                (
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::tokenize(&self.x),
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::tokenize(&self.y),
+                )
+            }
+            #[inline]
+            fn stv_abi_encoded_size(&self) -> usize {
+                if let Some(size) = <Self as alloy_sol_types::SolType>::ENCODED_SIZE {
+                    return size;
+                }
+                let tuple = <UnderlyingRustTuple<
+                    '_,
+                > as ::core::convert::From<Self>>::from(self.clone());
+                <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::abi_encoded_size(&tuple)
+            }
+            #[inline]
+            fn stv_eip712_data_word(&self) -> alloy_sol_types::Word {
+                <Self as alloy_sol_types::SolStruct>::eip712_hash_struct(self)
+            }
+            #[inline]
+            fn stv_abi_encode_packed_to(
+                &self,
+                out: &mut alloy_sol_types::private::Vec<u8>,
+            ) {
+                let tuple = <UnderlyingRustTuple<
+                    '_,
+                > as ::core::convert::From<Self>>::from(self.clone());
+                <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::abi_encode_packed_to(&tuple, out)
+            }
+            #[inline]
+            fn stv_abi_packed_encoded_size(&self) -> usize {
+                if let Some(size) = <Self as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE {
+                    return size;
+                }
+                let tuple = <UnderlyingRustTuple<
+                    '_,
+                > as ::core::convert::From<Self>>::from(self.clone());
+                <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::abi_packed_encoded_size(&tuple)
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::SolType for Delta {
+            type RustType = Self;
+            type Token<'a> = <UnderlyingSolTuple<
+                'a,
+            > as alloy_sol_types::SolType>::Token<'a>;
+            const SOL_NAME: &'static str = <Self as alloy_sol_types::SolStruct>::NAME;
+            const ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
+                '_,
+            > as alloy_sol_types::SolType>::ENCODED_SIZE;
+            const PACKED_ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
+                '_,
+            > as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE;
+            #[inline]
+            fn valid_token(token: &Self::Token<'_>) -> bool {
+                <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::valid_token(token)
+            }
+            #[inline]
+            fn detokenize(token: Self::Token<'_>) -> Self::RustType {
+                let tuple = <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::detokenize(token);
+                <Self as ::core::convert::From<UnderlyingRustTuple<'_>>>::from(tuple)
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::SolStruct for Delta {
+            const NAME: &'static str = "Delta";
+            #[inline]
+            fn eip712_root_type() -> alloy_sol_types::private::Cow<'static, str> {
+                alloy_sol_types::private::Cow::Borrowed("Delta(uint256 x,uint256 y)")
+            }
+            #[inline]
+            fn eip712_components() -> alloy_sol_types::private::Vec<
+                alloy_sol_types::private::Cow<'static, str>,
+            > {
+                alloy_sol_types::private::Vec::new()
+            }
+            #[inline]
+            fn eip712_encode_type() -> alloy_sol_types::private::Cow<'static, str> {
+                <Self as alloy_sol_types::SolStruct>::eip712_root_type()
+            }
+            #[inline]
+            fn eip712_encode_data(&self) -> alloy_sol_types::private::Vec<u8> {
+                [
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::eip712_data_word(&self.x)
+                        .0,
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::eip712_data_word(&self.y)
+                        .0,
+                ]
+                    .concat()
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::EventTopic for Delta {
+            #[inline]
+            fn topic_preimage_length(rust: &Self::RustType) -> usize {
+                0usize
+                    + <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.x)
+                    + <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.y)
+            }
+            #[inline]
+            fn encode_topic_preimage(
+                rust: &Self::RustType,
+                out: &mut alloy_sol_types::private::Vec<u8>,
+            ) {
+                out.reserve(
+                    <Self as alloy_sol_types::EventTopic>::topic_preimage_length(rust),
+                );
+                <alloy::sol_types::sol_data::Uint<
+                    256,
+                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.x, out);
+                <alloy::sol_types::sol_data::Uint<
+                    256,
+                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.y, out);
+            }
+            #[inline]
+            fn encode_topic(
+                rust: &Self::RustType,
+            ) -> alloy_sol_types::abi::token::WordToken {
+                let mut out = alloy_sol_types::private::Vec::new();
+                <Self as alloy_sol_types::EventTopic>::encode_topic_preimage(
+                    rust,
+                    &mut out,
+                );
+                alloy_sol_types::abi::token::WordToken(
+                    alloy_sol_types::private::keccak256(out),
+                )
+            }
+        }
+    };
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[derive()]
     /**```solidity
 struct Transaction { Action[] actions; bytes deltaProof; bytes aggregationProof; }
@@ -3109,6 +2133,978 @@ struct Transaction { Action[] actions; bytes deltaProof; bytes aggregationProof;
             }
         }
     };
+    use alloy::contract as alloy_contract;
+    /**Creates a new wrapper around an on-chain [`Types`](self) contract instance.
+
+See the [wrapper's documentation](`TypesInstance`) for more details.*/
+    #[inline]
+    pub const fn new<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    >(address: alloy_sol_types::private::Address, __provider: P) -> TypesInstance<P, N> {
+        TypesInstance::<P, N>::new(address, __provider)
+    }
+    /**A [`Types`](self) instance.
+
+Contains type-safe methods for interacting with an on-chain instance of the
+[`Types`](self) contract located at a given `address`, using a given
+provider `P`.
+
+If the contract bytecode is available (see the [`sol!`](alloy_sol_types::sol!)
+documentation on how to provide it), the `deploy` and `deploy_builder` methods can
+be used to deploy a new instance of the contract.
+
+See the [module-level documentation](self) for all the available methods.*/
+    #[derive(Clone)]
+    pub struct TypesInstance<P, N = alloy_contract::private::Ethereum> {
+        address: alloy_sol_types::private::Address,
+        provider: P,
+        _network: ::core::marker::PhantomData<N>,
+    }
+    #[automatically_derived]
+    impl<P, N> ::core::fmt::Debug for TypesInstance<P, N> {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+            f.debug_tuple("TypesInstance").field(&self.address).finish()
+        }
+    }
+    /// Instantiation and getters/setters.
+    impl<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    > TypesInstance<P, N> {
+        /**Creates a new wrapper around an on-chain [`Types`](self) contract instance.
+
+See the [wrapper's documentation](`TypesInstance`) for more details.*/
+        #[inline]
+        pub const fn new(
+            address: alloy_sol_types::private::Address,
+            __provider: P,
+        ) -> Self {
+            Self {
+                address,
+                provider: __provider,
+                _network: ::core::marker::PhantomData,
+            }
+        }
+        /// Returns a reference to the address.
+        #[inline]
+        pub const fn address(&self) -> &alloy_sol_types::private::Address {
+            &self.address
+        }
+        /// Sets the address.
+        #[inline]
+        pub fn set_address(&mut self, address: alloy_sol_types::private::Address) {
+            self.address = address;
+        }
+        /// Sets the address and returns `self`.
+        pub fn at(mut self, address: alloy_sol_types::private::Address) -> Self {
+            self.set_address(address);
+            self
+        }
+        /// Returns a reference to the provider.
+        #[inline]
+        pub const fn provider(&self) -> &P {
+            &self.provider
+        }
+    }
+    impl<P: ::core::clone::Clone, N> TypesInstance<&P, N> {
+        /// Clones the provider and returns a new instance with the cloned provider.
+        #[inline]
+        pub fn with_cloned_provider(self) -> TypesInstance<P, N> {
+            TypesInstance {
+                address: self.address,
+                provider: ::core::clone::Clone::clone(&self.provider),
+                _network: ::core::marker::PhantomData,
+            }
+        }
+    }
+    /// Function calls.
+    impl<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    > TypesInstance<P, N> {
+        /// Creates a new call builder using this contract instance's provider and address.
+        ///
+        /// Note that the call can be any function call, not just those defined in this
+        /// contract. Prefer using the other methods for building type-safe contract calls.
+        pub fn call_builder<C: alloy_sol_types::SolCall>(
+            &self,
+            call: &C,
+        ) -> alloy_contract::SolCallBuilder<&P, C, N> {
+            alloy_contract::SolCallBuilder::new_sol(&self.provider, &self.address, call)
+        }
+    }
+    /// Event filters.
+    impl<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    > TypesInstance<P, N> {
+        /// Creates a new event filter using this contract instance's provider and address.
+        ///
+        /// Note that the type can be any event, not just those defined in this contract.
+        /// Prefer using the other methods for building type-safe event filters.
+        pub fn event_filter<E: alloy_sol_types::SolEvent>(
+            &self,
+        ) -> alloy_contract::Event<&P, E, N> {
+            alloy_contract::Event::new_sol(&self.provider, &self.address)
+        }
+    }
+}
+/**
+
+Generated by the following Solidity interface...
+```solidity
+library Logic {
+    type DeletionCriterion is uint8;
+    struct AppData {
+        ExpirableBlob[] resourcePayload;
+        ExpirableBlob[] discoveryPayload;
+        ExpirableBlob[] externalPayload;
+        ExpirableBlob[] applicationPayload;
+    }
+    struct ExpirableBlob {
+        DeletionCriterion deletionCriterion;
+        bytes blob;
+    }
+}
+
+library Types {
+    struct Action {
+        Consumed[] consumed;
+        Created[] created;
+        Delta delta;
+        bytes32 actionTreeRoot;
+    }
+    struct Consumed {
+        bytes32 nullifier;
+        bytes32 logicRef;
+        bytes32 commitmentTreeRoot;
+        Logic.AppData appData;
+    }
+    struct Created {
+        bytes32 commitment;
+        bytes32 logicRef;
+        Logic.AppData appData;
+    }
+    struct Delta {
+        uint256 x;
+        uint256 y;
+    }
+    struct Transaction {
+        Action[] actions;
+        bytes deltaProof;
+        bytes aggregationProof;
+    }
+}
+
+interface IProtocolAdapter {
+    event ActionExecuted(bytes32 actionTreeRoot, bytes32[] nullifiers, bytes32[] consumedLogicRefs, bytes32[] commitments, bytes32[] createdLogicRefs);
+    event ApplicationPayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event DiscoveryPayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event ExternalPayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event ForwarderCallExecuted(address indexed untrustedForwarder, bytes input, bytes output);
+    event KindTableCommitmentUpdated(bytes32 indexed kindTableCommitment);
+    event ResourcePayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event TransactionExecuted(bytes32 indexed transactionId);
+
+    function emergencyStop() external;
+    function execute(Types.Transaction memory transaction) external;
+    function getKindTableCommitment() external view returns (bytes32 kindTableCommitment);
+    function getRiscZeroVerifierRouter() external view returns (address verifierRouter);
+    function getRiscZeroVerifierSelector() external view returns (bytes4 verifierSelector);
+    function isEmergencyStopped() external view returns (bool isStopped);
+    function setKindTableCommitment(bytes32 newKindTableCommitment) external;
+    function simulateExecute(Types.Transaction memory transaction, bool skipRiscZeroProofVerification) external;
+}
+```
+
+...which was generated by the following JSON ABI:
+```json
+[
+  {
+    "type": "function",
+    "name": "emergencyStop",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "execute",
+    "inputs": [
+      {
+        "name": "transaction",
+        "type": "tuple",
+        "internalType": "struct Types.Transaction",
+        "components": [
+          {
+            "name": "actions",
+            "type": "tuple[]",
+            "internalType": "struct Types.Action[]",
+            "components": [
+              {
+                "name": "consumed",
+                "type": "tuple[]",
+                "internalType": "struct Types.Consumed[]",
+                "components": [
+                  {
+                    "name": "nullifier",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "commitmentTreeRoot",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "created",
+                "type": "tuple[]",
+                "internalType": "struct Types.Created[]",
+                "components": [
+                  {
+                    "name": "commitment",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "delta",
+                "type": "tuple",
+                "internalType": "struct Types.Delta",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "actionTreeRoot",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "deltaProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "aggregationProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getKindTableCommitment",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "kindTableCommitment",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRiscZeroVerifierRouter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "verifierRouter",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRiscZeroVerifierSelector",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "verifierSelector",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isEmergencyStopped",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "isStopped",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setKindTableCommitment",
+    "inputs": [
+      {
+        "name": "newKindTableCommitment",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "simulateExecute",
+    "inputs": [
+      {
+        "name": "transaction",
+        "type": "tuple",
+        "internalType": "struct Types.Transaction",
+        "components": [
+          {
+            "name": "actions",
+            "type": "tuple[]",
+            "internalType": "struct Types.Action[]",
+            "components": [
+              {
+                "name": "consumed",
+                "type": "tuple[]",
+                "internalType": "struct Types.Consumed[]",
+                "components": [
+                  {
+                    "name": "nullifier",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "commitmentTreeRoot",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "created",
+                "type": "tuple[]",
+                "internalType": "struct Types.Created[]",
+                "components": [
+                  {
+                    "name": "commitment",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "delta",
+                "type": "tuple",
+                "internalType": "struct Types.Delta",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "actionTreeRoot",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "deltaProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "aggregationProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "skipRiscZeroProofVerification",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "ActionExecuted",
+    "inputs": [
+      {
+        "name": "actionTreeRoot",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nullifiers",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "consumedLogicRefs",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "commitments",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "createdLogicRefs",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApplicationPayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DiscoveryPayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExternalPayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ForwarderCallExecuted",
+    "inputs": [
+      {
+        "name": "untrustedForwarder",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "input",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "output",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "KindTableCommitmentUpdated",
+    "inputs": [
+      {
+        "name": "kindTableCommitment",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcePayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TransactionExecuted",
+    "inputs": [
+      {
+        "name": "transactionId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  }
+]
+```*/
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    clippy::pub_underscore_fields,
+    clippy::style,
+    clippy::empty_structs_with_brackets
+)]
+pub mod IProtocolAdapter {
+    use super::*;
+    use alloy::sol_types as alloy_sol_types;
+    /// The creation / init bytecode of the contract.
+    ///
+    /// ```text
+    ///0x
+    /// ```
+    #[rustfmt::skip]
+    #[allow(clippy::all)]
+    pub static BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
+        b"",
+    );
+    /// The runtime bytecode of the contract, as deployed on the network.
+    ///
+    /// ```text
+    ///0x
+    /// ```
+    #[rustfmt::skip]
+    #[allow(clippy::all)]
+    pub static DEPLOYED_BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
+        b"",
+    );
     #[derive(serde::Serialize, serde::Deserialize)]
     #[derive(Default, Debug, PartialEq, Eq, Hash)]
     /**Event with signature `ActionExecuted(bytes32,bytes32[],bytes32[],bytes32[],bytes32[])` and selector `0x4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc32`.
@@ -4248,13 +4244,13 @@ function emergencyStop() external;
     #[derive()]
     /**Function with signature `execute((((bytes32,bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(uint256,uint256),bytes32)[],bytes,bytes))` and selector `0x73ab9916`.
 ```solidity
-function execute(Transaction memory transaction) external;
+function execute(Types.Transaction memory transaction) external;
 ```*/
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct executeCall {
         #[allow(missing_docs)]
-        pub transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+        pub transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
     }
     ///Container type for the return parameters of the [`execute((((bytes32,bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(uint256,uint256),bytes32)[],bytes,bytes))`](executeCall) function.
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
@@ -4271,10 +4267,10 @@ function execute(Transaction memory transaction) external;
         {
             #[doc(hidden)]
             #[allow(dead_code)]
-            type UnderlyingSolTuple<'a> = (Transaction,);
+            type UnderlyingSolTuple<'a> = (Types::Transaction,);
             #[doc(hidden)]
             type UnderlyingRustTuple<'a> = (
-                <Transaction as alloy::sol_types::SolType>::RustType,
+                <Types::Transaction as alloy::sol_types::SolType>::RustType,
             );
             #[cfg(test)]
             #[allow(dead_code, unreachable_patterns)]
@@ -4343,7 +4339,7 @@ function execute(Transaction memory transaction) external;
         }
         #[automatically_derived]
         impl alloy_sol_types::SolCall for executeCall {
-            type Parameters<'a> = (Transaction,);
+            type Parameters<'a> = (Types::Transaction,);
             type Token<'a> = <Self::Parameters<
                 'a,
             > as alloy_sol_types::SolType>::Token<'a>;
@@ -4362,7 +4358,11 @@ function execute(Transaction memory transaction) external;
             }
             #[inline]
             fn tokenize(&self) -> Self::Token<'_> {
-                (<Transaction as alloy_sol_types::SolType>::tokenize(&self.transaction),)
+                (
+                    <Types::Transaction as alloy_sol_types::SolType>::tokenize(
+                        &self.transaction,
+                    ),
+                )
             }
             #[inline]
             fn tokenize_returns(ret: &Self::Return) -> Self::ReturnToken<'_> {
@@ -5142,13 +5142,13 @@ function setKindTableCommitment(bytes32 newKindTableCommitment) external;
     #[derive()]
     /**Function with signature `simulateExecute((((bytes32,bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(uint256,uint256),bytes32)[],bytes,bytes),bool)` and selector `0x87093eba`.
 ```solidity
-function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofVerification) external;
+function simulateExecute(Types.Transaction memory transaction, bool skipRiscZeroProofVerification) external;
 ```*/
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct simulateExecuteCall {
         #[allow(missing_docs)]
-        pub transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+        pub transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
         #[allow(missing_docs)]
         pub skipRiscZeroProofVerification: bool,
     }
@@ -5168,12 +5168,12 @@ function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofV
             #[doc(hidden)]
             #[allow(dead_code)]
             type UnderlyingSolTuple<'a> = (
-                Transaction,
+                Types::Transaction,
                 alloy::sol_types::sol_data::Bool,
             );
             #[doc(hidden)]
             type UnderlyingRustTuple<'a> = (
-                <Transaction as alloy::sol_types::SolType>::RustType,
+                <Types::Transaction as alloy::sol_types::SolType>::RustType,
                 bool,
             );
             #[cfg(test)]
@@ -5248,7 +5248,7 @@ function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofV
         }
         #[automatically_derived]
         impl alloy_sol_types::SolCall for simulateExecuteCall {
-            type Parameters<'a> = (Transaction, alloy::sol_types::sol_data::Bool);
+            type Parameters<'a> = (Types::Transaction, alloy::sol_types::sol_data::Bool);
             type Token<'a> = <Self::Parameters<
                 'a,
             > as alloy_sol_types::SolType>::Token<'a>;
@@ -5268,7 +5268,7 @@ function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofV
             #[inline]
             fn tokenize(&self) -> Self::Token<'_> {
                 (
-                    <Transaction as alloy_sol_types::SolType>::tokenize(
+                    <Types::Transaction as alloy_sol_types::SolType>::tokenize(
                         &self.transaction,
                     ),
                     <alloy::sol_types::sol_data::Bool as alloy_sol_types::SolType>::tokenize(
@@ -6154,7 +6154,7 @@ the bytecode concatenated with the constructor's ABI-encoded arguments.*/
         ///Creates a new call builder for the [`execute`] function.
         pub fn execute(
             &self,
-            transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+            transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
         ) -> alloy_contract::SolCallBuilder<&P, executeCall, N> {
             self.call_builder(&executeCall { transaction })
         }
@@ -6196,7 +6196,7 @@ the bytecode concatenated with the constructor's ABI-encoded arguments.*/
         ///Creates a new call builder for the [`simulateExecute`] function.
         pub fn simulateExecute(
             &self,
-            transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+            transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
             skipRiscZeroProofVerification: bool,
         ) -> alloy_contract::SolCallBuilder<&P, simulateExecuteCall, N> {
             self.call_builder(

--- a/crates/bindings/src/generated/protocol_adapter.rs
+++ b/crates/bindings/src/generated/protocol_adapter.rs
@@ -2,356 +2,6 @@
 /**
 
 ```solidity
-library Delta {
-    struct Point { uint256 x; uint256 y; }
-}
-```*/
-#[allow(
-    non_camel_case_types,
-    non_snake_case,
-    clippy::pub_underscore_fields,
-    clippy::style,
-    clippy::empty_structs_with_brackets
-)]
-pub mod Delta {
-    use super::*;
-    use alloy::sol_types as alloy_sol_types;
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[derive(Default, Debug, PartialEq, Eq, Hash)]
-    /**```solidity
-struct Point { uint256 x; uint256 y; }
-```*/
-    #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
-    #[derive(Clone)]
-    pub struct Point {
-        #[allow(missing_docs)]
-        pub x: alloy::sol_types::private::primitives::aliases::U256,
-        #[allow(missing_docs)]
-        pub y: alloy::sol_types::private::primitives::aliases::U256,
-    }
-    #[allow(
-        non_camel_case_types,
-        non_snake_case,
-        clippy::pub_underscore_fields,
-        clippy::style
-    )]
-    const _: () = {
-        use alloy::sol_types as alloy_sol_types;
-        #[doc(hidden)]
-        #[allow(dead_code)]
-        type UnderlyingSolTuple<'a> = (
-            alloy::sol_types::sol_data::Uint<256>,
-            alloy::sol_types::sol_data::Uint<256>,
-        );
-        #[doc(hidden)]
-        type UnderlyingRustTuple<'a> = (
-            alloy::sol_types::private::primitives::aliases::U256,
-            alloy::sol_types::private::primitives::aliases::U256,
-        );
-        #[cfg(test)]
-        #[allow(dead_code, unreachable_patterns)]
-        fn _type_assertion(
-            _t: alloy_sol_types::private::AssertTypeEq<UnderlyingRustTuple>,
-        ) {
-            match _t {
-                alloy_sol_types::private::AssertTypeEq::<
-                    <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
-                >(_) => {}
-            }
-        }
-        #[automatically_derived]
-        #[doc(hidden)]
-        impl ::core::convert::From<Point> for UnderlyingRustTuple<'_> {
-            fn from(value: Point) -> Self {
-                (value.x, value.y)
-            }
-        }
-        #[automatically_derived]
-        #[doc(hidden)]
-        impl ::core::convert::From<UnderlyingRustTuple<'_>> for Point {
-            fn from(tuple: UnderlyingRustTuple<'_>) -> Self {
-                Self { x: tuple.0, y: tuple.1 }
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::SolValue for Point {
-            type SolType = Self;
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::private::SolTypeValue<Self> for Point {
-            #[inline]
-            fn stv_to_tokens(&self) -> <Self as alloy_sol_types::SolType>::Token<'_> {
-                (
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::tokenize(&self.x),
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::tokenize(&self.y),
-                )
-            }
-            #[inline]
-            fn stv_abi_encoded_size(&self) -> usize {
-                if let Some(size) = <Self as alloy_sol_types::SolType>::ENCODED_SIZE {
-                    return size;
-                }
-                let tuple = <UnderlyingRustTuple<
-                    '_,
-                > as ::core::convert::From<Self>>::from(self.clone());
-                <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::abi_encoded_size(&tuple)
-            }
-            #[inline]
-            fn stv_eip712_data_word(&self) -> alloy_sol_types::Word {
-                <Self as alloy_sol_types::SolStruct>::eip712_hash_struct(self)
-            }
-            #[inline]
-            fn stv_abi_encode_packed_to(
-                &self,
-                out: &mut alloy_sol_types::private::Vec<u8>,
-            ) {
-                let tuple = <UnderlyingRustTuple<
-                    '_,
-                > as ::core::convert::From<Self>>::from(self.clone());
-                <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::abi_encode_packed_to(&tuple, out)
-            }
-            #[inline]
-            fn stv_abi_packed_encoded_size(&self) -> usize {
-                if let Some(size) = <Self as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE {
-                    return size;
-                }
-                let tuple = <UnderlyingRustTuple<
-                    '_,
-                > as ::core::convert::From<Self>>::from(self.clone());
-                <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::abi_packed_encoded_size(&tuple)
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::SolType for Point {
-            type RustType = Self;
-            type Token<'a> = <UnderlyingSolTuple<
-                'a,
-            > as alloy_sol_types::SolType>::Token<'a>;
-            const SOL_NAME: &'static str = <Self as alloy_sol_types::SolStruct>::NAME;
-            const ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
-                '_,
-            > as alloy_sol_types::SolType>::ENCODED_SIZE;
-            const PACKED_ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
-                '_,
-            > as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE;
-            #[inline]
-            fn valid_token(token: &Self::Token<'_>) -> bool {
-                <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::valid_token(token)
-            }
-            #[inline]
-            fn detokenize(token: Self::Token<'_>) -> Self::RustType {
-                let tuple = <UnderlyingSolTuple<
-                    '_,
-                > as alloy_sol_types::SolType>::detokenize(token);
-                <Self as ::core::convert::From<UnderlyingRustTuple<'_>>>::from(tuple)
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::SolStruct for Point {
-            const NAME: &'static str = "Point";
-            #[inline]
-            fn eip712_root_type() -> alloy_sol_types::private::Cow<'static, str> {
-                alloy_sol_types::private::Cow::Borrowed("Point(uint256 x,uint256 y)")
-            }
-            #[inline]
-            fn eip712_components() -> alloy_sol_types::private::Vec<
-                alloy_sol_types::private::Cow<'static, str>,
-            > {
-                alloy_sol_types::private::Vec::new()
-            }
-            #[inline]
-            fn eip712_encode_type() -> alloy_sol_types::private::Cow<'static, str> {
-                <Self as alloy_sol_types::SolStruct>::eip712_root_type()
-            }
-            #[inline]
-            fn eip712_encode_data(&self) -> alloy_sol_types::private::Vec<u8> {
-                [
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::eip712_data_word(&self.x)
-                        .0,
-                    <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::SolType>::eip712_data_word(&self.y)
-                        .0,
-                ]
-                    .concat()
-            }
-        }
-        #[automatically_derived]
-        impl alloy_sol_types::EventTopic for Point {
-            #[inline]
-            fn topic_preimage_length(rust: &Self::RustType) -> usize {
-                0usize
-                    + <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.x)
-                    + <alloy::sol_types::sol_data::Uint<
-                        256,
-                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.y)
-            }
-            #[inline]
-            fn encode_topic_preimage(
-                rust: &Self::RustType,
-                out: &mut alloy_sol_types::private::Vec<u8>,
-            ) {
-                out.reserve(
-                    <Self as alloy_sol_types::EventTopic>::topic_preimage_length(rust),
-                );
-                <alloy::sol_types::sol_data::Uint<
-                    256,
-                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.x, out);
-                <alloy::sol_types::sol_data::Uint<
-                    256,
-                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.y, out);
-            }
-            #[inline]
-            fn encode_topic(
-                rust: &Self::RustType,
-            ) -> alloy_sol_types::abi::token::WordToken {
-                let mut out = alloy_sol_types::private::Vec::new();
-                <Self as alloy_sol_types::EventTopic>::encode_topic_preimage(
-                    rust,
-                    &mut out,
-                );
-                alloy_sol_types::abi::token::WordToken(
-                    alloy_sol_types::private::keccak256(out),
-                )
-            }
-        }
-    };
-    use alloy::contract as alloy_contract;
-    /**Creates a new wrapper around an on-chain [`Delta`](self) contract instance.
-
-See the [wrapper's documentation](`DeltaInstance`) for more details.*/
-    #[inline]
-    pub const fn new<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    >(address: alloy_sol_types::private::Address, __provider: P) -> DeltaInstance<P, N> {
-        DeltaInstance::<P, N>::new(address, __provider)
-    }
-    /**A [`Delta`](self) instance.
-
-Contains type-safe methods for interacting with an on-chain instance of the
-[`Delta`](self) contract located at a given `address`, using a given
-provider `P`.
-
-If the contract bytecode is available (see the [`sol!`](alloy_sol_types::sol!)
-documentation on how to provide it), the `deploy` and `deploy_builder` methods can
-be used to deploy a new instance of the contract.
-
-See the [module-level documentation](self) for all the available methods.*/
-    #[derive(Clone)]
-    pub struct DeltaInstance<P, N = alloy_contract::private::Ethereum> {
-        address: alloy_sol_types::private::Address,
-        provider: P,
-        _network: ::core::marker::PhantomData<N>,
-    }
-    #[automatically_derived]
-    impl<P, N> ::core::fmt::Debug for DeltaInstance<P, N> {
-        #[inline]
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-            f.debug_tuple("DeltaInstance").field(&self.address).finish()
-        }
-    }
-    /// Instantiation and getters/setters.
-    impl<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    > DeltaInstance<P, N> {
-        /**Creates a new wrapper around an on-chain [`Delta`](self) contract instance.
-
-See the [wrapper's documentation](`DeltaInstance`) for more details.*/
-        #[inline]
-        pub const fn new(
-            address: alloy_sol_types::private::Address,
-            __provider: P,
-        ) -> Self {
-            Self {
-                address,
-                provider: __provider,
-                _network: ::core::marker::PhantomData,
-            }
-        }
-        /// Returns a reference to the address.
-        #[inline]
-        pub const fn address(&self) -> &alloy_sol_types::private::Address {
-            &self.address
-        }
-        /// Sets the address.
-        #[inline]
-        pub fn set_address(&mut self, address: alloy_sol_types::private::Address) {
-            self.address = address;
-        }
-        /// Sets the address and returns `self`.
-        pub fn at(mut self, address: alloy_sol_types::private::Address) -> Self {
-            self.set_address(address);
-            self
-        }
-        /// Returns a reference to the provider.
-        #[inline]
-        pub const fn provider(&self) -> &P {
-            &self.provider
-        }
-    }
-    impl<P: ::core::clone::Clone, N> DeltaInstance<&P, N> {
-        /// Clones the provider and returns a new instance with the cloned provider.
-        #[inline]
-        pub fn with_cloned_provider(self) -> DeltaInstance<P, N> {
-            DeltaInstance {
-                address: self.address,
-                provider: ::core::clone::Clone::clone(&self.provider),
-                _network: ::core::marker::PhantomData,
-            }
-        }
-    }
-    /// Function calls.
-    impl<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    > DeltaInstance<P, N> {
-        /// Creates a new call builder using this contract instance's provider and address.
-        ///
-        /// Note that the call can be any function call, not just those defined in this
-        /// contract. Prefer using the other methods for building type-safe contract calls.
-        pub fn call_builder<C: alloy_sol_types::SolCall>(
-            &self,
-            call: &C,
-        ) -> alloy_contract::SolCallBuilder<&P, C, N> {
-            alloy_contract::SolCallBuilder::new_sol(&self.provider, &self.address, call)
-        }
-    }
-    /// Event filters.
-    impl<
-        P: alloy_contract::private::Provider<N>,
-        N: alloy_contract::private::Network,
-    > DeltaInstance<P, N> {
-        /// Creates a new event filter using this contract instance's provider and address.
-        ///
-        /// Note that the type can be any event, not just those defined in this contract.
-        /// Prefer using the other methods for building type-safe event filters.
-        pub fn event_filter<E: alloy_sol_types::SolEvent>(
-            &self,
-        ) -> alloy_contract::Event<&P, E, N> {
-            alloy_contract::Event::new_sol(&self.provider, &self.address)
-        }
-    }
-}
-///Module containing a contract's types and functions.
-/**
-
-```solidity
 library Logic {
     type DeletionCriterion is uint8;
     struct AppData { ExpirableBlob[] resourcePayload; ExpirableBlob[] discoveryPayload; ExpirableBlob[] externalPayload; ExpirableBlob[] applicationPayload; }
@@ -1177,1519 +827,17 @@ See the [wrapper's documentation](`LogicInstance`) for more details.*/
         }
     }
 }
+///Module containing a contract's types and functions.
 /**
 
-Generated by the following Solidity interface...
 ```solidity
-library Delta {
-    struct Point {
-        uint256 x;
-        uint256 y;
-    }
+library Types {
+    struct Action { Consumed[] consumed; Created[] created; Delta delta; bytes32 actionTreeRoot; }
+    struct Consumed { bytes32 nullifier; bytes32 logicRef; bytes32 commitmentTreeRoot; Logic.AppData appData; }
+    struct Created { bytes32 commitment; bytes32 logicRef; Logic.AppData appData; }
+    struct Delta { uint256 x; uint256 y; }
+    struct Transaction { Action[] actions; bytes deltaProof; bytes aggregationProof; }
 }
-
-library Logic {
-    type DeletionCriterion is uint8;
-    struct AppData {
-        ExpirableBlob[] resourcePayload;
-        ExpirableBlob[] discoveryPayload;
-        ExpirableBlob[] externalPayload;
-        ExpirableBlob[] applicationPayload;
-    }
-    struct ExpirableBlob {
-        DeletionCriterion deletionCriterion;
-        bytes blob;
-    }
-}
-
-interface ProtocolAdapter {
-    struct Action {
-        Consumed[] consumed;
-        Created[] created;
-        Delta.Point delta;
-        bytes32 actionTreeRoot;
-    }
-    struct Consumed {
-        bytes32 nullifier;
-        bytes32 logicRef;
-        bytes32 commitmentTreeRoot;
-        Logic.AppData appData;
-    }
-    struct Created {
-        bytes32 commitment;
-        bytes32 logicRef;
-        Logic.AppData appData;
-    }
-    struct Transaction {
-        Action[] actions;
-        bytes deltaProof;
-        bytes aggregationProof;
-    }
-
-    error AddressEmptyCode(address target);
-    error DeltaMismatch(address expected, address actual);
-    error ECDSAInvalidSignature();
-    error ECDSAInvalidSignatureLength(uint256 length);
-    error ECDSAInvalidSignatureS(bytes32 s);
-    error ERC1967InvalidImplementation(address implementation);
-    error ERC1967NonPayable();
-    error EmptyTransactionNotAllowed();
-    error EnforcedPause();
-    error ExpectedPause();
-    error FailedCall();
-    error ForwarderCallOutputMismatch(bytes expected, bytes actual);
-    error InvalidInitialization();
-    error NonExistingRoot(bytes32 root);
-    error NotInitializing();
-    error OwnableInvalidOwner(address owner);
-    error OwnableUnauthorizedAccount(address account);
-    error PointNotOnCurve(Delta.Point point);
-    error PreExistingNullifier(bytes32 nullifier);
-    error PreExistingRoot(bytes32 root);
-    error ReentrancyGuardReentrantCall();
-    error RiscZeroVerifierSelectorMismatch(bytes4 expected, bytes4 actual);
-    error RiscZeroVerifierStopped();
-    error Simulated(uint256 gasUsed);
-    error UUPSUnauthorizedCallContext();
-    error UUPSUnsupportedProxiableUUID(bytes32 slot);
-    error ZeroKindTableCommitmentNotAllowed();
-    error ZeroRiscZeroVerifierRouterNotAllowed();
-    error ZeroRiscZeroVerifierSelectorNotAllowed();
-
-    event ActionExecuted(bytes32 actionTreeRoot, bytes32[] nullifiers, bytes32[] consumedLogicRefs, bytes32[] commitments, bytes32[] createdLogicRefs);
-    event ApplicationPayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event CommitmentTreeRootAdded(bytes32 root);
-    event DiscoveryPayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event ExternalPayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event ForwarderCallExecuted(address indexed untrustedForwarder, bytes input, bytes output);
-    event Initialized(uint64 version);
-    event KindTableCommitmentUpdated(bytes32 indexed kindTableCommitment);
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-    event Paused(address account);
-    event ResourcePayload(bytes32 indexed tag, uint256 index, bytes blob);
-    event TransactionExecuted(bytes32 indexed transactionId);
-    event Unpaused(address account);
-    event Upgraded(address indexed implementation);
-
-    constructor(address riscZeroVerifierRouter, bytes4 riscZeroVerifierSelector);
-
-    function UPGRADE_INTERFACE_VERSION() external view returns (string memory);
-    function commitmentCount() external view returns (uint256 count);
-    function commitmentTreeCapacity() external view returns (uint256 capacity);
-    function commitmentTreeDepth() external view returns (uint8 depth);
-    function commitmentTreeRootAtIndex(uint256 index) external view returns (bytes32 root);
-    function commitmentTreeRootCount() external view returns (uint256 count);
-    function emergencyStop() external;
-    function execute(Transaction memory transaction) external;
-    function getKindTableCommitment() external view returns (bytes32 kindTableCommitment);
-    function getRiscZeroVerifierRouter() external view returns (address verifierRouter);
-    function getRiscZeroVerifierSelector() external view returns (bytes4 verifierSelector);
-    function getVersion() external pure returns (bytes32 version);
-    function initialize(address initialOwner) external;
-    function isCommitmentTreeRootContained(bytes32 root) external view returns (bool isContained);
-    function isEmergencyStopped() external view returns (bool isStopped);
-    function isNullifierContained(bytes32 nullifier) external view returns (bool isContained);
-    function latestCommitmentTreeRoot() external view returns (bytes32 root);
-    function nullifierAtIndex(uint256 index) external view returns (bytes32 nullifier);
-    function nullifierCount() external view returns (uint256 count);
-    function owner() external view returns (address);
-    function paused() external view returns (bool);
-    function proxiableUUID() external view returns (bytes32);
-    function renounceOwnership() external;
-    function setKindTableCommitment(bytes32 newKindTableCommitment) external;
-    function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofVerification) external;
-    function transferOwnership(address newOwner) external;
-    function upgradeToAndCall(address newImplementation, bytes memory data) external payable;
-}
-```
-
-...which was generated by the following JSON ABI:
-```json
-[
-  {
-    "type": "constructor",
-    "inputs": [
-      {
-        "name": "riscZeroVerifierRouter",
-        "type": "address",
-        "internalType": "contract RiscZeroVerifierRouter"
-      },
-      {
-        "name": "riscZeroVerifierSelector",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "UPGRADE_INTERFACE_VERSION",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "string",
-        "internalType": "string"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "commitmentCount",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "count",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "commitmentTreeCapacity",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "capacity",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "commitmentTreeDepth",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "depth",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "commitmentTreeRootAtIndex",
-    "inputs": [
-      {
-        "name": "index",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "commitmentTreeRootCount",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "count",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "emergencyStop",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "execute",
-    "inputs": [
-      {
-        "name": "transaction",
-        "type": "tuple",
-        "internalType": "struct Transaction",
-        "components": [
-          {
-            "name": "actions",
-            "type": "tuple[]",
-            "internalType": "struct Action[]",
-            "components": [
-              {
-                "name": "consumed",
-                "type": "tuple[]",
-                "internalType": "struct Consumed[]",
-                "components": [
-                  {
-                    "name": "nullifier",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "commitmentTreeRoot",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "created",
-                "type": "tuple[]",
-                "internalType": "struct Created[]",
-                "components": [
-                  {
-                    "name": "commitment",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "delta",
-                "type": "tuple",
-                "internalType": "struct Delta.Point",
-                "components": [
-                  {
-                    "name": "x",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "y",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  }
-                ]
-              },
-              {
-                "name": "actionTreeRoot",
-                "type": "bytes32",
-                "internalType": "bytes32"
-              }
-            ]
-          },
-          {
-            "name": "deltaProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          },
-          {
-            "name": "aggregationProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "getKindTableCommitment",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "kindTableCommitment",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getRiscZeroVerifierRouter",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "verifierRouter",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getRiscZeroVerifierSelector",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "verifierSelector",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getVersion",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "version",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
-    "name": "initialize",
-    "inputs": [
-      {
-        "name": "initialOwner",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "isCommitmentTreeRootContained",
-    "inputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "isContained",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "isEmergencyStopped",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "isStopped",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "isNullifierContained",
-    "inputs": [
-      {
-        "name": "nullifier",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "isContained",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "latestCommitmentTreeRoot",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "nullifierAtIndex",
-    "inputs": [
-      {
-        "name": "index",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "nullifier",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "nullifierCount",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "count",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "owner",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "paused",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "proxiableUUID",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "renounceOwnership",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setKindTableCommitment",
-    "inputs": [
-      {
-        "name": "newKindTableCommitment",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "simulateExecute",
-    "inputs": [
-      {
-        "name": "transaction",
-        "type": "tuple",
-        "internalType": "struct Transaction",
-        "components": [
-          {
-            "name": "actions",
-            "type": "tuple[]",
-            "internalType": "struct Action[]",
-            "components": [
-              {
-                "name": "consumed",
-                "type": "tuple[]",
-                "internalType": "struct Consumed[]",
-                "components": [
-                  {
-                    "name": "nullifier",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "commitmentTreeRoot",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "created",
-                "type": "tuple[]",
-                "internalType": "struct Created[]",
-                "components": [
-                  {
-                    "name": "commitment",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "logicRef",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "appData",
-                    "type": "tuple",
-                    "internalType": "struct Logic.AppData",
-                    "components": [
-                      {
-                        "name": "resourcePayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "discoveryPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "externalPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "applicationPayload",
-                        "type": "tuple[]",
-                        "internalType": "struct Logic.ExpirableBlob[]",
-                        "components": [
-                          {
-                            "name": "deletionCriterion",
-                            "type": "uint8",
-                            "internalType": "enum Logic.DeletionCriterion"
-                          },
-                          {
-                            "name": "blob",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "name": "delta",
-                "type": "tuple",
-                "internalType": "struct Delta.Point",
-                "components": [
-                  {
-                    "name": "x",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "y",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  }
-                ]
-              },
-              {
-                "name": "actionTreeRoot",
-                "type": "bytes32",
-                "internalType": "bytes32"
-              }
-            ]
-          },
-          {
-            "name": "deltaProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          },
-          {
-            "name": "aggregationProof",
-            "type": "bytes",
-            "internalType": "bytes"
-          }
-        ]
-      },
-      {
-        "name": "skipRiscZeroProofVerification",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "transferOwnership",
-    "inputs": [
-      {
-        "name": "newOwner",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "upgradeToAndCall",
-    "inputs": [
-      {
-        "name": "newImplementation",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "data",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "payable"
-  },
-  {
-    "type": "event",
-    "name": "ActionExecuted",
-    "inputs": [
-      {
-        "name": "actionTreeRoot",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "nullifiers",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      },
-      {
-        "name": "consumedLogicRefs",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      },
-      {
-        "name": "commitments",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      },
-      {
-        "name": "createdLogicRefs",
-        "type": "bytes32[]",
-        "indexed": false,
-        "internalType": "bytes32[]"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ApplicationPayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "CommitmentTreeRootAdded",
-    "inputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "DiscoveryPayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ExternalPayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ForwarderCallExecuted",
-    "inputs": [
-      {
-        "name": "untrustedForwarder",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "input",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      },
-      {
-        "name": "output",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "Initialized",
-    "inputs": [
-      {
-        "name": "version",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "KindTableCommitmentUpdated",
-    "inputs": [
-      {
-        "name": "kindTableCommitment",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "OwnershipTransferred",
-    "inputs": [
-      {
-        "name": "previousOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "Paused",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ResourcePayload",
-    "inputs": [
-      {
-        "name": "tag",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "blob",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "TransactionExecuted",
-    "inputs": [
-      {
-        "name": "transactionId",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "Unpaused",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "Upgraded",
-    "inputs": [
-      {
-        "name": "implementation",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "error",
-    "name": "AddressEmptyCode",
-    "inputs": [
-      {
-        "name": "target",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "DeltaMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "actual",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignature",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureS",
-    "inputs": [
-      {
-        "name": "s",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC1967InvalidImplementation",
-    "inputs": [
-      {
-        "name": "implementation",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC1967NonPayable",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "EmptyTransactionNotAllowed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "EnforcedPause",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ExpectedPause",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "FailedCall",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ForwarderCallOutputMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "actual",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InvalidInitialization",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "NonExistingRoot",
-    "inputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "NotInitializing",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "OwnableInvalidOwner",
-    "inputs": [
-      {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "OwnableUnauthorizedAccount",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "PointNotOnCurve",
-    "inputs": [
-      {
-        "name": "point",
-        "type": "tuple",
-        "internalType": "struct Delta.Point",
-        "components": [
-          {
-            "name": "x",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "y",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "PreExistingNullifier",
-    "inputs": [
-      {
-        "name": "nullifier",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "PreExistingRoot",
-    "inputs": [
-      {
-        "name": "root",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ReentrancyGuardReentrantCall",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "RiscZeroVerifierSelectorMismatch",
-    "inputs": [
-      {
-        "name": "expected",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      },
-      {
-        "name": "actual",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "RiscZeroVerifierStopped",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "Simulated",
-    "inputs": [
-      {
-        "name": "gasUsed",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "UUPSUnauthorizedCallContext",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "UUPSUnsupportedProxiableUUID",
-    "inputs": [
-      {
-        "name": "slot",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ZeroKindTableCommitmentNotAllowed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ZeroRiscZeroVerifierRouterNotAllowed",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ZeroRiscZeroVerifierSelectorNotAllowed",
-    "inputs": []
-  }
-]
 ```*/
 #[allow(
     non_camel_case_types,
@@ -2698,33 +846,13 @@ interface ProtocolAdapter {
     clippy::style,
     clippy::empty_structs_with_brackets
 )]
-pub mod ProtocolAdapter {
+pub mod Types {
     use super::*;
     use alloy::sol_types as alloy_sol_types;
-    /// The creation / init bytecode of the contract.
-    ///
-    /// ```text
-    ///0x60e03461010e57601f6148d238819003918201601f19168301916001600160401b0383118484101761011257808492604094855283398101031261010e5780516001600160a01b0381169182820361010e5760200151916001600160e01b031983169081840361010e5730608052610075610126565b61007d610126565b156100ff57156100f05760a05260c052610095610126565b6040516146f590816101bd8239608051818181612747015261280b015260a051818181610e9501528181611b36015281816126c00152612dca015260c05181818161026001528181610d4901528181611af60152612d880152f35b63b1b25aaf60e01b5f5260045ffd5b63536c150160e11b5f5260045ffd5b5f80fd5b634e487b7160e01b5f52604160045260245ffd5b5f5160206148b25f395f51905f525460ff8160401c166101ad576002600160401b03196001600160401b0382160161015b5750565b6001600160401b0319166001600160401b039081175f5160206148b25f395f51905f52556040519081527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d290602090a1565b63f92ee8a960e01b5f5260045ffdfe60e0806040526004361015610012575f80fd5b5f60c0525f3560e01c9081630d8e6e2c14612ae95750806331ee624214612acb57806340f34d4214612a8f5780634f1ef286146127bf57806352d1902d1461272057806359ba9258146126e45780635b666b1e146126945780635c975abb1461265357806363a599a414612596578063715018a6146124da57806373ab99161461186757806387093eba14610a7c5780638da5cb5b14610a285780639ad91d4c14610977578063a06056f714610936578063ad3cb1cc146108d0578063bdeb442d14610846578063c0253023146107a7578063c1b0bed714610754578063c44956d114610716578063c4d66de8146102cd578063c879dbe414610284578063e33845cf14610226578063f2fde38b146101f7578063fddd4837146101d1578063fe18ab911461018d5763ffc33f7214610149575f80fd5b346101875760c0516003193601126101875760207f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054604051908152f35b60c05180fd5b346101875760c051600319360112610187576020600160ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b604051908152f35b346101875760c0516003193601126101875760206101ed612d3f565b6040519015158152f35b3461018757602060031936011261018757610220610213612b21565b61021b612f0e565b612c52565b60c05180f35b346101875760c0516003193601126101875760206040517fffffffff000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000168152f35b346101875760206003193601126101875760206101ed6004355f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b34610187576020600319360112610187576102e6612b21565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460ff8160401c16159167ffffffffffffffff82168015908161070e575b6001149081610704575b1590816106fb575b506106cf57818360017fffffffffffffffffffffffffffffffffffffffffffffffff000000000000000061039f9516177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005561067a575b5061039761327c565b61021b61327c565b6103a761327c565b6103af61327c565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90254680100000000000000008110156106495780600161043292017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b81549060031b905f197fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b06831b921b191617905560c0517f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055610492613de2565b507f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d260206040517fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b068152a16104e561327c565b7fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a2610579612d3f565b61061d576105875760c05180f35b7fffffffffffffffffffffffffffffffffffffffffffffff00ffffffffffffffff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054167ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00557fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2602060405160018152a1610220565b7f0b1d38a30000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526041600452602460c051fd5b7fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000001668010000000000000001177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00558361038e565b7ff92ee8a90000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b90501584610337565b303b15915061032f565b849150610325565b346101875760c0516003193601126101875760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054604051908152f35b346101875760206003193601126101875760c0515060043560c051527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc016020526020604060c05120541515604051908152f35b34610187576020600319360112610187576004356107c3612f0e565b801561081a57807f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a260c05180f35b7f774d5de10000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b346101875760c051600319360112610187577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903545f19810190811161089f576108906020916130eb565b90549060031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526011600452602460c051fd5b346101875760c0516003193601126101875760408051610932916108f49082612b8d565b600581527f352e302e300000000000000000000000000000000000000000000000000000006020820152604051918291602083526020830190612c20565b0390f35b346101875760c05160031936011261018757602060ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416604051908152f35b34610187576020600319360112610187577f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054600435908110156109f7576020907f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0060c051528160c051200160c051505460c05160031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526032600452602460c051fd5b346101875760c05160031936011261018757602073ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c1993005416604051908152f35b346101875760406003193601126101875767ffffffffffffffff6004351161018757606060031960043536030112610187576024358015158103610187575a6080527f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c61183b5760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610b10612f7a565b610b1e600480350180612fcd565b809291501561180f57610b3082613039565b610b38613156565b50604051610b4581612b44565b60c051815260c05160208201529260c05160a05260c0515b8181106112c9575050806020610ba5925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b3691612bcc565b856141a2565b909391936141dc565b602081519101519060c0515260205273ffffffffffffffffffffffffffffffffffffffff80604060c05120169116908082036112975750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054610c0d600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000610c6363ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152610caa606482612b8d565b60c051915b808310610f995750602080925060405191805191829101835e81019060c05182528060c05192039060025afa15610f5a5760c05151610cf860446004350160043560040161322b565b909281600411610187577fffffffff000000000000000000000000000000000000000000000000000000008435167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203610f6757505015610e7e575b50505060a051610e0b575b7f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610ddc5a608051612c45565b7f6f1498310000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b610e1660a051613d32565b15610e4c577f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d2602060405160a0518152a1610d83565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c0515260a051600452602460c051fd5b73ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b1561018757610ef96040519485937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b927f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e60248401526044830152818060c0519403915afa8015610f5a57610f41575b8080610d78565b60c051610f4d91612b8d565b60c0516101875781610f3a565b6040513d60c051823e3d90fd5b7f78a2221c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b90610fb283610fac600480350180612fcd565b9061306a565b610fbc8180612fcd565b919050610ff163ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b1660208201526004815261102e602482612b8d565b9160c051905b808210611213575050602081019160206110f36004826110548787612fcd565b95905061108963ffffffff871662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519683889451918291018686015e83019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b9260c051915b8083106111915750505060019260208093611188936111526060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e8401908382019060c0518252519283915e010160c051815203601f198101835282612b8d565b92019190610caf565b909193602061120a604060019383806111b48b6111ae8b8d612fcd565b906131b8565b6111c86111c38683018361316e565b6142b4565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e010160c051838201520301601f198101835282612b8d565b940191906110f9565b9092602061128f606060019383806112358a61122f8b80612fcd565b906131a1565b6112446111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e010160c051838201520301601f198101835282612b8d565b930190611034565b7fe6d44b4c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b6112db81610fac600480350180612fcd565b60c051909590866112ec8180612fcd565b90506112f781613039565b61130082613039565b9160c0515b81811061170d57505061131b6020840184612fcd565b92905061132783613039565b9161133184613039565b9360c051905b8082106114af575050926113ab7f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc32959361139d6113b99461138f608098604051998a990135895260a060208a015260a08901906131f8565b9087820360408901526131f8565b9085820360608701526131f8565b9083820360808501526131f8565b0390a1806114a6575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0873603011261018757604051906113fc82612b44565b6040870135825260208201606088013581526040519261141b84612b44565b5f84525f60208501526114318151835190613986565b1561146e578260019594926114539260206080965193015190519151926139e8565b6020830152815296013561146782866130d7565b5201610b5d565b604491604051917fb8a0e8a1000000000000000000000000000000000000000000000000000000008352516004830152516024820152fd5b60a052866113c2565b9192939495819750906111ae8260206114c9940190612fcd565b9560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154167f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900545f19811461089f57600181017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900559088359160c0515b82811061165257505090600192917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b146115f9575b50976020810135906115d66115cf604083016115c96115c3828661316e565b86613518565b8361316e565b8235613762565b356115e183896130d7565b526115ec82896130d7565b52018c9594939291611337565b61164761164061164c9261160c856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c05152602060c051200154809461415f565b928061415f565b61336c565b8f6115a4565b90926001908185166116d0576116c5907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c051528084602060c0512001557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c0515283602060c0512001549061415f565b935b811c9101611547565b611707907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c0515283602060c05120015461415f565b936116c7565b909192938161122f8261171f93612fcd565b6040810135611758815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b156117e057506117688135613c7d565b156117b0579081602060019301359061178e6115cf606083016115c96115c3828661316e565b3561179983876130d7565b526117a482876130d7565b5201908a939291611305565b7f39a940c50000000000000000000000000000000000000000000000000000000060c0515235600452602460c051fd5b7ff9849ea30000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b7fcf1b093c0000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f3ee5aeb50000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b34611cc4576020600319360112611cc45767ffffffffffffffff60043511611cc457606060031960043536030112611cc4577f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6124b25760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6118eb612f7a565b6118f9600480350180612fcd565b8091501561248a5761190a81613039565b90611913613156565b5060405161192081612b44565b5f81525f6020820152915f915f5b818110611f60575050806020611960925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b60208151910151905f5260205273ffffffffffffffffffffffffffffffffffffffff8060405f2016911690808203611f325750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700546119c4600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000611a1a63ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152611a61606482612b8d565b905f905b808210611cf65750505f60208092604051918183925191829101835e8101838152039060025afa15611cb9575f51611aa760446004350160043560040161322b565b80600411611cc4577fffffffff000000000000000000000000000000000000000000000000000000008235167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203611cc857505073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b15611cc4575f92611ba192604051958694859384937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b907f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e6024840152604483015203915afa8015611cb957611ca5575b5080611c37575b507f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d60c05180f35b611c4081613d32565b15611c765760207f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d291604051908152a181611be3565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b5f611caf91612b8d565b5f60c05282611bdc565b6040513d5f823e3d90fd5b5f80fd5b7f78a2221c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b9091611d0a83610fac600480350180612fcd565b611d148180612fcd565b919050611d4963ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b16602082015260048152611d86602482612b8d565b915f905b808210611eb657505060208101916020611daa6004826110548787612fcd565b925f915b808310611e415750505060019260208093611e3993611e076060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e840190838201905f8252519283915e01015f815203601f198101835282612b8d565b920190611a65565b9091936020611ead60406001938380611e5e8b6111ae8b8d612fcd565b611e6d6111c38683018361316e565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e01015f838201520301601f198101835282612b8d565b94019190611dae565b90926020611f2a60606001938380611ed28a61122f8b80612fcd565b611ee16111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e01015f838201520301601f198101835282612b8d565b930190611d8a565b7fe6d44b4c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b611f7281610fac600480350180612fcd565b5f95611f7e8280612fcd565b979050611f8a88613039565b611f9389613039565b985f5b818110612387575050611fac6020850185612fcd565b999050611fb88a613039565b99611fc281613039565b905f905b8082106120da575050906120217f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc3293926113ab61139d9d60808a01359e8f9561138f604051988998895260a060208a015260a08901906131f8565b0390a1806120d2575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc08336030112611cc4576040519161206483612b44565b6040810135835260606020840191013581526040519261208384612b44565b5f84525f60208501526120998151835190613986565b1561146e57916120b99160019594936020835193015190519151926139e8565b60208301528152956120cb82866130d7565b520161192e565b95508761202a565b9094506120ee856111ae60208a018a612fcd565b9460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416957f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054965f19881461235a57878f986001017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055908235915f5b8281106122765750509060019392917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b1461220f575b50976121fc836020840135936121f56115cf604083016115c96121ef828661316e565b89613518565b35926130d7565b5261220782866130d7565b520190611fc6565b61164761164061227092612222856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d431015493849061415f565b5f6121cc565b9092600190818516612303577fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f83018190557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d4318301546122f89161415f565b935b811c910161216e565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015f527fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f830154612354919061415f565b936122fa565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b6123958161122f8880612fcd565b60408101356123ce815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b1561245f575080356123df81613c7d565b15612434579061242d838e6001959461241d612417602087013596606081019061241261240c838361316e565b8a613518565b61316e565b82613762565b612427838a6130d7565b526130d7565b5201611f96565b7f39a940c5000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7ff9849ea3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7fcf1b093c000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b34611cc4575f600319360112611cc4576124f2612f0e565b5f73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300547fffffffffffffffffffffffff000000000000000000000000000000000000000081167f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08280a3005b34611cc4575f600319360112611cc4576125ae612f0e565b6125b6612f7a565b6125be612f7a565b60017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff007fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416177fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a2586020604051338152a1005b34611cc4575f600319360112611cc457602060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f0330054166040519015158152f35b34611cc4575f600319360112611cc457602060405173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000168152f35b34611cc4575f600319360112611cc45760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354604051908152f35b34611cc4575f600319360112611cc45773ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001630036127975760206040517f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8152f35b7fe07c8dba000000000000000000000000000000000000000000000000000000005f5260045ffd5b6040600319360112611cc4576127d3612b21565b60243567ffffffffffffffff8111611cc4576127f3903690600401612c02565b9073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803014908115612a4d575b5061279757612843612f0e565b73ffffffffffffffffffffffffffffffffffffffff8116916040517f52d1902d000000000000000000000000000000000000000000000000000000008152602081600481875afa5f9181612a19575b506128c357837f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b807f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8592036129ee5750823b156129c357807fffffffffffffffffffffffff00000000000000000000000000000000000000007f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416177f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc557fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f80a28051156129925761299091613411565b005b50503461299b57005b7fb398979f000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7faa1d49a4000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b9091506020813d602011612a45575b81612a3560209383612b8d565b81010312611cc457519085612892565b3d9150612a28565b905073ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416141583612836565b34611cc4575f600319360112611cc45760207f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054604051908152f35b34611cc4576020600319360112611cc45760206108906004356130eb565b34611cc4575f600319360112611cc457807f322e302e302d616c7068612e320000000000000000000000000000000000000060209252f35b6004359073ffffffffffffffffffffffffffffffffffffffff82168203611cc457565b6040810190811067ffffffffffffffff821117612b6057604052565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b90601f601f19910116810190811067ffffffffffffffff821117612b6057604052565b67ffffffffffffffff8111612b6057601f01601f191660200190565b929192612bd882612bb0565b91612be66040519384612b8d565b829481845281830111611cc4578281602093845f960137010152565b9080601f83011215611cc457816020612c1d93359101612bcc565b90565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b9190820391821161235a57565b73ffffffffffffffffffffffffffffffffffffffff168015612d135773ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054827fffffffffffffffffffffffff00000000000000000000000000000000000000008216177f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e05f80a3565b7f1e4fbdf7000000000000000000000000000000000000000000000000000000005f525f60045260245ffd5b6040517f3cadf4490000000000000000000000000000000000000000000000000000000081527fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016600482015260208160248173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000165afa908115611cb9575f91612ebe575b50602073ffffffffffffffffffffffffffffffffffffffff916004604051809481937f5c975abb000000000000000000000000000000000000000000000000000000008352165afa908115611cb9575f91612e83575b508015612e5a5790565b5060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300541690565b90506020813d602011612eb6575b81612e9e60209383612b8d565b81010312611cc457518015158103611cc4575f612e50565b3d9150612e91565b90506020813d602011612f06575b81612ed960209383612b8d565b81010312611cc4575173ffffffffffffffffffffffffffffffffffffffff81168103611cc4576020612dfa565b3d9150612ecc565b73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054163303612f4e57565b7f118cdaa7000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b60ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416612fa557565b7fd93c0665000000000000000000000000000000000000000000000000000000005f5260045ffd5b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918160051b36038313611cc457565b67ffffffffffffffff8111612b605760051b60200190565b9061304382613021565b6130506040519182612b8d565b828152601f196130608294613021565b0190602036910137565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6181360301821215611cc4570190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b80518210156130aa5760209160051b010190565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903548110156130aa577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9035f5260205f2001905f90565b80548210156130aa575f5260205f2001905f90565b6040519061316382612b44565b5f6020838281520152565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8181360301821215611cc4570190565b908210156130aa57612c1d9160051b81019061316e565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa181360301821215611cc4570190565b90602080835192838152019201905f5b8181106132155750505090565b8251845260209384019390920191600101613208565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918136038313611cc457565b60ff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460401c16156132ab57565b7fd7e6bcf8000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901613141565b5f19829392549160031b92831b921b1916179055565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b805468010000000000000000811015612b605761335691600182018155613141565b905f8091602081519101845af480806134c5575b156134455750506040513d81523d5f602083013e60203d82010160405290565b1561348c5773ffffffffffffffffffffffffffffffffffffffff907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b3d1561349d576040513d5f823e3d90fd5b7fd6bda275000000000000000000000000000000000000000000000000000000005f5260045ffd5b503d1515806134255750813b1515613425565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc181360301821215611cc4570190565b90604081016135278183612fcd565b9290505f5b83811061353a575050505050565b61355b6135518261354b8686612fcd565b906134d8565b602081019061322b565b8101606082820312611cc45781359173ffffffffffffffffffffffffffffffffffffffff8316809303611cc457602081013567ffffffffffffffff8111611cc457826135a8918301612c02565b91604082013567ffffffffffffffff8111611cc4576135c79201612c02565b90604051917f33a89203000000000000000000000000000000000000000000000000000000008352886004840152604060248401525f838061360c6044820186612c20565b038183885af1928315611cb9575f936136af575b50825160208401208151602083012003613674575060019392917fcddb327adb31fe5437df2a8c68301bb13a6baae432a804838caaf682506aadf19161366b60405192839283613f2d565b0390a20161352c565b90506136ab6040519283927fc504fada00000000000000000000000000000000000000000000000000000000845260048401613f2d565b0390fd5b9092503d805f833e6136c18183612b8d565b810190602081830312611cc45780519067ffffffffffffffff8211611cc4570181601f82011215611cc4578051906136f882612bb0565b926137066040519485612b8d565b82845260208383010111611cc457815f9260208093018386015e83010152915f613620565b601f8260209493601f1993818652868601375f8582860101520116010190565b604090612c1d94928152816020820152019161372b565b9061376d8180612fcd565b5f5b818110613917575050506137866020820182612fcd565b5f5b8181106138a85750505061379f6040820182612fcd565b5f5b818110613839575050508060606137b9920190612fcd565b90915f5b8281106137ca5750505050565b6137d58184866134d8565b35906002821015611cc45760018092146137f0575b016137bd565b827fa494dac4b7184843583f972e06783e2c3bb47f4f0137b8df52a860df07219f8c61382061355184888a6134d8565b90613831604051928392878461374b565b0390a26137ea565b6138448183856134d8565b35906002821015611cc457600180921461385f575b016137a1565b857f9c61b290f631097f56273cf4daf40df1ff9ccc33f101d464837da1f5ae18bd5961388f6135518487896134d8565b906138a0604051928392878461374b565b0390a2613859565b6138b38183856134d8565b35906002821015611cc45760018092146138ce575b01613788565b857f48243873b4752ddcb45e0d7b11c4c266583e5e099a0b798fdd9c1af7d49324f36138fe6135518487896134d8565b9061390f604051928392878461374b565b0390a26138c8565b6139228183856134d8565b35906002821015611cc457600180921461393d575b0161376f565b857f3a134d01c07803003c63301717ddc4612e6c47ae408eeea3222cded532d02ae661396d6135518487896134d8565b9061397e604051928392878461374b565b0390a2613937565b801580156139d8575b80156139d0575b80156139c0575b6139ba576401000003d01960078180938181800909089180091490565b50505f90565b506401000003d01982101561399d565b508115613996565b506401000003d01981101561398f565b90939290915f90808403613c615750506401000003d0195f918508613a1157505090505f905f90565b6401000003d0198060018180613a78818080613a689a81808f800996879281808080808f81818192099987096004099780095f09928009600309089181613a5b8183800882612c45565b81858009089d8e83612c45565b9008900993800960080983612c45565b900896096002099391905b8415158581613c50575b5080613c48575b15613bea5780946001906401000003d019918184925b613afe575050505080613ad15750906401000003d019809281808780098092099509900990565b807f4e487b7100000000000000000000000000000000000000000000000000000000602492526012600452fd5b929791928015613bbd57808904918094613b90576401000003d0199083096401000003d019036401000003d019811161235a576401000003d0199086940893988192828102928184041490151715613b635790613b5a91612c45565b90929080613aaa565b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526011600452fd5b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526012600452fd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f496e76616c6964206e756d6265720000000000000000000000000000000000006044820152fd5b506001613a94565b6401000003d019915014155f613a8d565b6401000003d019929195613c7494613f52565b93909190613a83565b805f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2054155f14613d2d57613cda817f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc006133ef565b7f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054905f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2055600190565b505f90565b805f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054155f14613d2d57613d8f817f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354905f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2055600190565b7fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e54613f2957613e997fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b067f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903547fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e55600190565b5f90565b9091613f44612c1d93604084526040840190612c20565b916020818403910152612c20565b9492909391851580614157575b61414c57801580614144575b61413c57604051608091613f7f8383612b8d565b823683378415613bbd5784600180098083529385856001099860208401998a52604084019286845287845160010993606086019485526040519a878c01958c871067ffffffffffffffff881117612b60578a80979581969482956040525190098d525190099460208b019586525190099860408901998a52519009606087019081528651885114801590614130575b156140d257849283808093816040519c8561402a8f9788612b8d565b368737518c5161403a9083612c45565b9008845251855161404b9083612c45565b90089860208301998a5281808b8180808089518a5190099360408a019485528185518b5190096060909a01998a5251800988516140889083612c45565b9008818087518551900960020961409f9083612c45565b90089c519351905190096140b38c83612c45565b900890099251905190096140c79083612c45565b900894510991929190565b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f557365206a6163446f75626c652066756e6374696f6e20696e737465616400006044820152fd5b5081518151141561400e565b505050600190565b508115613f6b565b945092506001919050565b508415613f5f565b5f9060209260405190848201928352604082015260408152614182606082612b8d565b604051918291518091835e8101838152039060025afa15611cb9575f5190565b81519190604183036141d2576141cb9250602082015190606060408401519301515f1a90614516565b9192909190565b50505f9160029190565b600481101561428757806141ee575050565b6001810361421e577ff645eedf000000000000000000000000000000000000000000000000000000005f5260045ffd5b6002810361425257507ffce698f7000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b60031461425c5750565b7fd78bce0c000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b6142be8180612fcd565b63ffffffff9150166142f29062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b6142fc8280612fcd565b614305916145a5565b9160208101906143158282612fcd565b63ffffffff9150166143499062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b916143549082612fcd565b61435d916145a5565b6040820161436b8184612fcd565b63ffffffff91501661439f9062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b906143aa9084612fcd565b6143b3916145a5565b9160608401936143c38582612fcd565b63ffffffff9150166143f79062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b9461440191612fcd565b61440a916145a5565b9460405197889760e01b7fffffffff000000000000000000000000000000000000000000000000000000001660208901528051602081920160248a015e87019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016602482015281516020819301602883015e016024019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e016004019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e01600401600481015f905203600401601f1981018252612c1d9082612b8d565b91907f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0841161459a579160209360809260ff5f9560405194855216868401526040830152606082015282805260015afa15611cb9575f5173ffffffffffffffffffffffffffffffffffffffff81161561459057905f905f90565b505f906001905f90565b5050505f9160039190565b606092915f915b8183106145b857505050565b9091936145ff63ffffffff6145d16135518887876134d8565b905060021c1662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b61460d6135518786866134d8565b61461b8887879594956134d8565b35906002821015611cc4576001946020947fffffffff0000000000000000000000000000000000000000000000000000000086846146df9760049796614684899862ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b95856040519c898e9a5191829101888c015e89019360e01b1685840152602483013701019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b940191906145ac56fea164736f6c6343000824000af0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00
-    /// ```
-    #[rustfmt::skip]
-    #[allow(clippy::all)]
-    pub static BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
-        b"`\xE04a\x01\x0EW`\x1FaH\xD28\x81\x90\x03\x91\x82\x01`\x1F\x19\x16\x83\x01\x91`\x01`\x01`@\x1B\x03\x83\x11\x84\x84\x10\x17a\x01\x12W\x80\x84\x92`@\x94\x85R\x839\x81\x01\x03\x12a\x01\x0EW\x80Q`\x01`\x01`\xA0\x1B\x03\x81\x16\x91\x82\x82\x03a\x01\x0EW` \x01Q\x91`\x01`\x01`\xE0\x1B\x03\x19\x83\x16\x90\x81\x84\x03a\x01\x0EW0`\x80Ra\0ua\x01&V[a\0}a\x01&V[\x15a\0\xFFW\x15a\0\xF0W`\xA0R`\xC0Ra\0\x95a\x01&V[`@QaF\xF5\x90\x81a\x01\xBD\x829`\x80Q\x81\x81\x81a'G\x01Ra(\x0B\x01R`\xA0Q\x81\x81\x81a\x0E\x95\x01R\x81\x81a\x1B6\x01R\x81\x81a&\xC0\x01Ra-\xCA\x01R`\xC0Q\x81\x81\x81a\x02`\x01R\x81\x81a\rI\x01R\x81\x81a\x1A\xF6\x01Ra-\x88\x01R\xF3[c\xB1\xB2Z\xAF`\xE0\x1B_R`\x04_\xFD[cSl\x15\x01`\xE1\x1B_R`\x04_\xFD[_\x80\xFD[cNH{q`\xE0\x1B_R`A`\x04R`$_\xFD[_Q` aH\xB2_9_Q\x90_RT`\xFF\x81`@\x1C\x16a\x01\xADW`\x02`\x01`@\x1B\x03\x19`\x01`\x01`@\x1B\x03\x82\x16\x01a\x01[WPV[`\x01`\x01`@\x1B\x03\x19\x16`\x01`\x01`@\x1B\x03\x90\x81\x17_Q` aH\xB2_9_Q\x90_RU`@Q\x90\x81R\x7F\xC7\xF5\x05\xB2\xF3q\xAE!u\xEEI\x13\xF4I\x9E\x1F&3\xA7\xB5\x93c!\xEE\xD1\xCD\xAE\xB6\x11Q\x81\xD2\x90` \x90\xA1V[c\xF9.\xE8\xA9`\xE0\x1B_R`\x04_\xFD\xFE`\xE0\x80`@R`\x046\x10\x15a\0\x12W_\x80\xFD[_`\xC0R_5`\xE0\x1C\x90\x81c\r\x8En,\x14a*\xE9WP\x80c1\xEEbB\x14a*\xCBW\x80c@\xF3MB\x14a*\x8FW\x80cO\x1E\xF2\x86\x14a'\xBFW\x80cR\xD1\x90-\x14a' W\x80cY\xBA\x92X\x14a&\xE4W\x80c[fk\x1E\x14a&\x94W\x80c\\\x97Z\xBB\x14a&SW\x80cc\xA5\x99\xA4\x14a%\x96W\x80cqP\x18\xA6\x14a$\xDAW\x80cs\xAB\x99\x16\x14a\x18gW\x80c\x87\t>\xBA\x14a\n|W\x80c\x8D\xA5\xCB[\x14a\n(W\x80c\x9A\xD9\x1DL\x14a\twW\x80c\xA0`V\xF7\x14a\t6W\x80c\xAD<\xB1\xCC\x14a\x08\xD0W\x80c\xBD\xEBD-\x14a\x08FW\x80c\xC0%0#\x14a\x07\xA7W\x80c\xC1\xB0\xBE\xD7\x14a\x07TW\x80c\xC4IV\xD1\x14a\x07\x16W\x80c\xC4\xD6m\xE8\x14a\x02\xCDW\x80c\xC8y\xDB\xE4\x14a\x02\x84W\x80c\xE38E\xCF\x14a\x02&W\x80c\xF2\xFD\xE3\x8B\x14a\x01\xF7W\x80c\xFD\xDDH7\x14a\x01\xD1W\x80c\xFE\x18\xAB\x91\x14a\x01\x8DWc\xFF\xC3?r\x14a\x01IW_\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0T`@Q\x90\x81R\xF3[`\xC0Q\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\x01`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B`@Q\x90\x81R\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` a\x01\xEDa-?V[`@Q\x90\x15\x15\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02 a\x02\x13a+!V[a\x02\x1Ba/\x0EV[a,RV[`\xC0Q\x80\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `@Q\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W` a\x01\xED`\x045_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02\xE6a+!V[\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`\xFF\x81`@\x1C\x16\x15\x91g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x80\x15\x90\x81a\x07\x0EW[`\x01\x14\x90\x81a\x07\x04W[\x15\x90\x81a\x06\xFBW[Pa\x06\xCFW\x81\x83`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0a\x03\x9F\x95\x16\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0Ua\x06zW[Pa\x03\x97a2|V[a\x02\x1Ba2|V[a\x03\xA7a2|V[a\x03\xAFa2|V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a\x06IW\x80`\x01a\x042\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x81T\x90`\x03\x1B\x90_\x19\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x83\x1B\x92\x1B\x19\x16\x17\x90U`\xC0Q\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0Ua\x04\x92a=\xE2V[P\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x81R\xA1a\x04\xE5a2|V[\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2a\x05ya-?V[a\x06\x1DWa\x05\x87W`\xC0Q\x80\xF3[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T\x16\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x7F\xC7\xF5\x05\xB2\xF3q\xAE!u\xEEI\x13\xF4I\x9E\x1F&3\xA7\xB5\x93c!\xEE\xD1\xCD\xAE\xB6\x11Q\x81\xD2` `@Q`\x01\x81R\xA1a\x02 V[\x7F\x0B\x1D8\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`A`\x04R`$`\xC0Q\xFD[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\x16h\x01\0\0\0\0\0\0\0\x01\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x83a\x03\x8EV[\x7F\xF9.\xE8\xA9\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x90P\x15\x84a\x037V[0;\x15\x91Pa\x03/V[\x84\x91Pa\x03%V[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\xC0QP`\x045`\xC0QR\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R` `@`\xC0Q T\x15\x15`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\x045a\x07\xC3a/\x0EV[\x80\x15a\x08\x1AW\x80\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2`\xC0Q\x80\xF3[\x7FwM]\xE1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T_\x19\x81\x01\x90\x81\x11a\x08\x9FWa\x08\x90` \x91a0\xEBV[\x90T\x90`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x11`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W`@\x80Qa\t2\x91a\x08\xF4\x90\x82a+\x8DV[`\x05\x81R\x7F5.0.0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x82\x01R`@Q\x91\x82\x91` \x83R` \x83\x01\x90a, V[\x03\x90\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`\x045\x90\x81\x10\x15a\t\xF7W` \x90\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0`\xC0QR\x81`\xC0Q \x01`\xC0QPT`\xC0Q`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`2`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x16`@Q\x90\x81R\xF3[4a\x01\x87W`@`\x03\x196\x01\x12a\x01\x87Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x01\x87W```\x03\x19`\x0456\x03\x01\x12a\x01\x87W`$5\x80\x15\x15\x81\x03a\x01\x87WZ`\x80R\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a\x18;W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x0B\x10a/zV[a\x0B\x1E`\x04\x805\x01\x80a/\xCDV[\x80\x92\x91P\x15a\x18\x0FWa\x0B0\x82a09V[a\x0B8a1VV[P`@Qa\x0BE\x81a+DV[`\xC0Q\x81R`\xC0Q` \x82\x01R\x92`\xC0Q`\xA0R`\xC0Q[\x81\x81\x10a\x12\xC9WPP\x80` a\x0B\xA5\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[6\x91a+\xCCV[\x85aA\xA2V[\x90\x93\x91\x93aA\xDCV[` \x81Q\x91\x01Q\x90`\xC0QR` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@`\xC0Q \x16\x91\x16\x90\x80\x82\x03a\x12\x97WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x0C\r`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x0Ccc\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x0C\xAA`d\x82a+\x8DV[`\xC0Q\x91[\x80\x83\x10a\x0F\x99WP` \x80\x92P`@Q\x91\x80Q\x91\x82\x91\x01\x83^\x81\x01\x90`\xC0Q\x82R\x80`\xC0Q\x92\x03\x90`\x02Z\xFA\x15a\x0FZW`\xC0QQa\x0C\xF8`D`\x045\x01`\x045`\x04\x01a2+V[\x90\x92\x81`\x04\x11a\x01\x87W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x845\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x0FgWPP\x15a\x0E~W[PPP`\xA0Qa\x0E\x0BW[\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\r\xDCZ`\x80Qa,EV[\x7Fo\x14\x981\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[a\x0E\x16`\xA0Qa=2V[\x15a\x0ELW\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q`\xA0Q\x81R\xA1a\r\x83V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\xA0Q`\x04R`$`\xC0Q\xFD[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x01\x87Wa\x0E\xF9`@Q\x94\x85\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x92\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x81\x80`\xC0Q\x94\x03\x91Z\xFA\x80\x15a\x0FZWa\x0FAW[\x80\x80a\rxV[`\xC0Qa\x0FM\x91a+\x8DV[`\xC0Qa\x01\x87W\x81a\x0F:V[`@Q=`\xC0Q\x82>=\x90\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[\x90a\x0F\xB2\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[\x90a0jV[a\x0F\xBC\x81\x80a/\xCDV[\x91\x90Pa\x0F\xF1c\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x10.`$\x82a+\x8DV[\x91`\xC0Q\x90[\x80\x82\x10a\x12\x13WPP` \x81\x01\x91` a\x10\xF3`\x04\x82a\x10T\x87\x87a/\xCDV[\x95\x90Pa\x10\x89c\xFF\xFF\xFF\xFF\x87\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x96\x83\x88\x94Q\x91\x82\x91\x01\x86\x86\x01^\x83\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x92`\xC0Q\x91[\x80\x83\x10a\x11\x91WPPP`\x01\x92` \x80\x93a\x11\x88\x93a\x11R``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90`\xC0Q\x82RQ\x92\x83\x91^\x01\x01`\xC0Q\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x91\x90a\x0C\xAFV[\x90\x91\x93` a\x12\n`@`\x01\x93\x83\x80a\x11\xB4\x8Ba\x11\xAE\x8B\x8Da/\xCDV[\x90a1\xB8V[a\x11\xC8a\x11\xC3\x86\x83\x01\x83a1nV[aB\xB4V[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x10\xF9V[\x90\x92` a\x12\x8F```\x01\x93\x83\x80a\x125\x8Aa\x12/\x8B\x80a/\xCDV[\x90a1\xA1V[a\x12Da\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x104V[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[a\x12\xDB\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[`\xC0Q\x90\x95\x90\x86a\x12\xEC\x81\x80a/\xCDV[\x90Pa\x12\xF7\x81a09V[a\x13\0\x82a09V[\x91`\xC0Q[\x81\x81\x10a\x17\rWPPa\x13\x1B` \x84\x01\x84a/\xCDV[\x92\x90Pa\x13'\x83a09V[\x91a\x131\x84a09V[\x93`\xC0Q\x90[\x80\x82\x10a\x14\xAFWPP\x92a\x13\xAB\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x95\x93a\x13\x9Da\x13\xB9\x94a\x13\x8F`\x80\x98`@Q\x99\x8A\x99\x015\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x90\x87\x82\x03`@\x89\x01Ra1\xF8V[\x90\x85\x82\x03``\x87\x01Ra1\xF8V[\x90\x83\x82\x03`\x80\x85\x01Ra1\xF8V[\x03\x90\xA1\x80a\x14\xA6W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x876\x03\x01\x12a\x01\x87W`@Q\x90a\x13\xFC\x82a+DV[`@\x87\x015\x82R` \x82\x01``\x88\x015\x81R`@Q\x92a\x14\x1B\x84a+DV[_\x84R_` \x85\x01Ra\x141\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x82`\x01\x95\x94\x92a\x14S\x92` `\x80\x96Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x96\x015a\x14g\x82\x86a0\xD7V[R\x01a\x0B]V[`D\x91`@Q\x91\x7F\xB8\xA0\xE8\xA1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83RQ`\x04\x83\x01RQ`$\x82\x01R\xFD[`\xA0R\x86a\x13\xC2V[\x91\x92\x93\x94\x95\x81\x97P\x90a\x11\xAE\x82` a\x14\xC9\x94\x01\x90a/\xCDV[\x95`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T_\x19\x81\x14a\x08\x9FW`\x01\x81\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x885\x91`\xC0Q[\x82\x81\x10a\x16RWPP\x90`\x01\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x84`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\x15\xF9W[P\x97` \x81\x015\x90a\x15\xD6a\x15\xCF`@\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[\x86a5\x18V[\x83a1nV[\x825a7bV[5a\x15\xE1\x83\x89a0\xD7V[Ra\x15\xEC\x82\x89a0\xD7V[R\x01\x8C\x95\x94\x93\x92\x91a\x137V[a\x16Ga\x16@a\x16L\x92a\x16\x0C\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR` `\xC0Q \x01T\x80\x94aA_V[\x92\x80aA_V[a3lV[\x8Fa\x15\xA4V[\x90\x92`\x01\x90\x81\x85\x16a\x16\xD0Wa\x16\xC5\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x80\x84` `\xC0Q \x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR\x83` `\xC0Q \x01T\x90aA_V[\x93[\x81\x1C\x91\x01a\x15GV[a\x17\x07\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x83` `\xC0Q \x01TaA_V[\x93a\x16\xC7V[\x90\x91\x92\x93\x81a\x12/\x82a\x17\x1F\x93a/\xCDV[`@\x81\x015a\x17X\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a\x17\xE0WPa\x17h\x815a<}V[\x15a\x17\xB0W\x90\x81` `\x01\x93\x015\x90a\x17\x8Ea\x15\xCF``\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[5a\x17\x99\x83\x87a0\xD7V[Ra\x17\xA4\x82\x87a0\xD7V[R\x01\x90\x8A\x93\x92\x91a\x13\x05V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR5`\x04R`$`\xC0Q\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x1C\xC4W```\x03\x19`\x0456\x03\x01\x12a\x1C\xC4W\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a$\xB2W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x18\xEBa/zV[a\x18\xF9`\x04\x805\x01\x80a/\xCDV[\x80\x91P\x15a$\x8AWa\x19\n\x81a09V[\x90a\x19\x13a1VV[P`@Qa\x19 \x81a+DV[_\x81R_` \x82\x01R\x91_\x91_[\x81\x81\x10a\x1F`WPP\x80` a\x19`\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[` \x81Q\x91\x01Q\x90_R` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@_ \x16\x91\x16\x90\x80\x82\x03a\x1F2WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x19\xC4`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x1A\x1Ac\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x1Aa`d\x82a+\x8DV[\x90_\x90[\x80\x82\x10a\x1C\xF6WPP_` \x80\x92`@Q\x91\x81\x83\x92Q\x91\x82\x91\x01\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Qa\x1A\xA7`D`\x045\x01`\x045`\x04\x01a2+V[\x80`\x04\x11a\x1C\xC4W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x825\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x1C\xC8WPPs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x1C\xC4W_\x92a\x1B\xA1\x92`@Q\x95\x86\x94\x85\x93\x84\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x90\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x03\x91Z\xFA\x80\x15a\x1C\xB9Wa\x1C\xA5W[P\x80a\x1C7W[P\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]`\xC0Q\x80\xF3[a\x1C@\x81a=2V[\x15a\x1CvW` \x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2\x91`@Q\x90\x81R\xA1\x81a\x1B\xE3V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[_a\x1C\xAF\x91a+\x8DV[_`\xC0R\x82a\x1B\xDCV[`@Q=_\x82>=\x90\xFD[_\x80\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[\x90\x91a\x1D\n\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[a\x1D\x14\x81\x80a/\xCDV[\x91\x90Pa\x1DIc\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x1D\x86`$\x82a+\x8DV[\x91_\x90[\x80\x82\x10a\x1E\xB6WPP` \x81\x01\x91` a\x1D\xAA`\x04\x82a\x10T\x87\x87a/\xCDV[\x92_\x91[\x80\x83\x10a\x1EAWPPP`\x01\x92` \x80\x93a\x1E9\x93a\x1E\x07``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90_\x82RQ\x92\x83\x91^\x01\x01_\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x90a\x1AeV[\x90\x91\x93` a\x1E\xAD`@`\x01\x93\x83\x80a\x1E^\x8Ba\x11\xAE\x8B\x8Da/\xCDV[a\x1Ema\x11\xC3\x86\x83\x01\x83a1nV[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x1D\xAEV[\x90\x92` a\x1F*```\x01\x93\x83\x80a\x1E\xD2\x8Aa\x12/\x8B\x80a/\xCDV[a\x1E\xE1a\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x1D\x8AV[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[a\x1Fr\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[_\x95a\x1F~\x82\x80a/\xCDV[\x97\x90Pa\x1F\x8A\x88a09V[a\x1F\x93\x89a09V[\x98_[\x81\x81\x10a#\x87WPPa\x1F\xAC` \x85\x01\x85a/\xCDV[\x99\x90Pa\x1F\xB8\x8Aa09V[\x99a\x1F\xC2\x81a09V[\x90_\x90[\x80\x82\x10a \xDAWPP\x90a !\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x93\x92a\x13\xABa\x13\x9D\x9D`\x80\x8A\x015\x9E\x8F\x95a\x13\x8F`@Q\x98\x89\x98\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x03\x90\xA1\x80a \xD2W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x836\x03\x01\x12a\x1C\xC4W`@Q\x91a d\x83a+DV[`@\x81\x015\x83R``` \x84\x01\x91\x015\x81R`@Q\x92a \x83\x84a+DV[_\x84R_` \x85\x01Ra \x99\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x91a \xB9\x91`\x01\x95\x94\x93` \x83Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x95a \xCB\x82\x86a0\xD7V[R\x01a\x19.V[\x95P\x87a *V[\x90\x94Pa \xEE\x85a\x11\xAE` \x8A\x01\x8Aa/\xCDV[\x94`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x95\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x96_\x19\x88\x14a#ZW\x87\x8F\x98`\x01\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x825\x91_[\x82\x81\x10a\"vWPP\x90`\x01\x93\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x85`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\"\x0FW[P\x97a!\xFC\x83` \x84\x015\x93a!\xF5a\x15\xCF`@\x83\x01a\x15\xC9a!\xEF\x82\x86a1nV[\x89a5\x18V[5\x92a0\xD7V[Ra\"\x07\x82\x86a0\xD7V[R\x01\x90a\x1F\xC6V[a\x16Ga\x16@a\"p\x92a\"\"\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x01T\x93\x84\x90aA_V[_a!\xCCV[\x90\x92`\x01\x90\x81\x85\x16a#\x03W\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01\x81\x90U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x83\x01Ta\"\xF8\x91aA_V[\x93[\x81\x1C\x91\x01a!nV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01_R\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01Ta#T\x91\x90aA_V[\x93a\"\xFAV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x11`\x04R`$_\xFD[a#\x95\x81a\x12/\x88\x80a/\xCDV[`@\x81\x015a#\xCE\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a$_WP\x805a#\xDF\x81a<}V[\x15a$4W\x90a$-\x83\x8E`\x01\x95\x94a$\x1Da$\x17` \x87\x015\x96``\x81\x01\x90a$\x12a$\x0C\x83\x83a1nV[\x8Aa5\x18V[a1nV[\x82a7bV[a$'\x83\x8Aa0\xD7V[Ra0\xD7V[R\x01a\x1F\x96V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa$\xF2a/\x0EV[_s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81\x16\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0\x82\x80\xA3\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa%\xAEa/\x0EV[a%\xB6a/zV[a%\xBEa/zV[`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x17\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0U\x7Fb\xE7\x8C\xEA\x01\xBE\xE3 \xCDNB\x02p\xB5\xEAt\0\r\x11\xB0\xC9\xF7GT\xEB\xDB\xFCTK\x05\xA2X` `@Q3\x81R\xA1\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16`@Q\x90\x15\x15\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `@Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T`@Q\x90\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x160\x03a'\x97W` `@Q\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x81R\xF3[\x7F\xE0|\x8D\xBA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`@`\x03\x196\x01\x12a\x1C\xC4Wa'\xD3a+!V[`$5g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa'\xF3\x906\x90`\x04\x01a,\x02V[\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x800\x14\x90\x81\x15a*MW[Pa'\x97Wa(Ca/\x0EV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x91`@Q\x7FR\xD1\x90-\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` \x81`\x04\x81\x87Z\xFA_\x91\x81a*\x19W[Pa(\xC3W\x83\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x80\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x85\x92\x03a)\xEEWP\x82;\x15a)\xC3W\x80\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x17\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCU\x7F\xBC|\xD7Z \xEE'\xFD\x9A\xDE\xBA\xB3 A\xF7U!M\xBCk\xFF\xA9\x0C\xC0\"[9\xDA.\\-;_\x80\xA2\x80Q\x15a)\x92Wa)\x90\x91a4\x11V[\0[PP4a)\x9BW\0[\x7F\xB3\x98\x97\x9F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xAA\x1DI\xA4\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x90\x91P` \x81=` \x11a*EW[\x81a*5` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x90\x85a(\x92V[=\x91Pa*(V[\x90Ps\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x14\x15\x83a(6V[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`@Q\x90\x81R\xF3[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4W` a\x08\x90`\x045a0\xEBV[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W\x80\x7F2.0.0-alpha.2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x92R\xF3[`\x045\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x82\x03a\x1C\xC4WV[`@\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`A`\x04R`$_\xFD[\x90`\x1F`\x1F\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x1F\x01`\x1F\x19\x16` \x01\x90V[\x92\x91\x92a+\xD8\x82a+\xB0V[\x91a+\xE6`@Q\x93\x84a+\x8DV[\x82\x94\x81\x84R\x81\x83\x01\x11a\x1C\xC4W\x82\x81` \x93\x84_\x96\x017\x01\x01RV[\x90\x80`\x1F\x83\x01\x12\x15a\x1C\xC4W\x81` a,\x1D\x935\x91\x01a+\xCCV[\x90V[\x90`\x1F\x19`\x1F` \x80\x94\x80Q\x91\x82\x91\x82\x87R\x01\x86\x86\x01^_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[\x91\x90\x82\x03\x91\x82\x11a#ZWV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x16\x80\x15a-\x13Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x82\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x82\x16\x17\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0_\x80\xA3V[\x7F\x1EO\xBD\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R_`\x04R`$_\xFD[`@Q\x7F<\xAD\xF4I\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R` \x81`$\x81s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\xBEW[P` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x91`\x04`@Q\x80\x94\x81\x93\x7F\\\x97Z\xBB\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\x83W[P\x80\x15a.ZW\x90V[P`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x90V[\x90P` \x81=` \x11a.\xB6W[\x81a.\x9E` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x80\x15\x15\x81\x03a\x1C\xC4W_a.PV[=\x91Pa.\x91V[\x90P` \x81=` \x11a/\x06W[\x81a.\xD9` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x81\x03a\x1C\xC4W` a-\xFAV[=\x91Pa.\xCCV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x163\x03a/NWV[\x7F\x11\x8C\xDA\xA7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R3`\x04R`$_\xFD[`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16a/\xA5WV[\x7F\xD9<\x06e\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x81`\x05\x1B6\x03\x83\x13a\x1C\xC4WV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x05\x1B` \x01\x90V[\x90a0C\x82a0!V[a0P`@Q\x91\x82a+\x8DV[\x82\x81R`\x1F\x19a0`\x82\x94a0!V[\x01\x90` 6\x91\x017V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFFa\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`2`\x04R`$_\xFD[\x80Q\x82\x10\x15a0\xAAW` \x91`\x05\x1B\x01\x01\x90V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x81\x10\x15a0\xAAW\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03_R` _ \x01\x90_\x90V[\x80T\x82\x10\x15a0\xAAW_R` _ \x01\x90_\x90V[`@Q\x90a1c\x82a+DV[_` \x83\x82\x81R\x01RV[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90\x82\x10\x15a0\xAAWa,\x1D\x91`\x05\x1B\x81\x01\x90a1nV[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xA1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90` \x80\x83Q\x92\x83\x81R\x01\x92\x01\x90_[\x81\x81\x10a2\x15WPPP\x90V[\x82Q\x84R` \x93\x84\x01\x93\x90\x92\x01\x91`\x01\x01a2\x08V[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x816\x03\x83\x13a\x1C\xC4WV[`\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`@\x1C\x16\x15a2\xABWV[\x7F\xD7\xE6\xBC\xF8\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01a1AV[_\x19\x82\x93\x92T\x91`\x03\x1B\x92\x83\x1B\x92\x1B\x19\x16\x17\x90UV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x80Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`Wa3V\x91`\x01\x82\x01\x81Ua1AV[\x90_\x80\x91` \x81Q\x91\x01\x84Z\xF4\x80\x80a4\xC5W[\x15a4EWPP`@Q=\x81R=_` \x83\x01>` =\x82\x01\x01`@R\x90V[\x15a4\x8CWs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x90\x7F\x99\x96\xB3\x15\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R\x16`\x04R`$_\xFD[=\x15a4\x9DW`@Q=_\x82>=\x90\xFD[\x7F\xD6\xBD\xA2u\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[P=\x15\x15\x80a4%WP\x81;\x15\x15a4%V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90`@\x81\x01a5'\x81\x83a/\xCDV[\x92\x90P_[\x83\x81\x10a5:WPPPPPV[a5[a5Q\x82a5K\x86\x86a/\xCDV[\x90a4\xD8V[` \x81\x01\x90a2+V[\x81\x01``\x82\x82\x03\x12a\x1C\xC4W\x815\x91s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x16\x80\x93\x03a\x1C\xC4W` \x81\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4W\x82a5\xA8\x91\x83\x01a,\x02V[\x91`@\x82\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa5\xC7\x92\x01a,\x02V[\x90`@Q\x91\x7F3\xA8\x92\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x88`\x04\x84\x01R`@`$\x84\x01R_\x83\x80a6\x0C`D\x82\x01\x86a, V[\x03\x81\x83\x88Z\xF1\x92\x83\x15a\x1C\xB9W_\x93a6\xAFW[P\x82Q` \x84\x01 \x81Q` \x83\x01 \x03a6tWP`\x01\x93\x92\x91\x7F\xCD\xDB2z\xDB1\xFET7\xDF*\x8Ch0\x1B\xB1:k\xAA\xE42\xA8\x04\x83\x8C\xAA\xF6\x82Pj\xAD\xF1\x91a6k`@Q\x92\x83\x92\x83a?-V[\x03\x90\xA2\x01a5,V[\x90Pa6\xAB`@Q\x92\x83\x92\x7F\xC5\x04\xFA\xDA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84R`\x04\x84\x01a?-V[\x03\x90\xFD[\x90\x92P=\x80_\x83>a6\xC1\x81\x83a+\x8DV[\x81\x01\x90` \x81\x83\x03\x12a\x1C\xC4W\x80Q\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W\x01\x81`\x1F\x82\x01\x12\x15a\x1C\xC4W\x80Q\x90a6\xF8\x82a+\xB0V[\x92a7\x06`@Q\x94\x85a+\x8DV[\x82\x84R` \x83\x83\x01\x01\x11a\x1C\xC4W\x81_\x92` \x80\x93\x01\x83\x86\x01^\x83\x01\x01R\x91_a6 V[`\x1F\x82` \x94\x93`\x1F\x19\x93\x81\x86R\x86\x86\x017_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[`@\x90a,\x1D\x94\x92\x81R\x81` \x82\x01R\x01\x91a7+V[\x90a7m\x81\x80a/\xCDV[_[\x81\x81\x10a9\x17WPPPa7\x86` \x82\x01\x82a/\xCDV[_[\x81\x81\x10a8\xA8WPPPa7\x9F`@\x82\x01\x82a/\xCDV[_[\x81\x81\x10a89WPPP\x80``a7\xB9\x92\x01\x90a/\xCDV[\x90\x91_[\x82\x81\x10a7\xCAWPPPPV[a7\xD5\x81\x84\x86a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a7\xF0W[\x01a7\xBDV[\x82\x7F\xA4\x94\xDA\xC4\xB7\x18HCX?\x97.\x06x>,;\xB4\x7FO\x017\xB8\xDFR\xA8`\xDF\x07!\x9F\x8Ca8 a5Q\x84\x88\x8Aa4\xD8V[\x90a81`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a7\xEAV[a8D\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8_W[\x01a7\xA1V[\x85\x7F\x9Ca\xB2\x90\xF61\t\x7FV'<\xF4\xDA\xF4\r\xF1\xFF\x9C\xCC3\xF1\x01\xD4d\x83}\xA1\xF5\xAE\x18\xBDYa8\x8Fa5Q\x84\x87\x89a4\xD8V[\x90a8\xA0`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8YV[a8\xB3\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8\xCEW[\x01a7\x88V[\x85\x7FH$8s\xB4u-\xDC\xB4^\r{\x11\xC4\xC2fX>^\t\x9A\x0By\x8F\xDD\x9C\x1A\xF7\xD4\x93$\xF3a8\xFEa5Q\x84\x87\x89a4\xD8V[\x90a9\x0F`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8\xC8V[a9\"\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a9=W[\x01a7oV[\x85\x7F:\x13M\x01\xC0x\x03\0<c0\x17\x17\xDD\xC4a.lG\xAE@\x8E\xEE\xA3\",\xDE\xD52\xD0*\xE6a9ma5Q\x84\x87\x89a4\xD8V[\x90a9~`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a97V[\x80\x15\x80\x15a9\xD8W[\x80\x15a9\xD0W[\x80\x15a9\xC0W[a9\xBAWd\x01\0\0\x03\xD0\x19`\x07\x81\x80\x93\x81\x81\x80\t\t\x08\x91\x80\t\x14\x90V[PP_\x90V[Pd\x01\0\0\x03\xD0\x19\x82\x10\x15a9\x9DV[P\x81\x15a9\x96V[Pd\x01\0\0\x03\xD0\x19\x81\x10\x15a9\x8FV[\x90\x93\x92\x90\x91_\x90\x80\x84\x03a<aWPPd\x01\0\0\x03\xD0\x19_\x91\x85\x08a:\x11WPP\x90P_\x90_\x90V[d\x01\0\0\x03\xD0\x19\x80`\x01\x81\x80a:x\x81\x80\x80a:h\x9A\x81\x80\x8F\x80\t\x96\x87\x92\x81\x80\x80\x80\x80\x8F\x81\x81\x81\x92\t\x99\x87\t`\x04\t\x97\x80\t_\t\x92\x80\t`\x03\t\x08\x91\x81a:[\x81\x83\x80\x08\x82a,EV[\x81\x85\x80\t\x08\x9D\x8E\x83a,EV[\x90\x08\x90\t\x93\x80\t`\x08\t\x83a,EV[\x90\x08\x96\t`\x02\t\x93\x91\x90[\x84\x15\x15\x85\x81a<PW[P\x80a<HW[\x15a;\xEAW\x80\x94`\x01\x90d\x01\0\0\x03\xD0\x19\x91\x81\x84\x92[a:\xFEWPPPP\x80a:\xD1WP\x90d\x01\0\0\x03\xD0\x19\x80\x92\x81\x80\x87\x80\t\x80\x92\t\x95\t\x90\t\x90V[\x80\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`$\x92R`\x12`\x04R\xFD[\x92\x97\x91\x92\x80\x15a;\xBDW\x80\x89\x04\x91\x80\x94a;\x90Wd\x01\0\0\x03\xD0\x19\x90\x83\td\x01\0\0\x03\xD0\x19\x03d\x01\0\0\x03\xD0\x19\x81\x11a#ZWd\x01\0\0\x03\xD0\x19\x90\x86\x94\x08\x93\x98\x81\x92\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a;cW\x90a;Z\x91a,EV[\x90\x92\x90\x80a:\xAAV[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x11`\x04R\xFD[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x12`\x04R\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x12`\x04R`$_\xFD[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x0E`$\x82\x01R\x7FInvalid number\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`D\x82\x01R\xFD[P`\x01a:\x94V[d\x01\0\0\x03\xD0\x19\x91P\x14\x15_a:\x8DV[d\x01\0\0\x03\xD0\x19\x92\x91\x95a<t\x94a?RV[\x93\x90\x91\x90a:\x83V[\x80_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ T\x15_\x14a=-Wa<\xDA\x81\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0a3\xEFV[\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T\x90_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ U`\x01\x90V[P_\x90V[\x80_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15_\x14a=-Wa=\x8F\x81\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x90_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ U`\x01\x90V[\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nTa?)Wa>\x99\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nU`\x01\x90V[_\x90V[\x90\x91a?Da,\x1D\x93`@\x84R`@\x84\x01\x90a, V[\x91` \x81\x84\x03\x91\x01Ra, V[\x94\x92\x90\x93\x91\x85\x15\x80aAWW[aALW\x80\x15\x80aADW[aA<W`@Q`\x80\x91a?\x7F\x83\x83a+\x8DV[\x826\x837\x84\x15a;\xBDW\x84`\x01\x80\t\x80\x83R\x93\x85\x85`\x01\t\x98` \x84\x01\x99\x8AR`@\x84\x01\x92\x86\x84R\x87\x84Q`\x01\t\x93``\x86\x01\x94\x85R`@Q\x9A\x87\x8C\x01\x95\x8C\x87\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x88\x11\x17a+`W\x8A\x80\x97\x95\x81\x96\x94\x82\x95`@RQ\x90\t\x8DRQ\x90\t\x94` \x8B\x01\x95\x86RQ\x90\t\x98`@\x89\x01\x99\x8ARQ\x90\t``\x87\x01\x90\x81R\x86Q\x88Q\x14\x80\x15\x90aA0W[\x15a@\xD2W\x84\x92\x83\x80\x80\x93\x81`@Q\x9C\x85a@*\x8F\x97\x88a+\x8DV[6\x877Q\x8CQa@:\x90\x83a,EV[\x90\x08\x84RQ\x85Qa@K\x90\x83a,EV[\x90\x08\x98` \x83\x01\x99\x8AR\x81\x80\x8B\x81\x80\x80\x80\x89Q\x8AQ\x90\t\x93`@\x8A\x01\x94\x85R\x81\x85Q\x8BQ\x90\t``\x90\x9A\x01\x99\x8ARQ\x80\t\x88Qa@\x88\x90\x83a,EV[\x90\x08\x81\x80\x87Q\x85Q\x90\t`\x02\ta@\x9F\x90\x83a,EV[\x90\x08\x9CQ\x93Q\x90Q\x90\ta@\xB3\x8C\x83a,EV[\x90\x08\x90\t\x92Q\x90Q\x90\ta@\xC7\x90\x83a,EV[\x90\x08\x94Q\t\x91\x92\x91\x90V[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x1E`$\x82\x01R\x7FUse jacDouble function instead\0\0`D\x82\x01R\xFD[P\x81Q\x81Q\x14\x15a@\x0EV[PPP`\x01\x90V[P\x81\x15a?kV[\x94P\x92P`\x01\x91\x90PV[P\x84\x15a?_V[_\x90` \x92`@Q\x90\x84\x82\x01\x92\x83R`@\x82\x01R`@\x81RaA\x82``\x82a+\x8DV[`@Q\x91\x82\x91Q\x80\x91\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Q\x90V[\x81Q\x91\x90`A\x83\x03aA\xD2WaA\xCB\x92P` \x82\x01Q\x90```@\x84\x01Q\x93\x01Q_\x1A\x90aE\x16V[\x91\x92\x90\x91\x90V[PP_\x91`\x02\x91\x90V[`\x04\x81\x10\x15aB\x87W\x80aA\xEEWPPV[`\x01\x81\x03aB\x1EW\x7F\xF6E\xEE\xDF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`\x02\x81\x03aBRWP\x7F\xFC\xE6\x98\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[`\x03\x14aB\\WPV[\x7F\xD7\x8B\xCE\x0C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`!`\x04R`$_\xFD[aB\xBE\x81\x80a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aB\xF2\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aB\xFC\x82\x80a/\xCDV[aC\x05\x91aE\xA5V[\x91` \x81\x01\x90aC\x15\x82\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aCI\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x91aCT\x90\x82a/\xCDV[aC]\x91aE\xA5V[`@\x82\x01aCk\x81\x84a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\x9F\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x90aC\xAA\x90\x84a/\xCDV[aC\xB3\x91aE\xA5V[\x91``\x84\x01\x93aC\xC3\x85\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\xF7\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x94aD\x01\x91a/\xCDV[aD\n\x91aE\xA5V[\x94`@Q\x97\x88\x97`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16` \x89\x01R\x80Q` \x81\x92\x01`$\x8A\x01^\x87\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`$\x82\x01R\x81Q` \x81\x93\x01`(\x83\x01^\x01`$\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01`\x04\x81\x01_\x90R\x03`\x04\x01`\x1F\x19\x81\x01\x82Ra,\x1D\x90\x82a+\x8DV[\x91\x90\x7F\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF]WnsW\xA4P\x1D\xDF\xE9/Fh\x1B \xA0\x84\x11aE\x9AW\x91` \x93`\x80\x92`\xFF_\x95`@Q\x94\x85R\x16\x86\x84\x01R`@\x83\x01R``\x82\x01R\x82\x80R`\x01Z\xFA\x15a\x1C\xB9W_Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x15aE\x90W\x90_\x90_\x90V[P_\x90`\x01\x90_\x90V[PPP_\x91`\x03\x91\x90V[``\x92\x91_\x91[\x81\x83\x10aE\xB8WPPPV[\x90\x91\x93aE\xFFc\xFF\xFF\xFF\xFFaE\xD1a5Q\x88\x87\x87a4\xD8V[\x90P`\x02\x1C\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aF\ra5Q\x87\x86\x86a4\xD8V[aF\x1B\x88\x87\x87\x95\x94\x95a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x94` \x94\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x86\x84aF\xDF\x97`\x04\x97\x96aF\x84\x89\x98b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x95\x85`@Q\x9C\x89\x8E\x9AQ\x91\x82\x91\x01\x88\x8C\x01^\x89\x01\x93`\xE0\x1B\x16\x85\x84\x01R`$\x83\x017\x01\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x94\x01\x91\x90aE\xACV\xFE\xA1dsolcC\0\x08$\0\n\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0",
-    );
-    /// The runtime bytecode of the contract, as deployed on the network.
-    ///
-    /// ```text
-    ///0x60e0806040526004361015610012575f80fd5b5f60c0525f3560e01c9081630d8e6e2c14612ae95750806331ee624214612acb57806340f34d4214612a8f5780634f1ef286146127bf57806352d1902d1461272057806359ba9258146126e45780635b666b1e146126945780635c975abb1461265357806363a599a414612596578063715018a6146124da57806373ab99161461186757806387093eba14610a7c5780638da5cb5b14610a285780639ad91d4c14610977578063a06056f714610936578063ad3cb1cc146108d0578063bdeb442d14610846578063c0253023146107a7578063c1b0bed714610754578063c44956d114610716578063c4d66de8146102cd578063c879dbe414610284578063e33845cf14610226578063f2fde38b146101f7578063fddd4837146101d1578063fe18ab911461018d5763ffc33f7214610149575f80fd5b346101875760c0516003193601126101875760207f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054604051908152f35b60c05180fd5b346101875760c051600319360112610187576020600160ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b604051908152f35b346101875760c0516003193601126101875760206101ed612d3f565b6040519015158152f35b3461018757602060031936011261018757610220610213612b21565b61021b612f0e565b612c52565b60c05180f35b346101875760c0516003193601126101875760206040517fffffffff000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000168152f35b346101875760206003193601126101875760206101ed6004355f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b34610187576020600319360112610187576102e6612b21565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460ff8160401c16159167ffffffffffffffff82168015908161070e575b6001149081610704575b1590816106fb575b506106cf57818360017fffffffffffffffffffffffffffffffffffffffffffffffff000000000000000061039f9516177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005561067a575b5061039761327c565b61021b61327c565b6103a761327c565b6103af61327c565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90254680100000000000000008110156106495780600161043292017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b81549060031b905f197fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b06831b921b191617905560c0517f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055610492613de2565b507f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d260206040517fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b068152a16104e561327c565b7fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a2610579612d3f565b61061d576105875760c05180f35b7fffffffffffffffffffffffffffffffffffffffffffffff00ffffffffffffffff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054167ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00557fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2602060405160018152a1610220565b7f0b1d38a30000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526041600452602460c051fd5b7fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000001668010000000000000001177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00558361038e565b7ff92ee8a90000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b90501584610337565b303b15915061032f565b849150610325565b346101875760c0516003193601126101875760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054604051908152f35b346101875760206003193601126101875760c0515060043560c051527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc016020526020604060c05120541515604051908152f35b34610187576020600319360112610187576004356107c3612f0e565b801561081a57807f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a260c05180f35b7f774d5de10000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b346101875760c051600319360112610187577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903545f19810190811161089f576108906020916130eb565b90549060031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526011600452602460c051fd5b346101875760c0516003193601126101875760408051610932916108f49082612b8d565b600581527f352e302e300000000000000000000000000000000000000000000000000000006020820152604051918291602083526020830190612c20565b0390f35b346101875760c05160031936011261018757602060ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416604051908152f35b34610187576020600319360112610187577f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054600435908110156109f7576020907f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0060c051528160c051200160c051505460c05160031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526032600452602460c051fd5b346101875760c05160031936011261018757602073ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c1993005416604051908152f35b346101875760406003193601126101875767ffffffffffffffff6004351161018757606060031960043536030112610187576024358015158103610187575a6080527f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c61183b5760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610b10612f7a565b610b1e600480350180612fcd565b809291501561180f57610b3082613039565b610b38613156565b50604051610b4581612b44565b60c051815260c05160208201529260c05160a05260c0515b8181106112c9575050806020610ba5925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b3691612bcc565b856141a2565b909391936141dc565b602081519101519060c0515260205273ffffffffffffffffffffffffffffffffffffffff80604060c05120169116908082036112975750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054610c0d600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000610c6363ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152610caa606482612b8d565b60c051915b808310610f995750602080925060405191805191829101835e81019060c05182528060c05192039060025afa15610f5a5760c05151610cf860446004350160043560040161322b565b909281600411610187577fffffffff000000000000000000000000000000000000000000000000000000008435167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203610f6757505015610e7e575b50505060a051610e0b575b7f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610ddc5a608051612c45565b7f6f1498310000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b610e1660a051613d32565b15610e4c577f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d2602060405160a0518152a1610d83565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c0515260a051600452602460c051fd5b73ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b1561018757610ef96040519485937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b927f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e60248401526044830152818060c0519403915afa8015610f5a57610f41575b8080610d78565b60c051610f4d91612b8d565b60c0516101875781610f3a565b6040513d60c051823e3d90fd5b7f78a2221c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b90610fb283610fac600480350180612fcd565b9061306a565b610fbc8180612fcd565b919050610ff163ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b1660208201526004815261102e602482612b8d565b9160c051905b808210611213575050602081019160206110f36004826110548787612fcd565b95905061108963ffffffff871662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519683889451918291018686015e83019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b9260c051915b8083106111915750505060019260208093611188936111526060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e8401908382019060c0518252519283915e010160c051815203601f198101835282612b8d565b92019190610caf565b909193602061120a604060019383806111b48b6111ae8b8d612fcd565b906131b8565b6111c86111c38683018361316e565b6142b4565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e010160c051838201520301601f198101835282612b8d565b940191906110f9565b9092602061128f606060019383806112358a61122f8b80612fcd565b906131a1565b6112446111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e010160c051838201520301601f198101835282612b8d565b930190611034565b7fe6d44b4c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b6112db81610fac600480350180612fcd565b60c051909590866112ec8180612fcd565b90506112f781613039565b61130082613039565b9160c0515b81811061170d57505061131b6020840184612fcd565b92905061132783613039565b9161133184613039565b9360c051905b8082106114af575050926113ab7f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc32959361139d6113b99461138f608098604051998a990135895260a060208a015260a08901906131f8565b9087820360408901526131f8565b9085820360608701526131f8565b9083820360808501526131f8565b0390a1806114a6575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0873603011261018757604051906113fc82612b44565b6040870135825260208201606088013581526040519261141b84612b44565b5f84525f60208501526114318151835190613986565b1561146e578260019594926114539260206080965193015190519151926139e8565b6020830152815296013561146782866130d7565b5201610b5d565b604491604051917fb8a0e8a1000000000000000000000000000000000000000000000000000000008352516004830152516024820152fd5b60a052866113c2565b9192939495819750906111ae8260206114c9940190612fcd565b9560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154167f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900545f19811461089f57600181017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900559088359160c0515b82811061165257505090600192917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b146115f9575b50976020810135906115d66115cf604083016115c96115c3828661316e565b86613518565b8361316e565b8235613762565b356115e183896130d7565b526115ec82896130d7565b52018c9594939291611337565b61164761164061164c9261160c856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c05152602060c051200154809461415f565b928061415f565b61336c565b8f6115a4565b90926001908185166116d0576116c5907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c051528084602060c0512001557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c0515283602060c0512001549061415f565b935b811c9101611547565b611707907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c0515283602060c05120015461415f565b936116c7565b909192938161122f8261171f93612fcd565b6040810135611758815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b156117e057506117688135613c7d565b156117b0579081602060019301359061178e6115cf606083016115c96115c3828661316e565b3561179983876130d7565b526117a482876130d7565b5201908a939291611305565b7f39a940c50000000000000000000000000000000000000000000000000000000060c0515235600452602460c051fd5b7ff9849ea30000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b7fcf1b093c0000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f3ee5aeb50000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b34611cc4576020600319360112611cc45767ffffffffffffffff60043511611cc457606060031960043536030112611cc4577f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6124b25760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6118eb612f7a565b6118f9600480350180612fcd565b8091501561248a5761190a81613039565b90611913613156565b5060405161192081612b44565b5f81525f6020820152915f915f5b818110611f60575050806020611960925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b60208151910151905f5260205273ffffffffffffffffffffffffffffffffffffffff8060405f2016911690808203611f325750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700546119c4600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000611a1a63ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152611a61606482612b8d565b905f905b808210611cf65750505f60208092604051918183925191829101835e8101838152039060025afa15611cb9575f51611aa760446004350160043560040161322b565b80600411611cc4577fffffffff000000000000000000000000000000000000000000000000000000008235167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203611cc857505073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b15611cc4575f92611ba192604051958694859384937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b907f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e6024840152604483015203915afa8015611cb957611ca5575b5080611c37575b507f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d60c05180f35b611c4081613d32565b15611c765760207f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d291604051908152a181611be3565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b5f611caf91612b8d565b5f60c05282611bdc565b6040513d5f823e3d90fd5b5f80fd5b7f78a2221c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b9091611d0a83610fac600480350180612fcd565b611d148180612fcd565b919050611d4963ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b16602082015260048152611d86602482612b8d565b915f905b808210611eb657505060208101916020611daa6004826110548787612fcd565b925f915b808310611e415750505060019260208093611e3993611e076060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e840190838201905f8252519283915e01015f815203601f198101835282612b8d565b920190611a65565b9091936020611ead60406001938380611e5e8b6111ae8b8d612fcd565b611e6d6111c38683018361316e565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e01015f838201520301601f198101835282612b8d565b94019190611dae565b90926020611f2a60606001938380611ed28a61122f8b80612fcd565b611ee16111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e01015f838201520301601f198101835282612b8d565b930190611d8a565b7fe6d44b4c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b611f7281610fac600480350180612fcd565b5f95611f7e8280612fcd565b979050611f8a88613039565b611f9389613039565b985f5b818110612387575050611fac6020850185612fcd565b999050611fb88a613039565b99611fc281613039565b905f905b8082106120da575050906120217f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc3293926113ab61139d9d60808a01359e8f9561138f604051988998895260a060208a015260a08901906131f8565b0390a1806120d2575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc08336030112611cc4576040519161206483612b44565b6040810135835260606020840191013581526040519261208384612b44565b5f84525f60208501526120998151835190613986565b1561146e57916120b99160019594936020835193015190519151926139e8565b60208301528152956120cb82866130d7565b520161192e565b95508761202a565b9094506120ee856111ae60208a018a612fcd565b9460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416957f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054965f19881461235a57878f986001017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055908235915f5b8281106122765750509060019392917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b1461220f575b50976121fc836020840135936121f56115cf604083016115c96121ef828661316e565b89613518565b35926130d7565b5261220782866130d7565b520190611fc6565b61164761164061227092612222856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d431015493849061415f565b5f6121cc565b9092600190818516612303577fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f83018190557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d4318301546122f89161415f565b935b811c910161216e565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015f527fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f830154612354919061415f565b936122fa565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b6123958161122f8880612fcd565b60408101356123ce815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b1561245f575080356123df81613c7d565b15612434579061242d838e6001959461241d612417602087013596606081019061241261240c838361316e565b8a613518565b61316e565b82613762565b612427838a6130d7565b526130d7565b5201611f96565b7f39a940c5000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7ff9849ea3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7fcf1b093c000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b34611cc4575f600319360112611cc4576124f2612f0e565b5f73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300547fffffffffffffffffffffffff000000000000000000000000000000000000000081167f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08280a3005b34611cc4575f600319360112611cc4576125ae612f0e565b6125b6612f7a565b6125be612f7a565b60017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff007fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416177fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a2586020604051338152a1005b34611cc4575f600319360112611cc457602060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f0330054166040519015158152f35b34611cc4575f600319360112611cc457602060405173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000168152f35b34611cc4575f600319360112611cc45760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354604051908152f35b34611cc4575f600319360112611cc45773ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001630036127975760206040517f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8152f35b7fe07c8dba000000000000000000000000000000000000000000000000000000005f5260045ffd5b6040600319360112611cc4576127d3612b21565b60243567ffffffffffffffff8111611cc4576127f3903690600401612c02565b9073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803014908115612a4d575b5061279757612843612f0e565b73ffffffffffffffffffffffffffffffffffffffff8116916040517f52d1902d000000000000000000000000000000000000000000000000000000008152602081600481875afa5f9181612a19575b506128c357837f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b807f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8592036129ee5750823b156129c357807fffffffffffffffffffffffff00000000000000000000000000000000000000007f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416177f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc557fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f80a28051156129925761299091613411565b005b50503461299b57005b7fb398979f000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7faa1d49a4000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b9091506020813d602011612a45575b81612a3560209383612b8d565b81010312611cc457519085612892565b3d9150612a28565b905073ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416141583612836565b34611cc4575f600319360112611cc45760207f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054604051908152f35b34611cc4576020600319360112611cc45760206108906004356130eb565b34611cc4575f600319360112611cc457807f322e302e302d616c7068612e320000000000000000000000000000000000000060209252f35b6004359073ffffffffffffffffffffffffffffffffffffffff82168203611cc457565b6040810190811067ffffffffffffffff821117612b6057604052565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b90601f601f19910116810190811067ffffffffffffffff821117612b6057604052565b67ffffffffffffffff8111612b6057601f01601f191660200190565b929192612bd882612bb0565b91612be66040519384612b8d565b829481845281830111611cc4578281602093845f960137010152565b9080601f83011215611cc457816020612c1d93359101612bcc565b90565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b9190820391821161235a57565b73ffffffffffffffffffffffffffffffffffffffff168015612d135773ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054827fffffffffffffffffffffffff00000000000000000000000000000000000000008216177f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e05f80a3565b7f1e4fbdf7000000000000000000000000000000000000000000000000000000005f525f60045260245ffd5b6040517f3cadf4490000000000000000000000000000000000000000000000000000000081527fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016600482015260208160248173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000165afa908115611cb9575f91612ebe575b50602073ffffffffffffffffffffffffffffffffffffffff916004604051809481937f5c975abb000000000000000000000000000000000000000000000000000000008352165afa908115611cb9575f91612e83575b508015612e5a5790565b5060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300541690565b90506020813d602011612eb6575b81612e9e60209383612b8d565b81010312611cc457518015158103611cc4575f612e50565b3d9150612e91565b90506020813d602011612f06575b81612ed960209383612b8d565b81010312611cc4575173ffffffffffffffffffffffffffffffffffffffff81168103611cc4576020612dfa565b3d9150612ecc565b73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054163303612f4e57565b7f118cdaa7000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b60ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416612fa557565b7fd93c0665000000000000000000000000000000000000000000000000000000005f5260045ffd5b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918160051b36038313611cc457565b67ffffffffffffffff8111612b605760051b60200190565b9061304382613021565b6130506040519182612b8d565b828152601f196130608294613021565b0190602036910137565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6181360301821215611cc4570190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b80518210156130aa5760209160051b010190565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903548110156130aa577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9035f5260205f2001905f90565b80548210156130aa575f5260205f2001905f90565b6040519061316382612b44565b5f6020838281520152565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8181360301821215611cc4570190565b908210156130aa57612c1d9160051b81019061316e565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa181360301821215611cc4570190565b90602080835192838152019201905f5b8181106132155750505090565b8251845260209384019390920191600101613208565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918136038313611cc457565b60ff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460401c16156132ab57565b7fd7e6bcf8000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901613141565b5f19829392549160031b92831b921b1916179055565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b805468010000000000000000811015612b605761335691600182018155613141565b905f8091602081519101845af480806134c5575b156134455750506040513d81523d5f602083013e60203d82010160405290565b1561348c5773ffffffffffffffffffffffffffffffffffffffff907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b3d1561349d576040513d5f823e3d90fd5b7fd6bda275000000000000000000000000000000000000000000000000000000005f5260045ffd5b503d1515806134255750813b1515613425565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc181360301821215611cc4570190565b90604081016135278183612fcd565b9290505f5b83811061353a575050505050565b61355b6135518261354b8686612fcd565b906134d8565b602081019061322b565b8101606082820312611cc45781359173ffffffffffffffffffffffffffffffffffffffff8316809303611cc457602081013567ffffffffffffffff8111611cc457826135a8918301612c02565b91604082013567ffffffffffffffff8111611cc4576135c79201612c02565b90604051917f33a89203000000000000000000000000000000000000000000000000000000008352886004840152604060248401525f838061360c6044820186612c20565b038183885af1928315611cb9575f936136af575b50825160208401208151602083012003613674575060019392917fcddb327adb31fe5437df2a8c68301bb13a6baae432a804838caaf682506aadf19161366b60405192839283613f2d565b0390a20161352c565b90506136ab6040519283927fc504fada00000000000000000000000000000000000000000000000000000000845260048401613f2d565b0390fd5b9092503d805f833e6136c18183612b8d565b810190602081830312611cc45780519067ffffffffffffffff8211611cc4570181601f82011215611cc4578051906136f882612bb0565b926137066040519485612b8d565b82845260208383010111611cc457815f9260208093018386015e83010152915f613620565b601f8260209493601f1993818652868601375f8582860101520116010190565b604090612c1d94928152816020820152019161372b565b9061376d8180612fcd565b5f5b818110613917575050506137866020820182612fcd565b5f5b8181106138a85750505061379f6040820182612fcd565b5f5b818110613839575050508060606137b9920190612fcd565b90915f5b8281106137ca5750505050565b6137d58184866134d8565b35906002821015611cc45760018092146137f0575b016137bd565b827fa494dac4b7184843583f972e06783e2c3bb47f4f0137b8df52a860df07219f8c61382061355184888a6134d8565b90613831604051928392878461374b565b0390a26137ea565b6138448183856134d8565b35906002821015611cc457600180921461385f575b016137a1565b857f9c61b290f631097f56273cf4daf40df1ff9ccc33f101d464837da1f5ae18bd5961388f6135518487896134d8565b906138a0604051928392878461374b565b0390a2613859565b6138b38183856134d8565b35906002821015611cc45760018092146138ce575b01613788565b857f48243873b4752ddcb45e0d7b11c4c266583e5e099a0b798fdd9c1af7d49324f36138fe6135518487896134d8565b9061390f604051928392878461374b565b0390a26138c8565b6139228183856134d8565b35906002821015611cc457600180921461393d575b0161376f565b857f3a134d01c07803003c63301717ddc4612e6c47ae408eeea3222cded532d02ae661396d6135518487896134d8565b9061397e604051928392878461374b565b0390a2613937565b801580156139d8575b80156139d0575b80156139c0575b6139ba576401000003d01960078180938181800909089180091490565b50505f90565b506401000003d01982101561399d565b508115613996565b506401000003d01981101561398f565b90939290915f90808403613c615750506401000003d0195f918508613a1157505090505f905f90565b6401000003d0198060018180613a78818080613a689a81808f800996879281808080808f81818192099987096004099780095f09928009600309089181613a5b8183800882612c45565b81858009089d8e83612c45565b9008900993800960080983612c45565b900896096002099391905b8415158581613c50575b5080613c48575b15613bea5780946001906401000003d019918184925b613afe575050505080613ad15750906401000003d019809281808780098092099509900990565b807f4e487b7100000000000000000000000000000000000000000000000000000000602492526012600452fd5b929791928015613bbd57808904918094613b90576401000003d0199083096401000003d019036401000003d019811161235a576401000003d0199086940893988192828102928184041490151715613b635790613b5a91612c45565b90929080613aaa565b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526011600452fd5b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526012600452fd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f496e76616c6964206e756d6265720000000000000000000000000000000000006044820152fd5b506001613a94565b6401000003d019915014155f613a8d565b6401000003d019929195613c7494613f52565b93909190613a83565b805f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2054155f14613d2d57613cda817f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc006133ef565b7f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054905f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2055600190565b505f90565b805f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054155f14613d2d57613d8f817f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354905f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2055600190565b7fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e54613f2957613e997fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b067f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903547fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e55600190565b5f90565b9091613f44612c1d93604084526040840190612c20565b916020818403910152612c20565b9492909391851580614157575b61414c57801580614144575b61413c57604051608091613f7f8383612b8d565b823683378415613bbd5784600180098083529385856001099860208401998a52604084019286845287845160010993606086019485526040519a878c01958c871067ffffffffffffffff881117612b60578a80979581969482956040525190098d525190099460208b019586525190099860408901998a52519009606087019081528651885114801590614130575b156140d257849283808093816040519c8561402a8f9788612b8d565b368737518c5161403a9083612c45565b9008845251855161404b9083612c45565b90089860208301998a5281808b8180808089518a5190099360408a019485528185518b5190096060909a01998a5251800988516140889083612c45565b9008818087518551900960020961409f9083612c45565b90089c519351905190096140b38c83612c45565b900890099251905190096140c79083612c45565b900894510991929190565b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f557365206a6163446f75626c652066756e6374696f6e20696e737465616400006044820152fd5b5081518151141561400e565b505050600190565b508115613f6b565b945092506001919050565b508415613f5f565b5f9060209260405190848201928352604082015260408152614182606082612b8d565b604051918291518091835e8101838152039060025afa15611cb9575f5190565b81519190604183036141d2576141cb9250602082015190606060408401519301515f1a90614516565b9192909190565b50505f9160029190565b600481101561428757806141ee575050565b6001810361421e577ff645eedf000000000000000000000000000000000000000000000000000000005f5260045ffd5b6002810361425257507ffce698f7000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b60031461425c5750565b7fd78bce0c000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b6142be8180612fcd565b63ffffffff9150166142f29062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b6142fc8280612fcd565b614305916145a5565b9160208101906143158282612fcd565b63ffffffff9150166143499062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b916143549082612fcd565b61435d916145a5565b6040820161436b8184612fcd565b63ffffffff91501661439f9062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b906143aa9084612fcd565b6143b3916145a5565b9160608401936143c38582612fcd565b63ffffffff9150166143f79062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b9461440191612fcd565b61440a916145a5565b9460405197889760e01b7fffffffff000000000000000000000000000000000000000000000000000000001660208901528051602081920160248a015e87019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016602482015281516020819301602883015e016024019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e016004019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e01600401600481015f905203600401601f1981018252612c1d9082612b8d565b91907f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0841161459a579160209360809260ff5f9560405194855216868401526040830152606082015282805260015afa15611cb9575f5173ffffffffffffffffffffffffffffffffffffffff81161561459057905f905f90565b505f906001905f90565b5050505f9160039190565b606092915f915b8183106145b857505050565b9091936145ff63ffffffff6145d16135518887876134d8565b905060021c1662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b61460d6135518786866134d8565b61461b8887879594956134d8565b35906002821015611cc4576001946020947fffffffff0000000000000000000000000000000000000000000000000000000086846146df9760049796614684899862ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b95856040519c898e9a5191829101888c015e89019360e01b1685840152602483013701019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b940191906145ac56fea164736f6c6343000824000a
-    /// ```
-    #[rustfmt::skip]
-    #[allow(clippy::all)]
-    pub static DEPLOYED_BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
-        b"`\xE0\x80`@R`\x046\x10\x15a\0\x12W_\x80\xFD[_`\xC0R_5`\xE0\x1C\x90\x81c\r\x8En,\x14a*\xE9WP\x80c1\xEEbB\x14a*\xCBW\x80c@\xF3MB\x14a*\x8FW\x80cO\x1E\xF2\x86\x14a'\xBFW\x80cR\xD1\x90-\x14a' W\x80cY\xBA\x92X\x14a&\xE4W\x80c[fk\x1E\x14a&\x94W\x80c\\\x97Z\xBB\x14a&SW\x80cc\xA5\x99\xA4\x14a%\x96W\x80cqP\x18\xA6\x14a$\xDAW\x80cs\xAB\x99\x16\x14a\x18gW\x80c\x87\t>\xBA\x14a\n|W\x80c\x8D\xA5\xCB[\x14a\n(W\x80c\x9A\xD9\x1DL\x14a\twW\x80c\xA0`V\xF7\x14a\t6W\x80c\xAD<\xB1\xCC\x14a\x08\xD0W\x80c\xBD\xEBD-\x14a\x08FW\x80c\xC0%0#\x14a\x07\xA7W\x80c\xC1\xB0\xBE\xD7\x14a\x07TW\x80c\xC4IV\xD1\x14a\x07\x16W\x80c\xC4\xD6m\xE8\x14a\x02\xCDW\x80c\xC8y\xDB\xE4\x14a\x02\x84W\x80c\xE38E\xCF\x14a\x02&W\x80c\xF2\xFD\xE3\x8B\x14a\x01\xF7W\x80c\xFD\xDDH7\x14a\x01\xD1W\x80c\xFE\x18\xAB\x91\x14a\x01\x8DWc\xFF\xC3?r\x14a\x01IW_\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0T`@Q\x90\x81R\xF3[`\xC0Q\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\x01`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B`@Q\x90\x81R\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` a\x01\xEDa-?V[`@Q\x90\x15\x15\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02 a\x02\x13a+!V[a\x02\x1Ba/\x0EV[a,RV[`\xC0Q\x80\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `@Q\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W` a\x01\xED`\x045_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02\xE6a+!V[\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`\xFF\x81`@\x1C\x16\x15\x91g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x80\x15\x90\x81a\x07\x0EW[`\x01\x14\x90\x81a\x07\x04W[\x15\x90\x81a\x06\xFBW[Pa\x06\xCFW\x81\x83`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0a\x03\x9F\x95\x16\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0Ua\x06zW[Pa\x03\x97a2|V[a\x02\x1Ba2|V[a\x03\xA7a2|V[a\x03\xAFa2|V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a\x06IW\x80`\x01a\x042\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x81T\x90`\x03\x1B\x90_\x19\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x83\x1B\x92\x1B\x19\x16\x17\x90U`\xC0Q\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0Ua\x04\x92a=\xE2V[P\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x81R\xA1a\x04\xE5a2|V[\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2a\x05ya-?V[a\x06\x1DWa\x05\x87W`\xC0Q\x80\xF3[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T\x16\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x7F\xC7\xF5\x05\xB2\xF3q\xAE!u\xEEI\x13\xF4I\x9E\x1F&3\xA7\xB5\x93c!\xEE\xD1\xCD\xAE\xB6\x11Q\x81\xD2` `@Q`\x01\x81R\xA1a\x02 V[\x7F\x0B\x1D8\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`A`\x04R`$`\xC0Q\xFD[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\x16h\x01\0\0\0\0\0\0\0\x01\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x83a\x03\x8EV[\x7F\xF9.\xE8\xA9\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x90P\x15\x84a\x037V[0;\x15\x91Pa\x03/V[\x84\x91Pa\x03%V[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\xC0QP`\x045`\xC0QR\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R` `@`\xC0Q T\x15\x15`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\x045a\x07\xC3a/\x0EV[\x80\x15a\x08\x1AW\x80\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2`\xC0Q\x80\xF3[\x7FwM]\xE1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T_\x19\x81\x01\x90\x81\x11a\x08\x9FWa\x08\x90` \x91a0\xEBV[\x90T\x90`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x11`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W`@\x80Qa\t2\x91a\x08\xF4\x90\x82a+\x8DV[`\x05\x81R\x7F5.0.0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x82\x01R`@Q\x91\x82\x91` \x83R` \x83\x01\x90a, V[\x03\x90\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`\x045\x90\x81\x10\x15a\t\xF7W` \x90\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0`\xC0QR\x81`\xC0Q \x01`\xC0QPT`\xC0Q`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`2`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x16`@Q\x90\x81R\xF3[4a\x01\x87W`@`\x03\x196\x01\x12a\x01\x87Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x01\x87W```\x03\x19`\x0456\x03\x01\x12a\x01\x87W`$5\x80\x15\x15\x81\x03a\x01\x87WZ`\x80R\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a\x18;W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x0B\x10a/zV[a\x0B\x1E`\x04\x805\x01\x80a/\xCDV[\x80\x92\x91P\x15a\x18\x0FWa\x0B0\x82a09V[a\x0B8a1VV[P`@Qa\x0BE\x81a+DV[`\xC0Q\x81R`\xC0Q` \x82\x01R\x92`\xC0Q`\xA0R`\xC0Q[\x81\x81\x10a\x12\xC9WPP\x80` a\x0B\xA5\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[6\x91a+\xCCV[\x85aA\xA2V[\x90\x93\x91\x93aA\xDCV[` \x81Q\x91\x01Q\x90`\xC0QR` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@`\xC0Q \x16\x91\x16\x90\x80\x82\x03a\x12\x97WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x0C\r`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x0Ccc\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x0C\xAA`d\x82a+\x8DV[`\xC0Q\x91[\x80\x83\x10a\x0F\x99WP` \x80\x92P`@Q\x91\x80Q\x91\x82\x91\x01\x83^\x81\x01\x90`\xC0Q\x82R\x80`\xC0Q\x92\x03\x90`\x02Z\xFA\x15a\x0FZW`\xC0QQa\x0C\xF8`D`\x045\x01`\x045`\x04\x01a2+V[\x90\x92\x81`\x04\x11a\x01\x87W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x845\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x0FgWPP\x15a\x0E~W[PPP`\xA0Qa\x0E\x0BW[\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\r\xDCZ`\x80Qa,EV[\x7Fo\x14\x981\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[a\x0E\x16`\xA0Qa=2V[\x15a\x0ELW\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q`\xA0Q\x81R\xA1a\r\x83V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\xA0Q`\x04R`$`\xC0Q\xFD[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x01\x87Wa\x0E\xF9`@Q\x94\x85\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x92\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x81\x80`\xC0Q\x94\x03\x91Z\xFA\x80\x15a\x0FZWa\x0FAW[\x80\x80a\rxV[`\xC0Qa\x0FM\x91a+\x8DV[`\xC0Qa\x01\x87W\x81a\x0F:V[`@Q=`\xC0Q\x82>=\x90\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[\x90a\x0F\xB2\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[\x90a0jV[a\x0F\xBC\x81\x80a/\xCDV[\x91\x90Pa\x0F\xF1c\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x10.`$\x82a+\x8DV[\x91`\xC0Q\x90[\x80\x82\x10a\x12\x13WPP` \x81\x01\x91` a\x10\xF3`\x04\x82a\x10T\x87\x87a/\xCDV[\x95\x90Pa\x10\x89c\xFF\xFF\xFF\xFF\x87\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x96\x83\x88\x94Q\x91\x82\x91\x01\x86\x86\x01^\x83\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x92`\xC0Q\x91[\x80\x83\x10a\x11\x91WPPP`\x01\x92` \x80\x93a\x11\x88\x93a\x11R``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90`\xC0Q\x82RQ\x92\x83\x91^\x01\x01`\xC0Q\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x91\x90a\x0C\xAFV[\x90\x91\x93` a\x12\n`@`\x01\x93\x83\x80a\x11\xB4\x8Ba\x11\xAE\x8B\x8Da/\xCDV[\x90a1\xB8V[a\x11\xC8a\x11\xC3\x86\x83\x01\x83a1nV[aB\xB4V[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x10\xF9V[\x90\x92` a\x12\x8F```\x01\x93\x83\x80a\x125\x8Aa\x12/\x8B\x80a/\xCDV[\x90a1\xA1V[a\x12Da\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x104V[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[a\x12\xDB\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[`\xC0Q\x90\x95\x90\x86a\x12\xEC\x81\x80a/\xCDV[\x90Pa\x12\xF7\x81a09V[a\x13\0\x82a09V[\x91`\xC0Q[\x81\x81\x10a\x17\rWPPa\x13\x1B` \x84\x01\x84a/\xCDV[\x92\x90Pa\x13'\x83a09V[\x91a\x131\x84a09V[\x93`\xC0Q\x90[\x80\x82\x10a\x14\xAFWPP\x92a\x13\xAB\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x95\x93a\x13\x9Da\x13\xB9\x94a\x13\x8F`\x80\x98`@Q\x99\x8A\x99\x015\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x90\x87\x82\x03`@\x89\x01Ra1\xF8V[\x90\x85\x82\x03``\x87\x01Ra1\xF8V[\x90\x83\x82\x03`\x80\x85\x01Ra1\xF8V[\x03\x90\xA1\x80a\x14\xA6W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x876\x03\x01\x12a\x01\x87W`@Q\x90a\x13\xFC\x82a+DV[`@\x87\x015\x82R` \x82\x01``\x88\x015\x81R`@Q\x92a\x14\x1B\x84a+DV[_\x84R_` \x85\x01Ra\x141\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x82`\x01\x95\x94\x92a\x14S\x92` `\x80\x96Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x96\x015a\x14g\x82\x86a0\xD7V[R\x01a\x0B]V[`D\x91`@Q\x91\x7F\xB8\xA0\xE8\xA1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83RQ`\x04\x83\x01RQ`$\x82\x01R\xFD[`\xA0R\x86a\x13\xC2V[\x91\x92\x93\x94\x95\x81\x97P\x90a\x11\xAE\x82` a\x14\xC9\x94\x01\x90a/\xCDV[\x95`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T_\x19\x81\x14a\x08\x9FW`\x01\x81\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x885\x91`\xC0Q[\x82\x81\x10a\x16RWPP\x90`\x01\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x84`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\x15\xF9W[P\x97` \x81\x015\x90a\x15\xD6a\x15\xCF`@\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[\x86a5\x18V[\x83a1nV[\x825a7bV[5a\x15\xE1\x83\x89a0\xD7V[Ra\x15\xEC\x82\x89a0\xD7V[R\x01\x8C\x95\x94\x93\x92\x91a\x137V[a\x16Ga\x16@a\x16L\x92a\x16\x0C\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR` `\xC0Q \x01T\x80\x94aA_V[\x92\x80aA_V[a3lV[\x8Fa\x15\xA4V[\x90\x92`\x01\x90\x81\x85\x16a\x16\xD0Wa\x16\xC5\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x80\x84` `\xC0Q \x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR\x83` `\xC0Q \x01T\x90aA_V[\x93[\x81\x1C\x91\x01a\x15GV[a\x17\x07\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x83` `\xC0Q \x01TaA_V[\x93a\x16\xC7V[\x90\x91\x92\x93\x81a\x12/\x82a\x17\x1F\x93a/\xCDV[`@\x81\x015a\x17X\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a\x17\xE0WPa\x17h\x815a<}V[\x15a\x17\xB0W\x90\x81` `\x01\x93\x015\x90a\x17\x8Ea\x15\xCF``\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[5a\x17\x99\x83\x87a0\xD7V[Ra\x17\xA4\x82\x87a0\xD7V[R\x01\x90\x8A\x93\x92\x91a\x13\x05V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR5`\x04R`$`\xC0Q\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x1C\xC4W```\x03\x19`\x0456\x03\x01\x12a\x1C\xC4W\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a$\xB2W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x18\xEBa/zV[a\x18\xF9`\x04\x805\x01\x80a/\xCDV[\x80\x91P\x15a$\x8AWa\x19\n\x81a09V[\x90a\x19\x13a1VV[P`@Qa\x19 \x81a+DV[_\x81R_` \x82\x01R\x91_\x91_[\x81\x81\x10a\x1F`WPP\x80` a\x19`\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[` \x81Q\x91\x01Q\x90_R` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@_ \x16\x91\x16\x90\x80\x82\x03a\x1F2WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x19\xC4`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x1A\x1Ac\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x1Aa`d\x82a+\x8DV[\x90_\x90[\x80\x82\x10a\x1C\xF6WPP_` \x80\x92`@Q\x91\x81\x83\x92Q\x91\x82\x91\x01\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Qa\x1A\xA7`D`\x045\x01`\x045`\x04\x01a2+V[\x80`\x04\x11a\x1C\xC4W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x825\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x1C\xC8WPPs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x1C\xC4W_\x92a\x1B\xA1\x92`@Q\x95\x86\x94\x85\x93\x84\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x90\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x03\x91Z\xFA\x80\x15a\x1C\xB9Wa\x1C\xA5W[P\x80a\x1C7W[P\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]`\xC0Q\x80\xF3[a\x1C@\x81a=2V[\x15a\x1CvW` \x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2\x91`@Q\x90\x81R\xA1\x81a\x1B\xE3V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[_a\x1C\xAF\x91a+\x8DV[_`\xC0R\x82a\x1B\xDCV[`@Q=_\x82>=\x90\xFD[_\x80\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[\x90\x91a\x1D\n\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[a\x1D\x14\x81\x80a/\xCDV[\x91\x90Pa\x1DIc\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x1D\x86`$\x82a+\x8DV[\x91_\x90[\x80\x82\x10a\x1E\xB6WPP` \x81\x01\x91` a\x1D\xAA`\x04\x82a\x10T\x87\x87a/\xCDV[\x92_\x91[\x80\x83\x10a\x1EAWPPP`\x01\x92` \x80\x93a\x1E9\x93a\x1E\x07``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90_\x82RQ\x92\x83\x91^\x01\x01_\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x90a\x1AeV[\x90\x91\x93` a\x1E\xAD`@`\x01\x93\x83\x80a\x1E^\x8Ba\x11\xAE\x8B\x8Da/\xCDV[a\x1Ema\x11\xC3\x86\x83\x01\x83a1nV[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x1D\xAEV[\x90\x92` a\x1F*```\x01\x93\x83\x80a\x1E\xD2\x8Aa\x12/\x8B\x80a/\xCDV[a\x1E\xE1a\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x1D\x8AV[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[a\x1Fr\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[_\x95a\x1F~\x82\x80a/\xCDV[\x97\x90Pa\x1F\x8A\x88a09V[a\x1F\x93\x89a09V[\x98_[\x81\x81\x10a#\x87WPPa\x1F\xAC` \x85\x01\x85a/\xCDV[\x99\x90Pa\x1F\xB8\x8Aa09V[\x99a\x1F\xC2\x81a09V[\x90_\x90[\x80\x82\x10a \xDAWPP\x90a !\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x93\x92a\x13\xABa\x13\x9D\x9D`\x80\x8A\x015\x9E\x8F\x95a\x13\x8F`@Q\x98\x89\x98\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x03\x90\xA1\x80a \xD2W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x836\x03\x01\x12a\x1C\xC4W`@Q\x91a d\x83a+DV[`@\x81\x015\x83R``` \x84\x01\x91\x015\x81R`@Q\x92a \x83\x84a+DV[_\x84R_` \x85\x01Ra \x99\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x91a \xB9\x91`\x01\x95\x94\x93` \x83Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x95a \xCB\x82\x86a0\xD7V[R\x01a\x19.V[\x95P\x87a *V[\x90\x94Pa \xEE\x85a\x11\xAE` \x8A\x01\x8Aa/\xCDV[\x94`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x95\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x96_\x19\x88\x14a#ZW\x87\x8F\x98`\x01\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x825\x91_[\x82\x81\x10a\"vWPP\x90`\x01\x93\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x85`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\"\x0FW[P\x97a!\xFC\x83` \x84\x015\x93a!\xF5a\x15\xCF`@\x83\x01a\x15\xC9a!\xEF\x82\x86a1nV[\x89a5\x18V[5\x92a0\xD7V[Ra\"\x07\x82\x86a0\xD7V[R\x01\x90a\x1F\xC6V[a\x16Ga\x16@a\"p\x92a\"\"\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x01T\x93\x84\x90aA_V[_a!\xCCV[\x90\x92`\x01\x90\x81\x85\x16a#\x03W\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01\x81\x90U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x83\x01Ta\"\xF8\x91aA_V[\x93[\x81\x1C\x91\x01a!nV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01_R\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01Ta#T\x91\x90aA_V[\x93a\"\xFAV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x11`\x04R`$_\xFD[a#\x95\x81a\x12/\x88\x80a/\xCDV[`@\x81\x015a#\xCE\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a$_WP\x805a#\xDF\x81a<}V[\x15a$4W\x90a$-\x83\x8E`\x01\x95\x94a$\x1Da$\x17` \x87\x015\x96``\x81\x01\x90a$\x12a$\x0C\x83\x83a1nV[\x8Aa5\x18V[a1nV[\x82a7bV[a$'\x83\x8Aa0\xD7V[Ra0\xD7V[R\x01a\x1F\x96V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa$\xF2a/\x0EV[_s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81\x16\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0\x82\x80\xA3\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa%\xAEa/\x0EV[a%\xB6a/zV[a%\xBEa/zV[`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x17\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0U\x7Fb\xE7\x8C\xEA\x01\xBE\xE3 \xCDNB\x02p\xB5\xEAt\0\r\x11\xB0\xC9\xF7GT\xEB\xDB\xFCTK\x05\xA2X` `@Q3\x81R\xA1\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16`@Q\x90\x15\x15\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `@Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T`@Q\x90\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x160\x03a'\x97W` `@Q\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x81R\xF3[\x7F\xE0|\x8D\xBA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`@`\x03\x196\x01\x12a\x1C\xC4Wa'\xD3a+!V[`$5g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa'\xF3\x906\x90`\x04\x01a,\x02V[\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x800\x14\x90\x81\x15a*MW[Pa'\x97Wa(Ca/\x0EV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x91`@Q\x7FR\xD1\x90-\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` \x81`\x04\x81\x87Z\xFA_\x91\x81a*\x19W[Pa(\xC3W\x83\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x80\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x85\x92\x03a)\xEEWP\x82;\x15a)\xC3W\x80\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x17\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCU\x7F\xBC|\xD7Z \xEE'\xFD\x9A\xDE\xBA\xB3 A\xF7U!M\xBCk\xFF\xA9\x0C\xC0\"[9\xDA.\\-;_\x80\xA2\x80Q\x15a)\x92Wa)\x90\x91a4\x11V[\0[PP4a)\x9BW\0[\x7F\xB3\x98\x97\x9F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xAA\x1DI\xA4\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x90\x91P` \x81=` \x11a*EW[\x81a*5` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x90\x85a(\x92V[=\x91Pa*(V[\x90Ps\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x14\x15\x83a(6V[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`@Q\x90\x81R\xF3[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4W` a\x08\x90`\x045a0\xEBV[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W\x80\x7F2.0.0-alpha.2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x92R\xF3[`\x045\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x82\x03a\x1C\xC4WV[`@\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`A`\x04R`$_\xFD[\x90`\x1F`\x1F\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x1F\x01`\x1F\x19\x16` \x01\x90V[\x92\x91\x92a+\xD8\x82a+\xB0V[\x91a+\xE6`@Q\x93\x84a+\x8DV[\x82\x94\x81\x84R\x81\x83\x01\x11a\x1C\xC4W\x82\x81` \x93\x84_\x96\x017\x01\x01RV[\x90\x80`\x1F\x83\x01\x12\x15a\x1C\xC4W\x81` a,\x1D\x935\x91\x01a+\xCCV[\x90V[\x90`\x1F\x19`\x1F` \x80\x94\x80Q\x91\x82\x91\x82\x87R\x01\x86\x86\x01^_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[\x91\x90\x82\x03\x91\x82\x11a#ZWV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x16\x80\x15a-\x13Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x82\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x82\x16\x17\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0_\x80\xA3V[\x7F\x1EO\xBD\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R_`\x04R`$_\xFD[`@Q\x7F<\xAD\xF4I\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R` \x81`$\x81s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\xBEW[P` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x91`\x04`@Q\x80\x94\x81\x93\x7F\\\x97Z\xBB\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\x83W[P\x80\x15a.ZW\x90V[P`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x90V[\x90P` \x81=` \x11a.\xB6W[\x81a.\x9E` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x80\x15\x15\x81\x03a\x1C\xC4W_a.PV[=\x91Pa.\x91V[\x90P` \x81=` \x11a/\x06W[\x81a.\xD9` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x81\x03a\x1C\xC4W` a-\xFAV[=\x91Pa.\xCCV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x163\x03a/NWV[\x7F\x11\x8C\xDA\xA7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R3`\x04R`$_\xFD[`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16a/\xA5WV[\x7F\xD9<\x06e\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x81`\x05\x1B6\x03\x83\x13a\x1C\xC4WV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x05\x1B` \x01\x90V[\x90a0C\x82a0!V[a0P`@Q\x91\x82a+\x8DV[\x82\x81R`\x1F\x19a0`\x82\x94a0!V[\x01\x90` 6\x91\x017V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFFa\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`2`\x04R`$_\xFD[\x80Q\x82\x10\x15a0\xAAW` \x91`\x05\x1B\x01\x01\x90V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x81\x10\x15a0\xAAW\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03_R` _ \x01\x90_\x90V[\x80T\x82\x10\x15a0\xAAW_R` _ \x01\x90_\x90V[`@Q\x90a1c\x82a+DV[_` \x83\x82\x81R\x01RV[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90\x82\x10\x15a0\xAAWa,\x1D\x91`\x05\x1B\x81\x01\x90a1nV[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xA1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90` \x80\x83Q\x92\x83\x81R\x01\x92\x01\x90_[\x81\x81\x10a2\x15WPPP\x90V[\x82Q\x84R` \x93\x84\x01\x93\x90\x92\x01\x91`\x01\x01a2\x08V[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x816\x03\x83\x13a\x1C\xC4WV[`\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`@\x1C\x16\x15a2\xABWV[\x7F\xD7\xE6\xBC\xF8\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01a1AV[_\x19\x82\x93\x92T\x91`\x03\x1B\x92\x83\x1B\x92\x1B\x19\x16\x17\x90UV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x80Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`Wa3V\x91`\x01\x82\x01\x81Ua1AV[\x90_\x80\x91` \x81Q\x91\x01\x84Z\xF4\x80\x80a4\xC5W[\x15a4EWPP`@Q=\x81R=_` \x83\x01>` =\x82\x01\x01`@R\x90V[\x15a4\x8CWs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x90\x7F\x99\x96\xB3\x15\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R\x16`\x04R`$_\xFD[=\x15a4\x9DW`@Q=_\x82>=\x90\xFD[\x7F\xD6\xBD\xA2u\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[P=\x15\x15\x80a4%WP\x81;\x15\x15a4%V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90`@\x81\x01a5'\x81\x83a/\xCDV[\x92\x90P_[\x83\x81\x10a5:WPPPPPV[a5[a5Q\x82a5K\x86\x86a/\xCDV[\x90a4\xD8V[` \x81\x01\x90a2+V[\x81\x01``\x82\x82\x03\x12a\x1C\xC4W\x815\x91s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x16\x80\x93\x03a\x1C\xC4W` \x81\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4W\x82a5\xA8\x91\x83\x01a,\x02V[\x91`@\x82\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa5\xC7\x92\x01a,\x02V[\x90`@Q\x91\x7F3\xA8\x92\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x88`\x04\x84\x01R`@`$\x84\x01R_\x83\x80a6\x0C`D\x82\x01\x86a, V[\x03\x81\x83\x88Z\xF1\x92\x83\x15a\x1C\xB9W_\x93a6\xAFW[P\x82Q` \x84\x01 \x81Q` \x83\x01 \x03a6tWP`\x01\x93\x92\x91\x7F\xCD\xDB2z\xDB1\xFET7\xDF*\x8Ch0\x1B\xB1:k\xAA\xE42\xA8\x04\x83\x8C\xAA\xF6\x82Pj\xAD\xF1\x91a6k`@Q\x92\x83\x92\x83a?-V[\x03\x90\xA2\x01a5,V[\x90Pa6\xAB`@Q\x92\x83\x92\x7F\xC5\x04\xFA\xDA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84R`\x04\x84\x01a?-V[\x03\x90\xFD[\x90\x92P=\x80_\x83>a6\xC1\x81\x83a+\x8DV[\x81\x01\x90` \x81\x83\x03\x12a\x1C\xC4W\x80Q\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W\x01\x81`\x1F\x82\x01\x12\x15a\x1C\xC4W\x80Q\x90a6\xF8\x82a+\xB0V[\x92a7\x06`@Q\x94\x85a+\x8DV[\x82\x84R` \x83\x83\x01\x01\x11a\x1C\xC4W\x81_\x92` \x80\x93\x01\x83\x86\x01^\x83\x01\x01R\x91_a6 V[`\x1F\x82` \x94\x93`\x1F\x19\x93\x81\x86R\x86\x86\x017_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[`@\x90a,\x1D\x94\x92\x81R\x81` \x82\x01R\x01\x91a7+V[\x90a7m\x81\x80a/\xCDV[_[\x81\x81\x10a9\x17WPPPa7\x86` \x82\x01\x82a/\xCDV[_[\x81\x81\x10a8\xA8WPPPa7\x9F`@\x82\x01\x82a/\xCDV[_[\x81\x81\x10a89WPPP\x80``a7\xB9\x92\x01\x90a/\xCDV[\x90\x91_[\x82\x81\x10a7\xCAWPPPPV[a7\xD5\x81\x84\x86a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a7\xF0W[\x01a7\xBDV[\x82\x7F\xA4\x94\xDA\xC4\xB7\x18HCX?\x97.\x06x>,;\xB4\x7FO\x017\xB8\xDFR\xA8`\xDF\x07!\x9F\x8Ca8 a5Q\x84\x88\x8Aa4\xD8V[\x90a81`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a7\xEAV[a8D\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8_W[\x01a7\xA1V[\x85\x7F\x9Ca\xB2\x90\xF61\t\x7FV'<\xF4\xDA\xF4\r\xF1\xFF\x9C\xCC3\xF1\x01\xD4d\x83}\xA1\xF5\xAE\x18\xBDYa8\x8Fa5Q\x84\x87\x89a4\xD8V[\x90a8\xA0`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8YV[a8\xB3\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8\xCEW[\x01a7\x88V[\x85\x7FH$8s\xB4u-\xDC\xB4^\r{\x11\xC4\xC2fX>^\t\x9A\x0By\x8F\xDD\x9C\x1A\xF7\xD4\x93$\xF3a8\xFEa5Q\x84\x87\x89a4\xD8V[\x90a9\x0F`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8\xC8V[a9\"\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a9=W[\x01a7oV[\x85\x7F:\x13M\x01\xC0x\x03\0<c0\x17\x17\xDD\xC4a.lG\xAE@\x8E\xEE\xA3\",\xDE\xD52\xD0*\xE6a9ma5Q\x84\x87\x89a4\xD8V[\x90a9~`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a97V[\x80\x15\x80\x15a9\xD8W[\x80\x15a9\xD0W[\x80\x15a9\xC0W[a9\xBAWd\x01\0\0\x03\xD0\x19`\x07\x81\x80\x93\x81\x81\x80\t\t\x08\x91\x80\t\x14\x90V[PP_\x90V[Pd\x01\0\0\x03\xD0\x19\x82\x10\x15a9\x9DV[P\x81\x15a9\x96V[Pd\x01\0\0\x03\xD0\x19\x81\x10\x15a9\x8FV[\x90\x93\x92\x90\x91_\x90\x80\x84\x03a<aWPPd\x01\0\0\x03\xD0\x19_\x91\x85\x08a:\x11WPP\x90P_\x90_\x90V[d\x01\0\0\x03\xD0\x19\x80`\x01\x81\x80a:x\x81\x80\x80a:h\x9A\x81\x80\x8F\x80\t\x96\x87\x92\x81\x80\x80\x80\x80\x8F\x81\x81\x81\x92\t\x99\x87\t`\x04\t\x97\x80\t_\t\x92\x80\t`\x03\t\x08\x91\x81a:[\x81\x83\x80\x08\x82a,EV[\x81\x85\x80\t\x08\x9D\x8E\x83a,EV[\x90\x08\x90\t\x93\x80\t`\x08\t\x83a,EV[\x90\x08\x96\t`\x02\t\x93\x91\x90[\x84\x15\x15\x85\x81a<PW[P\x80a<HW[\x15a;\xEAW\x80\x94`\x01\x90d\x01\0\0\x03\xD0\x19\x91\x81\x84\x92[a:\xFEWPPPP\x80a:\xD1WP\x90d\x01\0\0\x03\xD0\x19\x80\x92\x81\x80\x87\x80\t\x80\x92\t\x95\t\x90\t\x90V[\x80\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`$\x92R`\x12`\x04R\xFD[\x92\x97\x91\x92\x80\x15a;\xBDW\x80\x89\x04\x91\x80\x94a;\x90Wd\x01\0\0\x03\xD0\x19\x90\x83\td\x01\0\0\x03\xD0\x19\x03d\x01\0\0\x03\xD0\x19\x81\x11a#ZWd\x01\0\0\x03\xD0\x19\x90\x86\x94\x08\x93\x98\x81\x92\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a;cW\x90a;Z\x91a,EV[\x90\x92\x90\x80a:\xAAV[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x11`\x04R\xFD[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x12`\x04R\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x12`\x04R`$_\xFD[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x0E`$\x82\x01R\x7FInvalid number\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`D\x82\x01R\xFD[P`\x01a:\x94V[d\x01\0\0\x03\xD0\x19\x91P\x14\x15_a:\x8DV[d\x01\0\0\x03\xD0\x19\x92\x91\x95a<t\x94a?RV[\x93\x90\x91\x90a:\x83V[\x80_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ T\x15_\x14a=-Wa<\xDA\x81\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0a3\xEFV[\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T\x90_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ U`\x01\x90V[P_\x90V[\x80_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15_\x14a=-Wa=\x8F\x81\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x90_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ U`\x01\x90V[\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nTa?)Wa>\x99\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nU`\x01\x90V[_\x90V[\x90\x91a?Da,\x1D\x93`@\x84R`@\x84\x01\x90a, V[\x91` \x81\x84\x03\x91\x01Ra, V[\x94\x92\x90\x93\x91\x85\x15\x80aAWW[aALW\x80\x15\x80aADW[aA<W`@Q`\x80\x91a?\x7F\x83\x83a+\x8DV[\x826\x837\x84\x15a;\xBDW\x84`\x01\x80\t\x80\x83R\x93\x85\x85`\x01\t\x98` \x84\x01\x99\x8AR`@\x84\x01\x92\x86\x84R\x87\x84Q`\x01\t\x93``\x86\x01\x94\x85R`@Q\x9A\x87\x8C\x01\x95\x8C\x87\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x88\x11\x17a+`W\x8A\x80\x97\x95\x81\x96\x94\x82\x95`@RQ\x90\t\x8DRQ\x90\t\x94` \x8B\x01\x95\x86RQ\x90\t\x98`@\x89\x01\x99\x8ARQ\x90\t``\x87\x01\x90\x81R\x86Q\x88Q\x14\x80\x15\x90aA0W[\x15a@\xD2W\x84\x92\x83\x80\x80\x93\x81`@Q\x9C\x85a@*\x8F\x97\x88a+\x8DV[6\x877Q\x8CQa@:\x90\x83a,EV[\x90\x08\x84RQ\x85Qa@K\x90\x83a,EV[\x90\x08\x98` \x83\x01\x99\x8AR\x81\x80\x8B\x81\x80\x80\x80\x89Q\x8AQ\x90\t\x93`@\x8A\x01\x94\x85R\x81\x85Q\x8BQ\x90\t``\x90\x9A\x01\x99\x8ARQ\x80\t\x88Qa@\x88\x90\x83a,EV[\x90\x08\x81\x80\x87Q\x85Q\x90\t`\x02\ta@\x9F\x90\x83a,EV[\x90\x08\x9CQ\x93Q\x90Q\x90\ta@\xB3\x8C\x83a,EV[\x90\x08\x90\t\x92Q\x90Q\x90\ta@\xC7\x90\x83a,EV[\x90\x08\x94Q\t\x91\x92\x91\x90V[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x1E`$\x82\x01R\x7FUse jacDouble function instead\0\0`D\x82\x01R\xFD[P\x81Q\x81Q\x14\x15a@\x0EV[PPP`\x01\x90V[P\x81\x15a?kV[\x94P\x92P`\x01\x91\x90PV[P\x84\x15a?_V[_\x90` \x92`@Q\x90\x84\x82\x01\x92\x83R`@\x82\x01R`@\x81RaA\x82``\x82a+\x8DV[`@Q\x91\x82\x91Q\x80\x91\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Q\x90V[\x81Q\x91\x90`A\x83\x03aA\xD2WaA\xCB\x92P` \x82\x01Q\x90```@\x84\x01Q\x93\x01Q_\x1A\x90aE\x16V[\x91\x92\x90\x91\x90V[PP_\x91`\x02\x91\x90V[`\x04\x81\x10\x15aB\x87W\x80aA\xEEWPPV[`\x01\x81\x03aB\x1EW\x7F\xF6E\xEE\xDF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`\x02\x81\x03aBRWP\x7F\xFC\xE6\x98\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[`\x03\x14aB\\WPV[\x7F\xD7\x8B\xCE\x0C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`!`\x04R`$_\xFD[aB\xBE\x81\x80a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aB\xF2\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aB\xFC\x82\x80a/\xCDV[aC\x05\x91aE\xA5V[\x91` \x81\x01\x90aC\x15\x82\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aCI\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x91aCT\x90\x82a/\xCDV[aC]\x91aE\xA5V[`@\x82\x01aCk\x81\x84a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\x9F\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x90aC\xAA\x90\x84a/\xCDV[aC\xB3\x91aE\xA5V[\x91``\x84\x01\x93aC\xC3\x85\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\xF7\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x94aD\x01\x91a/\xCDV[aD\n\x91aE\xA5V[\x94`@Q\x97\x88\x97`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16` \x89\x01R\x80Q` \x81\x92\x01`$\x8A\x01^\x87\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`$\x82\x01R\x81Q` \x81\x93\x01`(\x83\x01^\x01`$\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01`\x04\x81\x01_\x90R\x03`\x04\x01`\x1F\x19\x81\x01\x82Ra,\x1D\x90\x82a+\x8DV[\x91\x90\x7F\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF]WnsW\xA4P\x1D\xDF\xE9/Fh\x1B \xA0\x84\x11aE\x9AW\x91` \x93`\x80\x92`\xFF_\x95`@Q\x94\x85R\x16\x86\x84\x01R`@\x83\x01R``\x82\x01R\x82\x80R`\x01Z\xFA\x15a\x1C\xB9W_Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x15aE\x90W\x90_\x90_\x90V[P_\x90`\x01\x90_\x90V[PPP_\x91`\x03\x91\x90V[``\x92\x91_\x91[\x81\x83\x10aE\xB8WPPPV[\x90\x91\x93aE\xFFc\xFF\xFF\xFF\xFFaE\xD1a5Q\x88\x87\x87a4\xD8V[\x90P`\x02\x1C\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aF\ra5Q\x87\x86\x86a4\xD8V[aF\x1B\x88\x87\x87\x95\x94\x95a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x94` \x94\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x86\x84aF\xDF\x97`\x04\x97\x96aF\x84\x89\x98b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x95\x85`@Q\x9C\x89\x8E\x9AQ\x91\x82\x91\x01\x88\x8C\x01^\x89\x01\x93`\xE0\x1B\x16\x85\x84\x01R`$\x83\x017\x01\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x94\x01\x91\x90aE\xACV\xFE\xA1dsolcC\0\x08$\0\n",
-    );
     #[derive(serde::Serialize, serde::Deserialize)]
     #[derive()]
     /**```solidity
-struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes32 actionTreeRoot; }
+struct Action { Consumed[] consumed; Created[] created; Delta delta; bytes32 actionTreeRoot; }
 ```*/
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
@@ -2738,7 +866,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
             <Created as alloy::sol_types::SolType>::RustType,
         >,
         #[allow(missing_docs)]
-        pub delta: <Delta::Point as alloy::sol_types::SolType>::RustType,
+        pub delta: <Delta as alloy::sol_types::SolType>::RustType,
         #[allow(missing_docs)]
         pub actionTreeRoot: alloy::sol_types::private::FixedBytes<32>,
     }
@@ -2755,7 +883,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
         type UnderlyingSolTuple<'a> = (
             alloy::sol_types::sol_data::Array<Consumed>,
             alloy::sol_types::sol_data::Array<Created>,
-            Delta::Point,
+            Delta,
             alloy::sol_types::sol_data::FixedBytes<32>,
         );
         #[doc(hidden)]
@@ -2766,7 +894,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
             alloy::sol_types::private::Vec<
                 <Created as alloy::sol_types::SolType>::RustType,
             >,
-            <Delta::Point as alloy::sol_types::SolType>::RustType,
+            <Delta as alloy::sol_types::SolType>::RustType,
             alloy::sol_types::private::FixedBytes<32>,
         );
         #[cfg(test)]
@@ -2814,7 +942,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                     <alloy::sol_types::sol_data::Array<
                         Created,
                     > as alloy_sol_types::SolType>::tokenize(&self.created),
-                    <Delta::Point as alloy_sol_types::SolType>::tokenize(&self.delta),
+                    <Delta as alloy_sol_types::SolType>::tokenize(&self.delta),
                     <alloy::sol_types::sol_data::FixedBytes<
                         32,
                     > as alloy_sol_types::SolType>::tokenize(&self.actionTreeRoot),
@@ -2892,7 +1020,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
             #[inline]
             fn eip712_root_type() -> alloy_sol_types::private::Cow<'static, str> {
                 alloy_sol_types::private::Cow::Borrowed(
-                    "Action(Consumed[] consumed,Created[] created,Point delta,bytes32 actionTreeRoot)",
+                    "Action(Consumed[] consumed,Created[] created,Delta delta,bytes32 actionTreeRoot)",
                 )
             }
             #[inline]
@@ -2913,13 +1041,9 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                         <Created as alloy_sol_types::SolStruct>::eip712_components(),
                     );
                 components
-                    .push(
-                        <Delta::Point as alloy_sol_types::SolStruct>::eip712_root_type(),
-                    );
+                    .push(<Delta as alloy_sol_types::SolStruct>::eip712_root_type());
                 components
-                    .extend(
-                        <Delta::Point as alloy_sol_types::SolStruct>::eip712_components(),
-                    );
+                    .extend(<Delta as alloy_sol_types::SolStruct>::eip712_components());
                 components
             }
             #[inline]
@@ -2933,10 +1057,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                         Created,
                     > as alloy_sol_types::SolType>::eip712_data_word(&self.created)
                         .0,
-                    <Delta::Point as alloy_sol_types::SolType>::eip712_data_word(
-                            &self.delta,
-                        )
-                        .0,
+                    <Delta as alloy_sol_types::SolType>::eip712_data_word(&self.delta).0,
                     <alloy::sol_types::sol_data::FixedBytes<
                         32,
                     > as alloy_sol_types::SolType>::eip712_data_word(
@@ -2962,7 +1083,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                     > as alloy_sol_types::EventTopic>::topic_preimage_length(
                         &rust.created,
                     )
-                    + <Delta::Point as alloy_sol_types::EventTopic>::topic_preimage_length(
+                    + <Delta as alloy_sol_types::EventTopic>::topic_preimage_length(
                         &rust.delta,
                     )
                     + <alloy::sol_types::sol_data::FixedBytes<
@@ -2991,7 +1112,7 @@ struct Action { Consumed[] consumed; Created[] created; Delta.Point delta; bytes
                     &rust.created,
                     out,
                 );
-                <Delta::Point as alloy_sol_types::EventTopic>::encode_topic_preimage(
+                <Delta as alloy_sol_types::EventTopic>::encode_topic_preimage(
                     &rust.delta,
                     out,
                 );
@@ -3550,6 +1671,220 @@ struct Created { bytes32 commitment; bytes32 logicRef; Logic.AppData appData; }
         }
     };
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(Default, Debug, PartialEq, Eq, Hash)]
+    /**```solidity
+struct Delta { uint256 x; uint256 y; }
+```*/
+    #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
+    #[derive(Clone)]
+    pub struct Delta {
+        #[allow(missing_docs)]
+        pub x: alloy::sol_types::private::primitives::aliases::U256,
+        #[allow(missing_docs)]
+        pub y: alloy::sol_types::private::primitives::aliases::U256,
+    }
+    #[allow(
+        non_camel_case_types,
+        non_snake_case,
+        clippy::pub_underscore_fields,
+        clippy::style
+    )]
+    const _: () = {
+        use alloy::sol_types as alloy_sol_types;
+        #[doc(hidden)]
+        #[allow(dead_code)]
+        type UnderlyingSolTuple<'a> = (
+            alloy::sol_types::sol_data::Uint<256>,
+            alloy::sol_types::sol_data::Uint<256>,
+        );
+        #[doc(hidden)]
+        type UnderlyingRustTuple<'a> = (
+            alloy::sol_types::private::primitives::aliases::U256,
+            alloy::sol_types::private::primitives::aliases::U256,
+        );
+        #[cfg(test)]
+        #[allow(dead_code, unreachable_patterns)]
+        fn _type_assertion(
+            _t: alloy_sol_types::private::AssertTypeEq<UnderlyingRustTuple>,
+        ) {
+            match _t {
+                alloy_sol_types::private::AssertTypeEq::<
+                    <UnderlyingSolTuple as alloy_sol_types::SolType>::RustType,
+                >(_) => {}
+            }
+        }
+        #[automatically_derived]
+        #[doc(hidden)]
+        impl ::core::convert::From<Delta> for UnderlyingRustTuple<'_> {
+            fn from(value: Delta) -> Self {
+                (value.x, value.y)
+            }
+        }
+        #[automatically_derived]
+        #[doc(hidden)]
+        impl ::core::convert::From<UnderlyingRustTuple<'_>> for Delta {
+            fn from(tuple: UnderlyingRustTuple<'_>) -> Self {
+                Self { x: tuple.0, y: tuple.1 }
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::SolValue for Delta {
+            type SolType = Self;
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::private::SolTypeValue<Self> for Delta {
+            #[inline]
+            fn stv_to_tokens(&self) -> <Self as alloy_sol_types::SolType>::Token<'_> {
+                (
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::tokenize(&self.x),
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::tokenize(&self.y),
+                )
+            }
+            #[inline]
+            fn stv_abi_encoded_size(&self) -> usize {
+                if let Some(size) = <Self as alloy_sol_types::SolType>::ENCODED_SIZE {
+                    return size;
+                }
+                let tuple = <UnderlyingRustTuple<
+                    '_,
+                > as ::core::convert::From<Self>>::from(self.clone());
+                <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::abi_encoded_size(&tuple)
+            }
+            #[inline]
+            fn stv_eip712_data_word(&self) -> alloy_sol_types::Word {
+                <Self as alloy_sol_types::SolStruct>::eip712_hash_struct(self)
+            }
+            #[inline]
+            fn stv_abi_encode_packed_to(
+                &self,
+                out: &mut alloy_sol_types::private::Vec<u8>,
+            ) {
+                let tuple = <UnderlyingRustTuple<
+                    '_,
+                > as ::core::convert::From<Self>>::from(self.clone());
+                <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::abi_encode_packed_to(&tuple, out)
+            }
+            #[inline]
+            fn stv_abi_packed_encoded_size(&self) -> usize {
+                if let Some(size) = <Self as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE {
+                    return size;
+                }
+                let tuple = <UnderlyingRustTuple<
+                    '_,
+                > as ::core::convert::From<Self>>::from(self.clone());
+                <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::abi_packed_encoded_size(&tuple)
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::SolType for Delta {
+            type RustType = Self;
+            type Token<'a> = <UnderlyingSolTuple<
+                'a,
+            > as alloy_sol_types::SolType>::Token<'a>;
+            const SOL_NAME: &'static str = <Self as alloy_sol_types::SolStruct>::NAME;
+            const ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
+                '_,
+            > as alloy_sol_types::SolType>::ENCODED_SIZE;
+            const PACKED_ENCODED_SIZE: Option<usize> = <UnderlyingSolTuple<
+                '_,
+            > as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE;
+            #[inline]
+            fn valid_token(token: &Self::Token<'_>) -> bool {
+                <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::valid_token(token)
+            }
+            #[inline]
+            fn detokenize(token: Self::Token<'_>) -> Self::RustType {
+                let tuple = <UnderlyingSolTuple<
+                    '_,
+                > as alloy_sol_types::SolType>::detokenize(token);
+                <Self as ::core::convert::From<UnderlyingRustTuple<'_>>>::from(tuple)
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::SolStruct for Delta {
+            const NAME: &'static str = "Delta";
+            #[inline]
+            fn eip712_root_type() -> alloy_sol_types::private::Cow<'static, str> {
+                alloy_sol_types::private::Cow::Borrowed("Delta(uint256 x,uint256 y)")
+            }
+            #[inline]
+            fn eip712_components() -> alloy_sol_types::private::Vec<
+                alloy_sol_types::private::Cow<'static, str>,
+            > {
+                alloy_sol_types::private::Vec::new()
+            }
+            #[inline]
+            fn eip712_encode_type() -> alloy_sol_types::private::Cow<'static, str> {
+                <Self as alloy_sol_types::SolStruct>::eip712_root_type()
+            }
+            #[inline]
+            fn eip712_encode_data(&self) -> alloy_sol_types::private::Vec<u8> {
+                [
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::eip712_data_word(&self.x)
+                        .0,
+                    <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::SolType>::eip712_data_word(&self.y)
+                        .0,
+                ]
+                    .concat()
+            }
+        }
+        #[automatically_derived]
+        impl alloy_sol_types::EventTopic for Delta {
+            #[inline]
+            fn topic_preimage_length(rust: &Self::RustType) -> usize {
+                0usize
+                    + <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.x)
+                    + <alloy::sol_types::sol_data::Uint<
+                        256,
+                    > as alloy_sol_types::EventTopic>::topic_preimage_length(&rust.y)
+            }
+            #[inline]
+            fn encode_topic_preimage(
+                rust: &Self::RustType,
+                out: &mut alloy_sol_types::private::Vec<u8>,
+            ) {
+                out.reserve(
+                    <Self as alloy_sol_types::EventTopic>::topic_preimage_length(rust),
+                );
+                <alloy::sol_types::sol_data::Uint<
+                    256,
+                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.x, out);
+                <alloy::sol_types::sol_data::Uint<
+                    256,
+                > as alloy_sol_types::EventTopic>::encode_topic_preimage(&rust.y, out);
+            }
+            #[inline]
+            fn encode_topic(
+                rust: &Self::RustType,
+            ) -> alloy_sol_types::abi::token::WordToken {
+                let mut out = alloy_sol_types::private::Vec::new();
+                <Self as alloy_sol_types::EventTopic>::encode_topic_preimage(
+                    rust,
+                    &mut out,
+                );
+                alloy_sol_types::abi::token::WordToken(
+                    alloy_sol_types::private::keccak256(out),
+                )
+            }
+        }
+    };
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[derive()]
     /**```solidity
 struct Transaction { Action[] actions; bytes deltaProof; bytes aggregationProof; }
@@ -3798,6 +2133,1667 @@ struct Transaction { Action[] actions; bytes deltaProof; bytes aggregationProof;
             }
         }
     };
+    use alloy::contract as alloy_contract;
+    /**Creates a new wrapper around an on-chain [`Types`](self) contract instance.
+
+See the [wrapper's documentation](`TypesInstance`) for more details.*/
+    #[inline]
+    pub const fn new<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    >(address: alloy_sol_types::private::Address, __provider: P) -> TypesInstance<P, N> {
+        TypesInstance::<P, N>::new(address, __provider)
+    }
+    /**A [`Types`](self) instance.
+
+Contains type-safe methods for interacting with an on-chain instance of the
+[`Types`](self) contract located at a given `address`, using a given
+provider `P`.
+
+If the contract bytecode is available (see the [`sol!`](alloy_sol_types::sol!)
+documentation on how to provide it), the `deploy` and `deploy_builder` methods can
+be used to deploy a new instance of the contract.
+
+See the [module-level documentation](self) for all the available methods.*/
+    #[derive(Clone)]
+    pub struct TypesInstance<P, N = alloy_contract::private::Ethereum> {
+        address: alloy_sol_types::private::Address,
+        provider: P,
+        _network: ::core::marker::PhantomData<N>,
+    }
+    #[automatically_derived]
+    impl<P, N> ::core::fmt::Debug for TypesInstance<P, N> {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+            f.debug_tuple("TypesInstance").field(&self.address).finish()
+        }
+    }
+    /// Instantiation and getters/setters.
+    impl<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    > TypesInstance<P, N> {
+        /**Creates a new wrapper around an on-chain [`Types`](self) contract instance.
+
+See the [wrapper's documentation](`TypesInstance`) for more details.*/
+        #[inline]
+        pub const fn new(
+            address: alloy_sol_types::private::Address,
+            __provider: P,
+        ) -> Self {
+            Self {
+                address,
+                provider: __provider,
+                _network: ::core::marker::PhantomData,
+            }
+        }
+        /// Returns a reference to the address.
+        #[inline]
+        pub const fn address(&self) -> &alloy_sol_types::private::Address {
+            &self.address
+        }
+        /// Sets the address.
+        #[inline]
+        pub fn set_address(&mut self, address: alloy_sol_types::private::Address) {
+            self.address = address;
+        }
+        /// Sets the address and returns `self`.
+        pub fn at(mut self, address: alloy_sol_types::private::Address) -> Self {
+            self.set_address(address);
+            self
+        }
+        /// Returns a reference to the provider.
+        #[inline]
+        pub const fn provider(&self) -> &P {
+            &self.provider
+        }
+    }
+    impl<P: ::core::clone::Clone, N> TypesInstance<&P, N> {
+        /// Clones the provider and returns a new instance with the cloned provider.
+        #[inline]
+        pub fn with_cloned_provider(self) -> TypesInstance<P, N> {
+            TypesInstance {
+                address: self.address,
+                provider: ::core::clone::Clone::clone(&self.provider),
+                _network: ::core::marker::PhantomData,
+            }
+        }
+    }
+    /// Function calls.
+    impl<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    > TypesInstance<P, N> {
+        /// Creates a new call builder using this contract instance's provider and address.
+        ///
+        /// Note that the call can be any function call, not just those defined in this
+        /// contract. Prefer using the other methods for building type-safe contract calls.
+        pub fn call_builder<C: alloy_sol_types::SolCall>(
+            &self,
+            call: &C,
+        ) -> alloy_contract::SolCallBuilder<&P, C, N> {
+            alloy_contract::SolCallBuilder::new_sol(&self.provider, &self.address, call)
+        }
+    }
+    /// Event filters.
+    impl<
+        P: alloy_contract::private::Provider<N>,
+        N: alloy_contract::private::Network,
+    > TypesInstance<P, N> {
+        /// Creates a new event filter using this contract instance's provider and address.
+        ///
+        /// Note that the type can be any event, not just those defined in this contract.
+        /// Prefer using the other methods for building type-safe event filters.
+        pub fn event_filter<E: alloy_sol_types::SolEvent>(
+            &self,
+        ) -> alloy_contract::Event<&P, E, N> {
+            alloy_contract::Event::new_sol(&self.provider, &self.address)
+        }
+    }
+}
+/**
+
+Generated by the following Solidity interface...
+```solidity
+library Logic {
+    type DeletionCriterion is uint8;
+    struct AppData {
+        ExpirableBlob[] resourcePayload;
+        ExpirableBlob[] discoveryPayload;
+        ExpirableBlob[] externalPayload;
+        ExpirableBlob[] applicationPayload;
+    }
+    struct ExpirableBlob {
+        DeletionCriterion deletionCriterion;
+        bytes blob;
+    }
+}
+
+library Types {
+    struct Action {
+        Consumed[] consumed;
+        Created[] created;
+        Delta delta;
+        bytes32 actionTreeRoot;
+    }
+    struct Consumed {
+        bytes32 nullifier;
+        bytes32 logicRef;
+        bytes32 commitmentTreeRoot;
+        Logic.AppData appData;
+    }
+    struct Created {
+        bytes32 commitment;
+        bytes32 logicRef;
+        Logic.AppData appData;
+    }
+    struct Delta {
+        uint256 x;
+        uint256 y;
+    }
+    struct Transaction {
+        Action[] actions;
+        bytes deltaProof;
+        bytes aggregationProof;
+    }
+}
+
+interface ProtocolAdapter {
+    error AddressEmptyCode(address target);
+    error DeltaMismatch(address expected, address actual);
+    error ECDSAInvalidSignature();
+    error ECDSAInvalidSignatureLength(uint256 length);
+    error ECDSAInvalidSignatureS(bytes32 s);
+    error ERC1967InvalidImplementation(address implementation);
+    error ERC1967NonPayable();
+    error EmptyTransactionNotAllowed();
+    error EnforcedPause();
+    error ExpectedPause();
+    error FailedCall();
+    error ForwarderCallOutputMismatch(bytes expected, bytes actual);
+    error InvalidInitialization();
+    error NonExistingRoot(bytes32 root);
+    error NotInitializing();
+    error OwnableInvalidOwner(address owner);
+    error OwnableUnauthorizedAccount(address account);
+    error PointNotOnCurve(Types.Delta point);
+    error PreExistingNullifier(bytes32 nullifier);
+    error PreExistingRoot(bytes32 root);
+    error ReentrancyGuardReentrantCall();
+    error RiscZeroVerifierSelectorMismatch(bytes4 expected, bytes4 actual);
+    error RiscZeroVerifierStopped();
+    error Simulated(uint256 gasUsed);
+    error UUPSUnauthorizedCallContext();
+    error UUPSUnsupportedProxiableUUID(bytes32 slot);
+    error ZeroKindTableCommitmentNotAllowed();
+    error ZeroRiscZeroVerifierRouterNotAllowed();
+    error ZeroRiscZeroVerifierSelectorNotAllowed();
+
+    event ActionExecuted(bytes32 actionTreeRoot, bytes32[] nullifiers, bytes32[] consumedLogicRefs, bytes32[] commitments, bytes32[] createdLogicRefs);
+    event ApplicationPayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event CommitmentTreeRootAdded(bytes32 root);
+    event DiscoveryPayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event ExternalPayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event ForwarderCallExecuted(address indexed untrustedForwarder, bytes input, bytes output);
+    event Initialized(uint64 version);
+    event KindTableCommitmentUpdated(bytes32 indexed kindTableCommitment);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event Paused(address account);
+    event ResourcePayload(bytes32 indexed tag, uint256 index, bytes blob);
+    event TransactionExecuted(bytes32 indexed transactionId);
+    event Unpaused(address account);
+    event Upgraded(address indexed implementation);
+
+    constructor(address riscZeroVerifierRouter, bytes4 riscZeroVerifierSelector);
+
+    function UPGRADE_INTERFACE_VERSION() external view returns (string memory);
+    function commitmentCount() external view returns (uint256 count);
+    function commitmentTreeCapacity() external view returns (uint256 capacity);
+    function commitmentTreeDepth() external view returns (uint8 depth);
+    function commitmentTreeRootAtIndex(uint256 index) external view returns (bytes32 root);
+    function commitmentTreeRootCount() external view returns (uint256 count);
+    function emergencyStop() external;
+    function execute(Types.Transaction memory transaction) external;
+    function getKindTableCommitment() external view returns (bytes32 kindTableCommitment);
+    function getRiscZeroVerifierRouter() external view returns (address verifierRouter);
+    function getRiscZeroVerifierSelector() external view returns (bytes4 verifierSelector);
+    function getVersion() external pure returns (bytes32 version);
+    function initialize(address initialOwner) external;
+    function isCommitmentTreeRootContained(bytes32 root) external view returns (bool isContained);
+    function isEmergencyStopped() external view returns (bool isStopped);
+    function isNullifierContained(bytes32 nullifier) external view returns (bool isContained);
+    function latestCommitmentTreeRoot() external view returns (bytes32 root);
+    function nullifierAtIndex(uint256 index) external view returns (bytes32 nullifier);
+    function nullifierCount() external view returns (uint256 count);
+    function owner() external view returns (address);
+    function paused() external view returns (bool);
+    function proxiableUUID() external view returns (bytes32);
+    function renounceOwnership() external;
+    function setKindTableCommitment(bytes32 newKindTableCommitment) external;
+    function simulateExecute(Types.Transaction memory transaction, bool skipRiscZeroProofVerification) external;
+    function transferOwnership(address newOwner) external;
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable;
+}
+```
+
+...which was generated by the following JSON ABI:
+```json
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "riscZeroVerifierRouter",
+        "type": "address",
+        "internalType": "contract RiscZeroVerifierRouter"
+      },
+      {
+        "name": "riscZeroVerifierSelector",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "commitmentCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "commitmentTreeCapacity",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "capacity",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "commitmentTreeDepth",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "depth",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "commitmentTreeRootAtIndex",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "root",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "commitmentTreeRootCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "emergencyStop",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "execute",
+    "inputs": [
+      {
+        "name": "transaction",
+        "type": "tuple",
+        "internalType": "struct Types.Transaction",
+        "components": [
+          {
+            "name": "actions",
+            "type": "tuple[]",
+            "internalType": "struct Types.Action[]",
+            "components": [
+              {
+                "name": "consumed",
+                "type": "tuple[]",
+                "internalType": "struct Types.Consumed[]",
+                "components": [
+                  {
+                    "name": "nullifier",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "commitmentTreeRoot",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "created",
+                "type": "tuple[]",
+                "internalType": "struct Types.Created[]",
+                "components": [
+                  {
+                    "name": "commitment",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "delta",
+                "type": "tuple",
+                "internalType": "struct Types.Delta",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "actionTreeRoot",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "deltaProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "aggregationProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getKindTableCommitment",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "kindTableCommitment",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRiscZeroVerifierRouter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "verifierRouter",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRiscZeroVerifierSelector",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "verifierSelector",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getVersion",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "version",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "initialOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isCommitmentTreeRootContained",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isContained",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isEmergencyStopped",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "isStopped",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isNullifierContained",
+    "inputs": [
+      {
+        "name": "nullifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isContained",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestCommitmentTreeRoot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "root",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nullifierAtIndex",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nullifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nullifierCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setKindTableCommitment",
+    "inputs": [
+      {
+        "name": "newKindTableCommitment",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "simulateExecute",
+    "inputs": [
+      {
+        "name": "transaction",
+        "type": "tuple",
+        "internalType": "struct Types.Transaction",
+        "components": [
+          {
+            "name": "actions",
+            "type": "tuple[]",
+            "internalType": "struct Types.Action[]",
+            "components": [
+              {
+                "name": "consumed",
+                "type": "tuple[]",
+                "internalType": "struct Types.Consumed[]",
+                "components": [
+                  {
+                    "name": "nullifier",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "commitmentTreeRoot",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "created",
+                "type": "tuple[]",
+                "internalType": "struct Types.Created[]",
+                "components": [
+                  {
+                    "name": "commitment",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "logicRef",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "appData",
+                    "type": "tuple",
+                    "internalType": "struct Logic.AppData",
+                    "components": [
+                      {
+                        "name": "resourcePayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "discoveryPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "externalPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "applicationPayload",
+                        "type": "tuple[]",
+                        "internalType": "struct Logic.ExpirableBlob[]",
+                        "components": [
+                          {
+                            "name": "deletionCriterion",
+                            "type": "uint8",
+                            "internalType": "enum Logic.DeletionCriterion"
+                          },
+                          {
+                            "name": "blob",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "delta",
+                "type": "tuple",
+                "internalType": "struct Types.Delta",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "actionTreeRoot",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "deltaProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "aggregationProof",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "skipRiscZeroProofVerification",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "ActionExecuted",
+    "inputs": [
+      {
+        "name": "actionTreeRoot",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nullifiers",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "consumedLogicRefs",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "commitments",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "createdLogicRefs",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApplicationPayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CommitmentTreeRootAdded",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DiscoveryPayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExternalPayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ForwarderCallExecuted",
+    "inputs": [
+      {
+        "name": "untrustedForwarder",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "input",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "output",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "KindTableCommitmentUpdated",
+    "inputs": [
+      {
+        "name": "kindTableCommitment",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcePayload",
+    "inputs": [
+      {
+        "name": "tag",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blob",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TransactionExecuted",
+    "inputs": [
+      {
+        "name": "transactionId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DeltaMismatch",
+    "inputs": [
+      {
+        "name": "expected",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "actual",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureLength",
+    "inputs": [
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureS",
+    "inputs": [
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyTransactionNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EnforcedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ExpectedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ForwarderCallOutputMismatch",
+    "inputs": [
+      {
+        "name": "expected",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "actual",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NonExistingRoot",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "PointNotOnCurve",
+    "inputs": [
+      {
+        "name": "point",
+        "type": "tuple",
+        "internalType": "struct Types.Delta",
+        "components": [
+          {
+            "name": "x",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "y",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "PreExistingNullifier",
+    "inputs": [
+      {
+        "name": "nullifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "PreExistingRoot",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RiscZeroVerifierSelectorMismatch",
+    "inputs": [
+      {
+        "name": "expected",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      },
+      {
+        "name": "actual",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RiscZeroVerifierStopped",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Simulated",
+    "inputs": [
+      {
+        "name": "gasUsed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroKindTableCommitmentNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRiscZeroVerifierRouterNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRiscZeroVerifierSelectorNotAllowed",
+    "inputs": []
+  }
+]
+```*/
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    clippy::pub_underscore_fields,
+    clippy::style,
+    clippy::empty_structs_with_brackets
+)]
+pub mod ProtocolAdapter {
+    use super::*;
+    use alloy::sol_types as alloy_sol_types;
+    /// The creation / init bytecode of the contract.
+    ///
+    /// ```text
+    ///0x60e03461010e57601f6148d238819003918201601f19168301916001600160401b0383118484101761011257808492604094855283398101031261010e5780516001600160a01b0381169182820361010e5760200151916001600160e01b031983169081840361010e5730608052610075610126565b61007d610126565b156100ff57156100f05760a05260c052610095610126565b6040516146f590816101bd8239608051818181612747015261280b015260a051818181610e9501528181611b36015281816126c00152612dca015260c05181818161026001528181610d4901528181611af60152612d880152f35b63b1b25aaf60e01b5f5260045ffd5b63536c150160e11b5f5260045ffd5b5f80fd5b634e487b7160e01b5f52604160045260245ffd5b5f5160206148b25f395f51905f525460ff8160401c166101ad576002600160401b03196001600160401b0382160161015b5750565b6001600160401b0319166001600160401b039081175f5160206148b25f395f51905f52556040519081527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d290602090a1565b63f92ee8a960e01b5f5260045ffdfe60e0806040526004361015610012575f80fd5b5f60c0525f3560e01c9081630d8e6e2c14612ae95750806331ee624214612acb57806340f34d4214612a8f5780634f1ef286146127bf57806352d1902d1461272057806359ba9258146126e45780635b666b1e146126945780635c975abb1461265357806363a599a414612596578063715018a6146124da57806373ab99161461186757806387093eba14610a7c5780638da5cb5b14610a285780639ad91d4c14610977578063a06056f714610936578063ad3cb1cc146108d0578063bdeb442d14610846578063c0253023146107a7578063c1b0bed714610754578063c44956d114610716578063c4d66de8146102cd578063c879dbe414610284578063e33845cf14610226578063f2fde38b146101f7578063fddd4837146101d1578063fe18ab911461018d5763ffc33f7214610149575f80fd5b346101875760c0516003193601126101875760207f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054604051908152f35b60c05180fd5b346101875760c051600319360112610187576020600160ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b604051908152f35b346101875760c0516003193601126101875760206101ed612d3f565b6040519015158152f35b3461018757602060031936011261018757610220610213612b21565b61021b612f0e565b612c52565b60c05180f35b346101875760c0516003193601126101875760206040517fffffffff000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000168152f35b346101875760206003193601126101875760206101ed6004355f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b34610187576020600319360112610187576102e6612b21565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460ff8160401c16159167ffffffffffffffff82168015908161070e575b6001149081610704575b1590816106fb575b506106cf57818360017fffffffffffffffffffffffffffffffffffffffffffffffff000000000000000061039f9516177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005561067a575b5061039761327c565b61021b61327c565b6103a761327c565b6103af61327c565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90254680100000000000000008110156106495780600161043292017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b81549060031b905f197fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b06831b921b191617905560c0517f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055610492613de2565b507f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d260206040517fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b068152a16104e561327c565b7fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a2610579612d3f565b61061d576105875760c05180f35b7fffffffffffffffffffffffffffffffffffffffffffffff00ffffffffffffffff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054167ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00557fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2602060405160018152a1610220565b7f0b1d38a30000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526041600452602460c051fd5b7fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000001668010000000000000001177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00558361038e565b7ff92ee8a90000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b90501584610337565b303b15915061032f565b849150610325565b346101875760c0516003193601126101875760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054604051908152f35b346101875760206003193601126101875760c0515060043560c051527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc016020526020604060c05120541515604051908152f35b34610187576020600319360112610187576004356107c3612f0e565b801561081a57807f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a260c05180f35b7f774d5de10000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b346101875760c051600319360112610187577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903545f19810190811161089f576108906020916130eb565b90549060031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526011600452602460c051fd5b346101875760c0516003193601126101875760408051610932916108f49082612b8d565b600581527f352e302e300000000000000000000000000000000000000000000000000000006020820152604051918291602083526020830190612c20565b0390f35b346101875760c05160031936011261018757602060ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416604051908152f35b34610187576020600319360112610187577f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054600435908110156109f7576020907f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0060c051528160c051200160c051505460c05160031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526032600452602460c051fd5b346101875760c05160031936011261018757602073ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c1993005416604051908152f35b346101875760406003193601126101875767ffffffffffffffff6004351161018757606060031960043536030112610187576024358015158103610187575a6080527f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c61183b5760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610b10612f7a565b610b1e600480350180612fcd565b809291501561180f57610b3082613039565b610b38613156565b50604051610b4581612b44565b60c051815260c05160208201529260c05160a05260c0515b8181106112c9575050806020610ba5925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b3691612bcc565b856141a2565b909391936141dc565b602081519101519060c0515260205273ffffffffffffffffffffffffffffffffffffffff80604060c05120169116908082036112975750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054610c0d600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000610c6363ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152610caa606482612b8d565b60c051915b808310610f995750602080925060405191805191829101835e81019060c05182528060c05192039060025afa15610f5a5760c05151610cf860446004350160043560040161322b565b909281600411610187577fffffffff000000000000000000000000000000000000000000000000000000008435167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203610f6757505015610e7e575b50505060a051610e0b575b7f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610ddc5a608051612c45565b7f6f1498310000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b610e1660a051613d32565b15610e4c577f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d2602060405160a0518152a1610d83565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c0515260a051600452602460c051fd5b73ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b1561018757610ef96040519485937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b927f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e60248401526044830152818060c0519403915afa8015610f5a57610f41575b8080610d78565b60c051610f4d91612b8d565b60c0516101875781610f3a565b6040513d60c051823e3d90fd5b7f78a2221c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b90610fb283610fac600480350180612fcd565b9061306a565b610fbc8180612fcd565b919050610ff163ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b1660208201526004815261102e602482612b8d565b9160c051905b808210611213575050602081019160206110f36004826110548787612fcd565b95905061108963ffffffff871662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519683889451918291018686015e83019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b9260c051915b8083106111915750505060019260208093611188936111526060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e8401908382019060c0518252519283915e010160c051815203601f198101835282612b8d565b92019190610caf565b909193602061120a604060019383806111b48b6111ae8b8d612fcd565b906131b8565b6111c86111c38683018361316e565b6142b4565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e010160c051838201520301601f198101835282612b8d565b940191906110f9565b9092602061128f606060019383806112358a61122f8b80612fcd565b906131a1565b6112446111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e010160c051838201520301601f198101835282612b8d565b930190611034565b7fe6d44b4c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b6112db81610fac600480350180612fcd565b60c051909590866112ec8180612fcd565b90506112f781613039565b61130082613039565b9160c0515b81811061170d57505061131b6020840184612fcd565b92905061132783613039565b9161133184613039565b9360c051905b8082106114af575050926113ab7f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc32959361139d6113b99461138f608098604051998a990135895260a060208a015260a08901906131f8565b9087820360408901526131f8565b9085820360608701526131f8565b9083820360808501526131f8565b0390a1806114a6575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0873603011261018757604051906113fc82612b44565b6040870135825260208201606088013581526040519261141b84612b44565b5f84525f60208501526114318151835190613986565b1561146e578260019594926114539260206080965193015190519151926139e8565b6020830152815296013561146782866130d7565b5201610b5d565b604491604051917fb8a0e8a1000000000000000000000000000000000000000000000000000000008352516004830152516024820152fd5b60a052866113c2565b9192939495819750906111ae8260206114c9940190612fcd565b9560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154167f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900545f19811461089f57600181017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900559088359160c0515b82811061165257505090600192917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b146115f9575b50976020810135906115d66115cf604083016115c96115c3828661316e565b86613518565b8361316e565b8235613762565b356115e183896130d7565b526115ec82896130d7565b52018c9594939291611337565b61164761164061164c9261160c856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c05152602060c051200154809461415f565b928061415f565b61336c565b8f6115a4565b90926001908185166116d0576116c5907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c051528084602060c0512001557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c0515283602060c0512001549061415f565b935b811c9101611547565b611707907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c0515283602060c05120015461415f565b936116c7565b909192938161122f8261171f93612fcd565b6040810135611758815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b156117e057506117688135613c7d565b156117b0579081602060019301359061178e6115cf606083016115c96115c3828661316e565b3561179983876130d7565b526117a482876130d7565b5201908a939291611305565b7f39a940c50000000000000000000000000000000000000000000000000000000060c0515235600452602460c051fd5b7ff9849ea30000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b7fcf1b093c0000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f3ee5aeb50000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b34611cc4576020600319360112611cc45767ffffffffffffffff60043511611cc457606060031960043536030112611cc4577f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6124b25760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6118eb612f7a565b6118f9600480350180612fcd565b8091501561248a5761190a81613039565b90611913613156565b5060405161192081612b44565b5f81525f6020820152915f915f5b818110611f60575050806020611960925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b60208151910151905f5260205273ffffffffffffffffffffffffffffffffffffffff8060405f2016911690808203611f325750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700546119c4600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000611a1a63ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152611a61606482612b8d565b905f905b808210611cf65750505f60208092604051918183925191829101835e8101838152039060025afa15611cb9575f51611aa760446004350160043560040161322b565b80600411611cc4577fffffffff000000000000000000000000000000000000000000000000000000008235167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203611cc857505073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b15611cc4575f92611ba192604051958694859384937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b907f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e6024840152604483015203915afa8015611cb957611ca5575b5080611c37575b507f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d60c05180f35b611c4081613d32565b15611c765760207f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d291604051908152a181611be3565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b5f611caf91612b8d565b5f60c05282611bdc565b6040513d5f823e3d90fd5b5f80fd5b7f78a2221c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b9091611d0a83610fac600480350180612fcd565b611d148180612fcd565b919050611d4963ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b16602082015260048152611d86602482612b8d565b915f905b808210611eb657505060208101916020611daa6004826110548787612fcd565b925f915b808310611e415750505060019260208093611e3993611e076060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e840190838201905f8252519283915e01015f815203601f198101835282612b8d565b920190611a65565b9091936020611ead60406001938380611e5e8b6111ae8b8d612fcd565b611e6d6111c38683018361316e565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e01015f838201520301601f198101835282612b8d565b94019190611dae565b90926020611f2a60606001938380611ed28a61122f8b80612fcd565b611ee16111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e01015f838201520301601f198101835282612b8d565b930190611d8a565b7fe6d44b4c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b611f7281610fac600480350180612fcd565b5f95611f7e8280612fcd565b979050611f8a88613039565b611f9389613039565b985f5b818110612387575050611fac6020850185612fcd565b999050611fb88a613039565b99611fc281613039565b905f905b8082106120da575050906120217f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc3293926113ab61139d9d60808a01359e8f9561138f604051988998895260a060208a015260a08901906131f8565b0390a1806120d2575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc08336030112611cc4576040519161206483612b44565b6040810135835260606020840191013581526040519261208384612b44565b5f84525f60208501526120998151835190613986565b1561146e57916120b99160019594936020835193015190519151926139e8565b60208301528152956120cb82866130d7565b520161192e565b95508761202a565b9094506120ee856111ae60208a018a612fcd565b9460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416957f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054965f19881461235a57878f986001017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055908235915f5b8281106122765750509060019392917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b1461220f575b50976121fc836020840135936121f56115cf604083016115c96121ef828661316e565b89613518565b35926130d7565b5261220782866130d7565b520190611fc6565b61164761164061227092612222856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d431015493849061415f565b5f6121cc565b9092600190818516612303577fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f83018190557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d4318301546122f89161415f565b935b811c910161216e565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015f527fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f830154612354919061415f565b936122fa565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b6123958161122f8880612fcd565b60408101356123ce815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b1561245f575080356123df81613c7d565b15612434579061242d838e6001959461241d612417602087013596606081019061241261240c838361316e565b8a613518565b61316e565b82613762565b612427838a6130d7565b526130d7565b5201611f96565b7f39a940c5000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7ff9849ea3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7fcf1b093c000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b34611cc4575f600319360112611cc4576124f2612f0e565b5f73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300547fffffffffffffffffffffffff000000000000000000000000000000000000000081167f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08280a3005b34611cc4575f600319360112611cc4576125ae612f0e565b6125b6612f7a565b6125be612f7a565b60017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff007fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416177fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a2586020604051338152a1005b34611cc4575f600319360112611cc457602060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f0330054166040519015158152f35b34611cc4575f600319360112611cc457602060405173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000168152f35b34611cc4575f600319360112611cc45760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354604051908152f35b34611cc4575f600319360112611cc45773ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001630036127975760206040517f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8152f35b7fe07c8dba000000000000000000000000000000000000000000000000000000005f5260045ffd5b6040600319360112611cc4576127d3612b21565b60243567ffffffffffffffff8111611cc4576127f3903690600401612c02565b9073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803014908115612a4d575b5061279757612843612f0e565b73ffffffffffffffffffffffffffffffffffffffff8116916040517f52d1902d000000000000000000000000000000000000000000000000000000008152602081600481875afa5f9181612a19575b506128c357837f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b807f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8592036129ee5750823b156129c357807fffffffffffffffffffffffff00000000000000000000000000000000000000007f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416177f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc557fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f80a28051156129925761299091613411565b005b50503461299b57005b7fb398979f000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7faa1d49a4000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b9091506020813d602011612a45575b81612a3560209383612b8d565b81010312611cc457519085612892565b3d9150612a28565b905073ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416141583612836565b34611cc4575f600319360112611cc45760207f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054604051908152f35b34611cc4576020600319360112611cc45760206108906004356130eb565b34611cc4575f600319360112611cc457807f322e302e302d616c7068612e320000000000000000000000000000000000000060209252f35b6004359073ffffffffffffffffffffffffffffffffffffffff82168203611cc457565b6040810190811067ffffffffffffffff821117612b6057604052565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b90601f601f19910116810190811067ffffffffffffffff821117612b6057604052565b67ffffffffffffffff8111612b6057601f01601f191660200190565b929192612bd882612bb0565b91612be66040519384612b8d565b829481845281830111611cc4578281602093845f960137010152565b9080601f83011215611cc457816020612c1d93359101612bcc565b90565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b9190820391821161235a57565b73ffffffffffffffffffffffffffffffffffffffff168015612d135773ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054827fffffffffffffffffffffffff00000000000000000000000000000000000000008216177f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e05f80a3565b7f1e4fbdf7000000000000000000000000000000000000000000000000000000005f525f60045260245ffd5b6040517f3cadf4490000000000000000000000000000000000000000000000000000000081527fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016600482015260208160248173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000165afa908115611cb9575f91612ebe575b50602073ffffffffffffffffffffffffffffffffffffffff916004604051809481937f5c975abb000000000000000000000000000000000000000000000000000000008352165afa908115611cb9575f91612e83575b508015612e5a5790565b5060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300541690565b90506020813d602011612eb6575b81612e9e60209383612b8d565b81010312611cc457518015158103611cc4575f612e50565b3d9150612e91565b90506020813d602011612f06575b81612ed960209383612b8d565b81010312611cc4575173ffffffffffffffffffffffffffffffffffffffff81168103611cc4576020612dfa565b3d9150612ecc565b73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054163303612f4e57565b7f118cdaa7000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b60ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416612fa557565b7fd93c0665000000000000000000000000000000000000000000000000000000005f5260045ffd5b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918160051b36038313611cc457565b67ffffffffffffffff8111612b605760051b60200190565b9061304382613021565b6130506040519182612b8d565b828152601f196130608294613021565b0190602036910137565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6181360301821215611cc4570190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b80518210156130aa5760209160051b010190565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903548110156130aa577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9035f5260205f2001905f90565b80548210156130aa575f5260205f2001905f90565b6040519061316382612b44565b5f6020838281520152565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8181360301821215611cc4570190565b908210156130aa57612c1d9160051b81019061316e565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa181360301821215611cc4570190565b90602080835192838152019201905f5b8181106132155750505090565b8251845260209384019390920191600101613208565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918136038313611cc457565b60ff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460401c16156132ab57565b7fd7e6bcf8000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901613141565b5f19829392549160031b92831b921b1916179055565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b805468010000000000000000811015612b605761335691600182018155613141565b905f8091602081519101845af480806134c5575b156134455750506040513d81523d5f602083013e60203d82010160405290565b1561348c5773ffffffffffffffffffffffffffffffffffffffff907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b3d1561349d576040513d5f823e3d90fd5b7fd6bda275000000000000000000000000000000000000000000000000000000005f5260045ffd5b503d1515806134255750813b1515613425565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc181360301821215611cc4570190565b90604081016135278183612fcd565b9290505f5b83811061353a575050505050565b61355b6135518261354b8686612fcd565b906134d8565b602081019061322b565b8101606082820312611cc45781359173ffffffffffffffffffffffffffffffffffffffff8316809303611cc457602081013567ffffffffffffffff8111611cc457826135a8918301612c02565b91604082013567ffffffffffffffff8111611cc4576135c79201612c02565b90604051917f33a89203000000000000000000000000000000000000000000000000000000008352886004840152604060248401525f838061360c6044820186612c20565b038183885af1928315611cb9575f936136af575b50825160208401208151602083012003613674575060019392917fcddb327adb31fe5437df2a8c68301bb13a6baae432a804838caaf682506aadf19161366b60405192839283613f2d565b0390a20161352c565b90506136ab6040519283927fc504fada00000000000000000000000000000000000000000000000000000000845260048401613f2d565b0390fd5b9092503d805f833e6136c18183612b8d565b810190602081830312611cc45780519067ffffffffffffffff8211611cc4570181601f82011215611cc4578051906136f882612bb0565b926137066040519485612b8d565b82845260208383010111611cc457815f9260208093018386015e83010152915f613620565b601f8260209493601f1993818652868601375f8582860101520116010190565b604090612c1d94928152816020820152019161372b565b9061376d8180612fcd565b5f5b818110613917575050506137866020820182612fcd565b5f5b8181106138a85750505061379f6040820182612fcd565b5f5b818110613839575050508060606137b9920190612fcd565b90915f5b8281106137ca5750505050565b6137d58184866134d8565b35906002821015611cc45760018092146137f0575b016137bd565b827fa494dac4b7184843583f972e06783e2c3bb47f4f0137b8df52a860df07219f8c61382061355184888a6134d8565b90613831604051928392878461374b565b0390a26137ea565b6138448183856134d8565b35906002821015611cc457600180921461385f575b016137a1565b857f9c61b290f631097f56273cf4daf40df1ff9ccc33f101d464837da1f5ae18bd5961388f6135518487896134d8565b906138a0604051928392878461374b565b0390a2613859565b6138b38183856134d8565b35906002821015611cc45760018092146138ce575b01613788565b857f48243873b4752ddcb45e0d7b11c4c266583e5e099a0b798fdd9c1af7d49324f36138fe6135518487896134d8565b9061390f604051928392878461374b565b0390a26138c8565b6139228183856134d8565b35906002821015611cc457600180921461393d575b0161376f565b857f3a134d01c07803003c63301717ddc4612e6c47ae408eeea3222cded532d02ae661396d6135518487896134d8565b9061397e604051928392878461374b565b0390a2613937565b801580156139d8575b80156139d0575b80156139c0575b6139ba576401000003d01960078180938181800909089180091490565b50505f90565b506401000003d01982101561399d565b508115613996565b506401000003d01981101561398f565b90939290915f90808403613c615750506401000003d0195f918508613a1157505090505f905f90565b6401000003d0198060018180613a78818080613a689a81808f800996879281808080808f81818192099987096004099780095f09928009600309089181613a5b8183800882612c45565b81858009089d8e83612c45565b9008900993800960080983612c45565b900896096002099391905b8415158581613c50575b5080613c48575b15613bea5780946001906401000003d019918184925b613afe575050505080613ad15750906401000003d019809281808780098092099509900990565b807f4e487b7100000000000000000000000000000000000000000000000000000000602492526012600452fd5b929791928015613bbd57808904918094613b90576401000003d0199083096401000003d019036401000003d019811161235a576401000003d0199086940893988192828102928184041490151715613b635790613b5a91612c45565b90929080613aaa565b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526011600452fd5b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526012600452fd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f496e76616c6964206e756d6265720000000000000000000000000000000000006044820152fd5b506001613a94565b6401000003d019915014155f613a8d565b6401000003d019929195613c7494613f52565b93909190613a83565b805f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2054155f14613d2d57613cda817f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc006133ef565b7f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054905f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2055600190565b505f90565b805f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054155f14613d2d57613d8f817f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354905f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2055600190565b7fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e54613f2957613e997fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b067f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903547fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e55600190565b5f90565b9091613f44612c1d93604084526040840190612c20565b916020818403910152612c20565b9492909391851580614157575b61414c57801580614144575b61413c57604051608091613f7f8383612b8d565b823683378415613bbd5784600180098083529385856001099860208401998a52604084019286845287845160010993606086019485526040519a878c01958c871067ffffffffffffffff881117612b60578a80979581969482956040525190098d525190099460208b019586525190099860408901998a52519009606087019081528651885114801590614130575b156140d257849283808093816040519c8561402a8f9788612b8d565b368737518c5161403a9083612c45565b9008845251855161404b9083612c45565b90089860208301998a5281808b8180808089518a5190099360408a019485528185518b5190096060909a01998a5251800988516140889083612c45565b9008818087518551900960020961409f9083612c45565b90089c519351905190096140b38c83612c45565b900890099251905190096140c79083612c45565b900894510991929190565b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f557365206a6163446f75626c652066756e6374696f6e20696e737465616400006044820152fd5b5081518151141561400e565b505050600190565b508115613f6b565b945092506001919050565b508415613f5f565b5f9060209260405190848201928352604082015260408152614182606082612b8d565b604051918291518091835e8101838152039060025afa15611cb9575f5190565b81519190604183036141d2576141cb9250602082015190606060408401519301515f1a90614516565b9192909190565b50505f9160029190565b600481101561428757806141ee575050565b6001810361421e577ff645eedf000000000000000000000000000000000000000000000000000000005f5260045ffd5b6002810361425257507ffce698f7000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b60031461425c5750565b7fd78bce0c000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b6142be8180612fcd565b63ffffffff9150166142f29062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b6142fc8280612fcd565b614305916145a5565b9160208101906143158282612fcd565b63ffffffff9150166143499062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b916143549082612fcd565b61435d916145a5565b6040820161436b8184612fcd565b63ffffffff91501661439f9062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b906143aa9084612fcd565b6143b3916145a5565b9160608401936143c38582612fcd565b63ffffffff9150166143f79062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b9461440191612fcd565b61440a916145a5565b9460405197889760e01b7fffffffff000000000000000000000000000000000000000000000000000000001660208901528051602081920160248a015e87019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016602482015281516020819301602883015e016024019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e016004019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e01600401600481015f905203600401601f1981018252612c1d9082612b8d565b91907f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0841161459a579160209360809260ff5f9560405194855216868401526040830152606082015282805260015afa15611cb9575f5173ffffffffffffffffffffffffffffffffffffffff81161561459057905f905f90565b505f906001905f90565b5050505f9160039190565b606092915f915b8183106145b857505050565b9091936145ff63ffffffff6145d16135518887876134d8565b905060021c1662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b61460d6135518786866134d8565b61461b8887879594956134d8565b35906002821015611cc4576001946020947fffffffff0000000000000000000000000000000000000000000000000000000086846146df9760049796614684899862ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b95856040519c898e9a5191829101888c015e89019360e01b1685840152602483013701019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b940191906145ac56fea164736f6c6343000824000af0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00
+    /// ```
+    #[rustfmt::skip]
+    #[allow(clippy::all)]
+    pub static BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
+        b"`\xE04a\x01\x0EW`\x1FaH\xD28\x81\x90\x03\x91\x82\x01`\x1F\x19\x16\x83\x01\x91`\x01`\x01`@\x1B\x03\x83\x11\x84\x84\x10\x17a\x01\x12W\x80\x84\x92`@\x94\x85R\x839\x81\x01\x03\x12a\x01\x0EW\x80Q`\x01`\x01`\xA0\x1B\x03\x81\x16\x91\x82\x82\x03a\x01\x0EW` \x01Q\x91`\x01`\x01`\xE0\x1B\x03\x19\x83\x16\x90\x81\x84\x03a\x01\x0EW0`\x80Ra\0ua\x01&V[a\0}a\x01&V[\x15a\0\xFFW\x15a\0\xF0W`\xA0R`\xC0Ra\0\x95a\x01&V[`@QaF\xF5\x90\x81a\x01\xBD\x829`\x80Q\x81\x81\x81a'G\x01Ra(\x0B\x01R`\xA0Q\x81\x81\x81a\x0E\x95\x01R\x81\x81a\x1B6\x01R\x81\x81a&\xC0\x01Ra-\xCA\x01R`\xC0Q\x81\x81\x81a\x02`\x01R\x81\x81a\rI\x01R\x81\x81a\x1A\xF6\x01Ra-\x88\x01R\xF3[c\xB1\xB2Z\xAF`\xE0\x1B_R`\x04_\xFD[cSl\x15\x01`\xE1\x1B_R`\x04_\xFD[_\x80\xFD[cNH{q`\xE0\x1B_R`A`\x04R`$_\xFD[_Q` aH\xB2_9_Q\x90_RT`\xFF\x81`@\x1C\x16a\x01\xADW`\x02`\x01`@\x1B\x03\x19`\x01`\x01`@\x1B\x03\x82\x16\x01a\x01[WPV[`\x01`\x01`@\x1B\x03\x19\x16`\x01`\x01`@\x1B\x03\x90\x81\x17_Q` aH\xB2_9_Q\x90_RU`@Q\x90\x81R\x7F\xC7\xF5\x05\xB2\xF3q\xAE!u\xEEI\x13\xF4I\x9E\x1F&3\xA7\xB5\x93c!\xEE\xD1\xCD\xAE\xB6\x11Q\x81\xD2\x90` \x90\xA1V[c\xF9.\xE8\xA9`\xE0\x1B_R`\x04_\xFD\xFE`\xE0\x80`@R`\x046\x10\x15a\0\x12W_\x80\xFD[_`\xC0R_5`\xE0\x1C\x90\x81c\r\x8En,\x14a*\xE9WP\x80c1\xEEbB\x14a*\xCBW\x80c@\xF3MB\x14a*\x8FW\x80cO\x1E\xF2\x86\x14a'\xBFW\x80cR\xD1\x90-\x14a' W\x80cY\xBA\x92X\x14a&\xE4W\x80c[fk\x1E\x14a&\x94W\x80c\\\x97Z\xBB\x14a&SW\x80cc\xA5\x99\xA4\x14a%\x96W\x80cqP\x18\xA6\x14a$\xDAW\x80cs\xAB\x99\x16\x14a\x18gW\x80c\x87\t>\xBA\x14a\n|W\x80c\x8D\xA5\xCB[\x14a\n(W\x80c\x9A\xD9\x1DL\x14a\twW\x80c\xA0`V\xF7\x14a\t6W\x80c\xAD<\xB1\xCC\x14a\x08\xD0W\x80c\xBD\xEBD-\x14a\x08FW\x80c\xC0%0#\x14a\x07\xA7W\x80c\xC1\xB0\xBE\xD7\x14a\x07TW\x80c\xC4IV\xD1\x14a\x07\x16W\x80c\xC4\xD6m\xE8\x14a\x02\xCDW\x80c\xC8y\xDB\xE4\x14a\x02\x84W\x80c\xE38E\xCF\x14a\x02&W\x80c\xF2\xFD\xE3\x8B\x14a\x01\xF7W\x80c\xFD\xDDH7\x14a\x01\xD1W\x80c\xFE\x18\xAB\x91\x14a\x01\x8DWc\xFF\xC3?r\x14a\x01IW_\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0T`@Q\x90\x81R\xF3[`\xC0Q\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\x01`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B`@Q\x90\x81R\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` a\x01\xEDa-?V[`@Q\x90\x15\x15\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02 a\x02\x13a+!V[a\x02\x1Ba/\x0EV[a,RV[`\xC0Q\x80\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `@Q\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W` a\x01\xED`\x045_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02\xE6a+!V[\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`\xFF\x81`@\x1C\x16\x15\x91g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x80\x15\x90\x81a\x07\x0EW[`\x01\x14\x90\x81a\x07\x04W[\x15\x90\x81a\x06\xFBW[Pa\x06\xCFW\x81\x83`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0a\x03\x9F\x95\x16\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0Ua\x06zW[Pa\x03\x97a2|V[a\x02\x1Ba2|V[a\x03\xA7a2|V[a\x03\xAFa2|V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a\x06IW\x80`\x01a\x042\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x81T\x90`\x03\x1B\x90_\x19\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x83\x1B\x92\x1B\x19\x16\x17\x90U`\xC0Q\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0Ua\x04\x92a=\xE2V[P\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x81R\xA1a\x04\xE5a2|V[\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2a\x05ya-?V[a\x06\x1DWa\x05\x87W`\xC0Q\x80\xF3[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T\x16\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x7F\xC7\xF5\x05\xB2\xF3q\xAE!u\xEEI\x13\xF4I\x9E\x1F&3\xA7\xB5\x93c!\xEE\xD1\xCD\xAE\xB6\x11Q\x81\xD2` `@Q`\x01\x81R\xA1a\x02 V[\x7F\x0B\x1D8\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`A`\x04R`$`\xC0Q\xFD[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\x16h\x01\0\0\0\0\0\0\0\x01\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x83a\x03\x8EV[\x7F\xF9.\xE8\xA9\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x90P\x15\x84a\x037V[0;\x15\x91Pa\x03/V[\x84\x91Pa\x03%V[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\xC0QP`\x045`\xC0QR\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R` `@`\xC0Q T\x15\x15`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\x045a\x07\xC3a/\x0EV[\x80\x15a\x08\x1AW\x80\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2`\xC0Q\x80\xF3[\x7FwM]\xE1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T_\x19\x81\x01\x90\x81\x11a\x08\x9FWa\x08\x90` \x91a0\xEBV[\x90T\x90`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x11`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W`@\x80Qa\t2\x91a\x08\xF4\x90\x82a+\x8DV[`\x05\x81R\x7F5.0.0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x82\x01R`@Q\x91\x82\x91` \x83R` \x83\x01\x90a, V[\x03\x90\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`\x045\x90\x81\x10\x15a\t\xF7W` \x90\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0`\xC0QR\x81`\xC0Q \x01`\xC0QPT`\xC0Q`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`2`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x16`@Q\x90\x81R\xF3[4a\x01\x87W`@`\x03\x196\x01\x12a\x01\x87Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x01\x87W```\x03\x19`\x0456\x03\x01\x12a\x01\x87W`$5\x80\x15\x15\x81\x03a\x01\x87WZ`\x80R\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a\x18;W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x0B\x10a/zV[a\x0B\x1E`\x04\x805\x01\x80a/\xCDV[\x80\x92\x91P\x15a\x18\x0FWa\x0B0\x82a09V[a\x0B8a1VV[P`@Qa\x0BE\x81a+DV[`\xC0Q\x81R`\xC0Q` \x82\x01R\x92`\xC0Q`\xA0R`\xC0Q[\x81\x81\x10a\x12\xC9WPP\x80` a\x0B\xA5\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[6\x91a+\xCCV[\x85aA\xA2V[\x90\x93\x91\x93aA\xDCV[` \x81Q\x91\x01Q\x90`\xC0QR` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@`\xC0Q \x16\x91\x16\x90\x80\x82\x03a\x12\x97WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x0C\r`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x0Ccc\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x0C\xAA`d\x82a+\x8DV[`\xC0Q\x91[\x80\x83\x10a\x0F\x99WP` \x80\x92P`@Q\x91\x80Q\x91\x82\x91\x01\x83^\x81\x01\x90`\xC0Q\x82R\x80`\xC0Q\x92\x03\x90`\x02Z\xFA\x15a\x0FZW`\xC0QQa\x0C\xF8`D`\x045\x01`\x045`\x04\x01a2+V[\x90\x92\x81`\x04\x11a\x01\x87W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x845\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x0FgWPP\x15a\x0E~W[PPP`\xA0Qa\x0E\x0BW[\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\r\xDCZ`\x80Qa,EV[\x7Fo\x14\x981\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[a\x0E\x16`\xA0Qa=2V[\x15a\x0ELW\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q`\xA0Q\x81R\xA1a\r\x83V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\xA0Q`\x04R`$`\xC0Q\xFD[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x01\x87Wa\x0E\xF9`@Q\x94\x85\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x92\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x81\x80`\xC0Q\x94\x03\x91Z\xFA\x80\x15a\x0FZWa\x0FAW[\x80\x80a\rxV[`\xC0Qa\x0FM\x91a+\x8DV[`\xC0Qa\x01\x87W\x81a\x0F:V[`@Q=`\xC0Q\x82>=\x90\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[\x90a\x0F\xB2\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[\x90a0jV[a\x0F\xBC\x81\x80a/\xCDV[\x91\x90Pa\x0F\xF1c\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x10.`$\x82a+\x8DV[\x91`\xC0Q\x90[\x80\x82\x10a\x12\x13WPP` \x81\x01\x91` a\x10\xF3`\x04\x82a\x10T\x87\x87a/\xCDV[\x95\x90Pa\x10\x89c\xFF\xFF\xFF\xFF\x87\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x96\x83\x88\x94Q\x91\x82\x91\x01\x86\x86\x01^\x83\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x92`\xC0Q\x91[\x80\x83\x10a\x11\x91WPPP`\x01\x92` \x80\x93a\x11\x88\x93a\x11R``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90`\xC0Q\x82RQ\x92\x83\x91^\x01\x01`\xC0Q\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x91\x90a\x0C\xAFV[\x90\x91\x93` a\x12\n`@`\x01\x93\x83\x80a\x11\xB4\x8Ba\x11\xAE\x8B\x8Da/\xCDV[\x90a1\xB8V[a\x11\xC8a\x11\xC3\x86\x83\x01\x83a1nV[aB\xB4V[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x10\xF9V[\x90\x92` a\x12\x8F```\x01\x93\x83\x80a\x125\x8Aa\x12/\x8B\x80a/\xCDV[\x90a1\xA1V[a\x12Da\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x104V[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[a\x12\xDB\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[`\xC0Q\x90\x95\x90\x86a\x12\xEC\x81\x80a/\xCDV[\x90Pa\x12\xF7\x81a09V[a\x13\0\x82a09V[\x91`\xC0Q[\x81\x81\x10a\x17\rWPPa\x13\x1B` \x84\x01\x84a/\xCDV[\x92\x90Pa\x13'\x83a09V[\x91a\x131\x84a09V[\x93`\xC0Q\x90[\x80\x82\x10a\x14\xAFWPP\x92a\x13\xAB\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x95\x93a\x13\x9Da\x13\xB9\x94a\x13\x8F`\x80\x98`@Q\x99\x8A\x99\x015\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x90\x87\x82\x03`@\x89\x01Ra1\xF8V[\x90\x85\x82\x03``\x87\x01Ra1\xF8V[\x90\x83\x82\x03`\x80\x85\x01Ra1\xF8V[\x03\x90\xA1\x80a\x14\xA6W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x876\x03\x01\x12a\x01\x87W`@Q\x90a\x13\xFC\x82a+DV[`@\x87\x015\x82R` \x82\x01``\x88\x015\x81R`@Q\x92a\x14\x1B\x84a+DV[_\x84R_` \x85\x01Ra\x141\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x82`\x01\x95\x94\x92a\x14S\x92` `\x80\x96Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x96\x015a\x14g\x82\x86a0\xD7V[R\x01a\x0B]V[`D\x91`@Q\x91\x7F\xB8\xA0\xE8\xA1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83RQ`\x04\x83\x01RQ`$\x82\x01R\xFD[`\xA0R\x86a\x13\xC2V[\x91\x92\x93\x94\x95\x81\x97P\x90a\x11\xAE\x82` a\x14\xC9\x94\x01\x90a/\xCDV[\x95`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T_\x19\x81\x14a\x08\x9FW`\x01\x81\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x885\x91`\xC0Q[\x82\x81\x10a\x16RWPP\x90`\x01\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x84`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\x15\xF9W[P\x97` \x81\x015\x90a\x15\xD6a\x15\xCF`@\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[\x86a5\x18V[\x83a1nV[\x825a7bV[5a\x15\xE1\x83\x89a0\xD7V[Ra\x15\xEC\x82\x89a0\xD7V[R\x01\x8C\x95\x94\x93\x92\x91a\x137V[a\x16Ga\x16@a\x16L\x92a\x16\x0C\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR` `\xC0Q \x01T\x80\x94aA_V[\x92\x80aA_V[a3lV[\x8Fa\x15\xA4V[\x90\x92`\x01\x90\x81\x85\x16a\x16\xD0Wa\x16\xC5\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x80\x84` `\xC0Q \x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR\x83` `\xC0Q \x01T\x90aA_V[\x93[\x81\x1C\x91\x01a\x15GV[a\x17\x07\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x83` `\xC0Q \x01TaA_V[\x93a\x16\xC7V[\x90\x91\x92\x93\x81a\x12/\x82a\x17\x1F\x93a/\xCDV[`@\x81\x015a\x17X\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a\x17\xE0WPa\x17h\x815a<}V[\x15a\x17\xB0W\x90\x81` `\x01\x93\x015\x90a\x17\x8Ea\x15\xCF``\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[5a\x17\x99\x83\x87a0\xD7V[Ra\x17\xA4\x82\x87a0\xD7V[R\x01\x90\x8A\x93\x92\x91a\x13\x05V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR5`\x04R`$`\xC0Q\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x1C\xC4W```\x03\x19`\x0456\x03\x01\x12a\x1C\xC4W\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a$\xB2W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x18\xEBa/zV[a\x18\xF9`\x04\x805\x01\x80a/\xCDV[\x80\x91P\x15a$\x8AWa\x19\n\x81a09V[\x90a\x19\x13a1VV[P`@Qa\x19 \x81a+DV[_\x81R_` \x82\x01R\x91_\x91_[\x81\x81\x10a\x1F`WPP\x80` a\x19`\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[` \x81Q\x91\x01Q\x90_R` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@_ \x16\x91\x16\x90\x80\x82\x03a\x1F2WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x19\xC4`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x1A\x1Ac\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x1Aa`d\x82a+\x8DV[\x90_\x90[\x80\x82\x10a\x1C\xF6WPP_` \x80\x92`@Q\x91\x81\x83\x92Q\x91\x82\x91\x01\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Qa\x1A\xA7`D`\x045\x01`\x045`\x04\x01a2+V[\x80`\x04\x11a\x1C\xC4W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x825\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x1C\xC8WPPs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x1C\xC4W_\x92a\x1B\xA1\x92`@Q\x95\x86\x94\x85\x93\x84\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x90\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x03\x91Z\xFA\x80\x15a\x1C\xB9Wa\x1C\xA5W[P\x80a\x1C7W[P\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]`\xC0Q\x80\xF3[a\x1C@\x81a=2V[\x15a\x1CvW` \x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2\x91`@Q\x90\x81R\xA1\x81a\x1B\xE3V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[_a\x1C\xAF\x91a+\x8DV[_`\xC0R\x82a\x1B\xDCV[`@Q=_\x82>=\x90\xFD[_\x80\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[\x90\x91a\x1D\n\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[a\x1D\x14\x81\x80a/\xCDV[\x91\x90Pa\x1DIc\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x1D\x86`$\x82a+\x8DV[\x91_\x90[\x80\x82\x10a\x1E\xB6WPP` \x81\x01\x91` a\x1D\xAA`\x04\x82a\x10T\x87\x87a/\xCDV[\x92_\x91[\x80\x83\x10a\x1EAWPPP`\x01\x92` \x80\x93a\x1E9\x93a\x1E\x07``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90_\x82RQ\x92\x83\x91^\x01\x01_\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x90a\x1AeV[\x90\x91\x93` a\x1E\xAD`@`\x01\x93\x83\x80a\x1E^\x8Ba\x11\xAE\x8B\x8Da/\xCDV[a\x1Ema\x11\xC3\x86\x83\x01\x83a1nV[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x1D\xAEV[\x90\x92` a\x1F*```\x01\x93\x83\x80a\x1E\xD2\x8Aa\x12/\x8B\x80a/\xCDV[a\x1E\xE1a\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x1D\x8AV[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[a\x1Fr\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[_\x95a\x1F~\x82\x80a/\xCDV[\x97\x90Pa\x1F\x8A\x88a09V[a\x1F\x93\x89a09V[\x98_[\x81\x81\x10a#\x87WPPa\x1F\xAC` \x85\x01\x85a/\xCDV[\x99\x90Pa\x1F\xB8\x8Aa09V[\x99a\x1F\xC2\x81a09V[\x90_\x90[\x80\x82\x10a \xDAWPP\x90a !\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x93\x92a\x13\xABa\x13\x9D\x9D`\x80\x8A\x015\x9E\x8F\x95a\x13\x8F`@Q\x98\x89\x98\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x03\x90\xA1\x80a \xD2W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x836\x03\x01\x12a\x1C\xC4W`@Q\x91a d\x83a+DV[`@\x81\x015\x83R``` \x84\x01\x91\x015\x81R`@Q\x92a \x83\x84a+DV[_\x84R_` \x85\x01Ra \x99\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x91a \xB9\x91`\x01\x95\x94\x93` \x83Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x95a \xCB\x82\x86a0\xD7V[R\x01a\x19.V[\x95P\x87a *V[\x90\x94Pa \xEE\x85a\x11\xAE` \x8A\x01\x8Aa/\xCDV[\x94`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x95\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x96_\x19\x88\x14a#ZW\x87\x8F\x98`\x01\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x825\x91_[\x82\x81\x10a\"vWPP\x90`\x01\x93\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x85`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\"\x0FW[P\x97a!\xFC\x83` \x84\x015\x93a!\xF5a\x15\xCF`@\x83\x01a\x15\xC9a!\xEF\x82\x86a1nV[\x89a5\x18V[5\x92a0\xD7V[Ra\"\x07\x82\x86a0\xD7V[R\x01\x90a\x1F\xC6V[a\x16Ga\x16@a\"p\x92a\"\"\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x01T\x93\x84\x90aA_V[_a!\xCCV[\x90\x92`\x01\x90\x81\x85\x16a#\x03W\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01\x81\x90U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x83\x01Ta\"\xF8\x91aA_V[\x93[\x81\x1C\x91\x01a!nV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01_R\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01Ta#T\x91\x90aA_V[\x93a\"\xFAV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x11`\x04R`$_\xFD[a#\x95\x81a\x12/\x88\x80a/\xCDV[`@\x81\x015a#\xCE\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a$_WP\x805a#\xDF\x81a<}V[\x15a$4W\x90a$-\x83\x8E`\x01\x95\x94a$\x1Da$\x17` \x87\x015\x96``\x81\x01\x90a$\x12a$\x0C\x83\x83a1nV[\x8Aa5\x18V[a1nV[\x82a7bV[a$'\x83\x8Aa0\xD7V[Ra0\xD7V[R\x01a\x1F\x96V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa$\xF2a/\x0EV[_s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81\x16\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0\x82\x80\xA3\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa%\xAEa/\x0EV[a%\xB6a/zV[a%\xBEa/zV[`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x17\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0U\x7Fb\xE7\x8C\xEA\x01\xBE\xE3 \xCDNB\x02p\xB5\xEAt\0\r\x11\xB0\xC9\xF7GT\xEB\xDB\xFCTK\x05\xA2X` `@Q3\x81R\xA1\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16`@Q\x90\x15\x15\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `@Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T`@Q\x90\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x160\x03a'\x97W` `@Q\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x81R\xF3[\x7F\xE0|\x8D\xBA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`@`\x03\x196\x01\x12a\x1C\xC4Wa'\xD3a+!V[`$5g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa'\xF3\x906\x90`\x04\x01a,\x02V[\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x800\x14\x90\x81\x15a*MW[Pa'\x97Wa(Ca/\x0EV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x91`@Q\x7FR\xD1\x90-\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` \x81`\x04\x81\x87Z\xFA_\x91\x81a*\x19W[Pa(\xC3W\x83\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x80\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x85\x92\x03a)\xEEWP\x82;\x15a)\xC3W\x80\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x17\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCU\x7F\xBC|\xD7Z \xEE'\xFD\x9A\xDE\xBA\xB3 A\xF7U!M\xBCk\xFF\xA9\x0C\xC0\"[9\xDA.\\-;_\x80\xA2\x80Q\x15a)\x92Wa)\x90\x91a4\x11V[\0[PP4a)\x9BW\0[\x7F\xB3\x98\x97\x9F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xAA\x1DI\xA4\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x90\x91P` \x81=` \x11a*EW[\x81a*5` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x90\x85a(\x92V[=\x91Pa*(V[\x90Ps\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x14\x15\x83a(6V[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`@Q\x90\x81R\xF3[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4W` a\x08\x90`\x045a0\xEBV[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W\x80\x7F2.0.0-alpha.2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x92R\xF3[`\x045\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x82\x03a\x1C\xC4WV[`@\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`A`\x04R`$_\xFD[\x90`\x1F`\x1F\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x1F\x01`\x1F\x19\x16` \x01\x90V[\x92\x91\x92a+\xD8\x82a+\xB0V[\x91a+\xE6`@Q\x93\x84a+\x8DV[\x82\x94\x81\x84R\x81\x83\x01\x11a\x1C\xC4W\x82\x81` \x93\x84_\x96\x017\x01\x01RV[\x90\x80`\x1F\x83\x01\x12\x15a\x1C\xC4W\x81` a,\x1D\x935\x91\x01a+\xCCV[\x90V[\x90`\x1F\x19`\x1F` \x80\x94\x80Q\x91\x82\x91\x82\x87R\x01\x86\x86\x01^_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[\x91\x90\x82\x03\x91\x82\x11a#ZWV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x16\x80\x15a-\x13Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x82\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x82\x16\x17\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0_\x80\xA3V[\x7F\x1EO\xBD\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R_`\x04R`$_\xFD[`@Q\x7F<\xAD\xF4I\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R` \x81`$\x81s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\xBEW[P` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x91`\x04`@Q\x80\x94\x81\x93\x7F\\\x97Z\xBB\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\x83W[P\x80\x15a.ZW\x90V[P`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x90V[\x90P` \x81=` \x11a.\xB6W[\x81a.\x9E` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x80\x15\x15\x81\x03a\x1C\xC4W_a.PV[=\x91Pa.\x91V[\x90P` \x81=` \x11a/\x06W[\x81a.\xD9` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x81\x03a\x1C\xC4W` a-\xFAV[=\x91Pa.\xCCV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x163\x03a/NWV[\x7F\x11\x8C\xDA\xA7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R3`\x04R`$_\xFD[`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16a/\xA5WV[\x7F\xD9<\x06e\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x81`\x05\x1B6\x03\x83\x13a\x1C\xC4WV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x05\x1B` \x01\x90V[\x90a0C\x82a0!V[a0P`@Q\x91\x82a+\x8DV[\x82\x81R`\x1F\x19a0`\x82\x94a0!V[\x01\x90` 6\x91\x017V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFFa\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`2`\x04R`$_\xFD[\x80Q\x82\x10\x15a0\xAAW` \x91`\x05\x1B\x01\x01\x90V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x81\x10\x15a0\xAAW\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03_R` _ \x01\x90_\x90V[\x80T\x82\x10\x15a0\xAAW_R` _ \x01\x90_\x90V[`@Q\x90a1c\x82a+DV[_` \x83\x82\x81R\x01RV[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90\x82\x10\x15a0\xAAWa,\x1D\x91`\x05\x1B\x81\x01\x90a1nV[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xA1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90` \x80\x83Q\x92\x83\x81R\x01\x92\x01\x90_[\x81\x81\x10a2\x15WPPP\x90V[\x82Q\x84R` \x93\x84\x01\x93\x90\x92\x01\x91`\x01\x01a2\x08V[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x816\x03\x83\x13a\x1C\xC4WV[`\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`@\x1C\x16\x15a2\xABWV[\x7F\xD7\xE6\xBC\xF8\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01a1AV[_\x19\x82\x93\x92T\x91`\x03\x1B\x92\x83\x1B\x92\x1B\x19\x16\x17\x90UV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x80Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`Wa3V\x91`\x01\x82\x01\x81Ua1AV[\x90_\x80\x91` \x81Q\x91\x01\x84Z\xF4\x80\x80a4\xC5W[\x15a4EWPP`@Q=\x81R=_` \x83\x01>` =\x82\x01\x01`@R\x90V[\x15a4\x8CWs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x90\x7F\x99\x96\xB3\x15\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R\x16`\x04R`$_\xFD[=\x15a4\x9DW`@Q=_\x82>=\x90\xFD[\x7F\xD6\xBD\xA2u\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[P=\x15\x15\x80a4%WP\x81;\x15\x15a4%V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90`@\x81\x01a5'\x81\x83a/\xCDV[\x92\x90P_[\x83\x81\x10a5:WPPPPPV[a5[a5Q\x82a5K\x86\x86a/\xCDV[\x90a4\xD8V[` \x81\x01\x90a2+V[\x81\x01``\x82\x82\x03\x12a\x1C\xC4W\x815\x91s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x16\x80\x93\x03a\x1C\xC4W` \x81\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4W\x82a5\xA8\x91\x83\x01a,\x02V[\x91`@\x82\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa5\xC7\x92\x01a,\x02V[\x90`@Q\x91\x7F3\xA8\x92\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x88`\x04\x84\x01R`@`$\x84\x01R_\x83\x80a6\x0C`D\x82\x01\x86a, V[\x03\x81\x83\x88Z\xF1\x92\x83\x15a\x1C\xB9W_\x93a6\xAFW[P\x82Q` \x84\x01 \x81Q` \x83\x01 \x03a6tWP`\x01\x93\x92\x91\x7F\xCD\xDB2z\xDB1\xFET7\xDF*\x8Ch0\x1B\xB1:k\xAA\xE42\xA8\x04\x83\x8C\xAA\xF6\x82Pj\xAD\xF1\x91a6k`@Q\x92\x83\x92\x83a?-V[\x03\x90\xA2\x01a5,V[\x90Pa6\xAB`@Q\x92\x83\x92\x7F\xC5\x04\xFA\xDA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84R`\x04\x84\x01a?-V[\x03\x90\xFD[\x90\x92P=\x80_\x83>a6\xC1\x81\x83a+\x8DV[\x81\x01\x90` \x81\x83\x03\x12a\x1C\xC4W\x80Q\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W\x01\x81`\x1F\x82\x01\x12\x15a\x1C\xC4W\x80Q\x90a6\xF8\x82a+\xB0V[\x92a7\x06`@Q\x94\x85a+\x8DV[\x82\x84R` \x83\x83\x01\x01\x11a\x1C\xC4W\x81_\x92` \x80\x93\x01\x83\x86\x01^\x83\x01\x01R\x91_a6 V[`\x1F\x82` \x94\x93`\x1F\x19\x93\x81\x86R\x86\x86\x017_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[`@\x90a,\x1D\x94\x92\x81R\x81` \x82\x01R\x01\x91a7+V[\x90a7m\x81\x80a/\xCDV[_[\x81\x81\x10a9\x17WPPPa7\x86` \x82\x01\x82a/\xCDV[_[\x81\x81\x10a8\xA8WPPPa7\x9F`@\x82\x01\x82a/\xCDV[_[\x81\x81\x10a89WPPP\x80``a7\xB9\x92\x01\x90a/\xCDV[\x90\x91_[\x82\x81\x10a7\xCAWPPPPV[a7\xD5\x81\x84\x86a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a7\xF0W[\x01a7\xBDV[\x82\x7F\xA4\x94\xDA\xC4\xB7\x18HCX?\x97.\x06x>,;\xB4\x7FO\x017\xB8\xDFR\xA8`\xDF\x07!\x9F\x8Ca8 a5Q\x84\x88\x8Aa4\xD8V[\x90a81`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a7\xEAV[a8D\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8_W[\x01a7\xA1V[\x85\x7F\x9Ca\xB2\x90\xF61\t\x7FV'<\xF4\xDA\xF4\r\xF1\xFF\x9C\xCC3\xF1\x01\xD4d\x83}\xA1\xF5\xAE\x18\xBDYa8\x8Fa5Q\x84\x87\x89a4\xD8V[\x90a8\xA0`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8YV[a8\xB3\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8\xCEW[\x01a7\x88V[\x85\x7FH$8s\xB4u-\xDC\xB4^\r{\x11\xC4\xC2fX>^\t\x9A\x0By\x8F\xDD\x9C\x1A\xF7\xD4\x93$\xF3a8\xFEa5Q\x84\x87\x89a4\xD8V[\x90a9\x0F`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8\xC8V[a9\"\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a9=W[\x01a7oV[\x85\x7F:\x13M\x01\xC0x\x03\0<c0\x17\x17\xDD\xC4a.lG\xAE@\x8E\xEE\xA3\",\xDE\xD52\xD0*\xE6a9ma5Q\x84\x87\x89a4\xD8V[\x90a9~`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a97V[\x80\x15\x80\x15a9\xD8W[\x80\x15a9\xD0W[\x80\x15a9\xC0W[a9\xBAWd\x01\0\0\x03\xD0\x19`\x07\x81\x80\x93\x81\x81\x80\t\t\x08\x91\x80\t\x14\x90V[PP_\x90V[Pd\x01\0\0\x03\xD0\x19\x82\x10\x15a9\x9DV[P\x81\x15a9\x96V[Pd\x01\0\0\x03\xD0\x19\x81\x10\x15a9\x8FV[\x90\x93\x92\x90\x91_\x90\x80\x84\x03a<aWPPd\x01\0\0\x03\xD0\x19_\x91\x85\x08a:\x11WPP\x90P_\x90_\x90V[d\x01\0\0\x03\xD0\x19\x80`\x01\x81\x80a:x\x81\x80\x80a:h\x9A\x81\x80\x8F\x80\t\x96\x87\x92\x81\x80\x80\x80\x80\x8F\x81\x81\x81\x92\t\x99\x87\t`\x04\t\x97\x80\t_\t\x92\x80\t`\x03\t\x08\x91\x81a:[\x81\x83\x80\x08\x82a,EV[\x81\x85\x80\t\x08\x9D\x8E\x83a,EV[\x90\x08\x90\t\x93\x80\t`\x08\t\x83a,EV[\x90\x08\x96\t`\x02\t\x93\x91\x90[\x84\x15\x15\x85\x81a<PW[P\x80a<HW[\x15a;\xEAW\x80\x94`\x01\x90d\x01\0\0\x03\xD0\x19\x91\x81\x84\x92[a:\xFEWPPPP\x80a:\xD1WP\x90d\x01\0\0\x03\xD0\x19\x80\x92\x81\x80\x87\x80\t\x80\x92\t\x95\t\x90\t\x90V[\x80\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`$\x92R`\x12`\x04R\xFD[\x92\x97\x91\x92\x80\x15a;\xBDW\x80\x89\x04\x91\x80\x94a;\x90Wd\x01\0\0\x03\xD0\x19\x90\x83\td\x01\0\0\x03\xD0\x19\x03d\x01\0\0\x03\xD0\x19\x81\x11a#ZWd\x01\0\0\x03\xD0\x19\x90\x86\x94\x08\x93\x98\x81\x92\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a;cW\x90a;Z\x91a,EV[\x90\x92\x90\x80a:\xAAV[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x11`\x04R\xFD[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x12`\x04R\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x12`\x04R`$_\xFD[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x0E`$\x82\x01R\x7FInvalid number\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`D\x82\x01R\xFD[P`\x01a:\x94V[d\x01\0\0\x03\xD0\x19\x91P\x14\x15_a:\x8DV[d\x01\0\0\x03\xD0\x19\x92\x91\x95a<t\x94a?RV[\x93\x90\x91\x90a:\x83V[\x80_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ T\x15_\x14a=-Wa<\xDA\x81\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0a3\xEFV[\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T\x90_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ U`\x01\x90V[P_\x90V[\x80_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15_\x14a=-Wa=\x8F\x81\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x90_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ U`\x01\x90V[\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nTa?)Wa>\x99\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nU`\x01\x90V[_\x90V[\x90\x91a?Da,\x1D\x93`@\x84R`@\x84\x01\x90a, V[\x91` \x81\x84\x03\x91\x01Ra, V[\x94\x92\x90\x93\x91\x85\x15\x80aAWW[aALW\x80\x15\x80aADW[aA<W`@Q`\x80\x91a?\x7F\x83\x83a+\x8DV[\x826\x837\x84\x15a;\xBDW\x84`\x01\x80\t\x80\x83R\x93\x85\x85`\x01\t\x98` \x84\x01\x99\x8AR`@\x84\x01\x92\x86\x84R\x87\x84Q`\x01\t\x93``\x86\x01\x94\x85R`@Q\x9A\x87\x8C\x01\x95\x8C\x87\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x88\x11\x17a+`W\x8A\x80\x97\x95\x81\x96\x94\x82\x95`@RQ\x90\t\x8DRQ\x90\t\x94` \x8B\x01\x95\x86RQ\x90\t\x98`@\x89\x01\x99\x8ARQ\x90\t``\x87\x01\x90\x81R\x86Q\x88Q\x14\x80\x15\x90aA0W[\x15a@\xD2W\x84\x92\x83\x80\x80\x93\x81`@Q\x9C\x85a@*\x8F\x97\x88a+\x8DV[6\x877Q\x8CQa@:\x90\x83a,EV[\x90\x08\x84RQ\x85Qa@K\x90\x83a,EV[\x90\x08\x98` \x83\x01\x99\x8AR\x81\x80\x8B\x81\x80\x80\x80\x89Q\x8AQ\x90\t\x93`@\x8A\x01\x94\x85R\x81\x85Q\x8BQ\x90\t``\x90\x9A\x01\x99\x8ARQ\x80\t\x88Qa@\x88\x90\x83a,EV[\x90\x08\x81\x80\x87Q\x85Q\x90\t`\x02\ta@\x9F\x90\x83a,EV[\x90\x08\x9CQ\x93Q\x90Q\x90\ta@\xB3\x8C\x83a,EV[\x90\x08\x90\t\x92Q\x90Q\x90\ta@\xC7\x90\x83a,EV[\x90\x08\x94Q\t\x91\x92\x91\x90V[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x1E`$\x82\x01R\x7FUse jacDouble function instead\0\0`D\x82\x01R\xFD[P\x81Q\x81Q\x14\x15a@\x0EV[PPP`\x01\x90V[P\x81\x15a?kV[\x94P\x92P`\x01\x91\x90PV[P\x84\x15a?_V[_\x90` \x92`@Q\x90\x84\x82\x01\x92\x83R`@\x82\x01R`@\x81RaA\x82``\x82a+\x8DV[`@Q\x91\x82\x91Q\x80\x91\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Q\x90V[\x81Q\x91\x90`A\x83\x03aA\xD2WaA\xCB\x92P` \x82\x01Q\x90```@\x84\x01Q\x93\x01Q_\x1A\x90aE\x16V[\x91\x92\x90\x91\x90V[PP_\x91`\x02\x91\x90V[`\x04\x81\x10\x15aB\x87W\x80aA\xEEWPPV[`\x01\x81\x03aB\x1EW\x7F\xF6E\xEE\xDF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`\x02\x81\x03aBRWP\x7F\xFC\xE6\x98\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[`\x03\x14aB\\WPV[\x7F\xD7\x8B\xCE\x0C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`!`\x04R`$_\xFD[aB\xBE\x81\x80a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aB\xF2\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aB\xFC\x82\x80a/\xCDV[aC\x05\x91aE\xA5V[\x91` \x81\x01\x90aC\x15\x82\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aCI\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x91aCT\x90\x82a/\xCDV[aC]\x91aE\xA5V[`@\x82\x01aCk\x81\x84a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\x9F\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x90aC\xAA\x90\x84a/\xCDV[aC\xB3\x91aE\xA5V[\x91``\x84\x01\x93aC\xC3\x85\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\xF7\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x94aD\x01\x91a/\xCDV[aD\n\x91aE\xA5V[\x94`@Q\x97\x88\x97`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16` \x89\x01R\x80Q` \x81\x92\x01`$\x8A\x01^\x87\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`$\x82\x01R\x81Q` \x81\x93\x01`(\x83\x01^\x01`$\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01`\x04\x81\x01_\x90R\x03`\x04\x01`\x1F\x19\x81\x01\x82Ra,\x1D\x90\x82a+\x8DV[\x91\x90\x7F\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF]WnsW\xA4P\x1D\xDF\xE9/Fh\x1B \xA0\x84\x11aE\x9AW\x91` \x93`\x80\x92`\xFF_\x95`@Q\x94\x85R\x16\x86\x84\x01R`@\x83\x01R``\x82\x01R\x82\x80R`\x01Z\xFA\x15a\x1C\xB9W_Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x15aE\x90W\x90_\x90_\x90V[P_\x90`\x01\x90_\x90V[PPP_\x91`\x03\x91\x90V[``\x92\x91_\x91[\x81\x83\x10aE\xB8WPPPV[\x90\x91\x93aE\xFFc\xFF\xFF\xFF\xFFaE\xD1a5Q\x88\x87\x87a4\xD8V[\x90P`\x02\x1C\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aF\ra5Q\x87\x86\x86a4\xD8V[aF\x1B\x88\x87\x87\x95\x94\x95a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x94` \x94\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x86\x84aF\xDF\x97`\x04\x97\x96aF\x84\x89\x98b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x95\x85`@Q\x9C\x89\x8E\x9AQ\x91\x82\x91\x01\x88\x8C\x01^\x89\x01\x93`\xE0\x1B\x16\x85\x84\x01R`$\x83\x017\x01\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x94\x01\x91\x90aE\xACV\xFE\xA1dsolcC\0\x08$\0\n\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0",
+    );
+    /// The runtime bytecode of the contract, as deployed on the network.
+    ///
+    /// ```text
+    ///0x60e0806040526004361015610012575f80fd5b5f60c0525f3560e01c9081630d8e6e2c14612ae95750806331ee624214612acb57806340f34d4214612a8f5780634f1ef286146127bf57806352d1902d1461272057806359ba9258146126e45780635b666b1e146126945780635c975abb1461265357806363a599a414612596578063715018a6146124da57806373ab99161461186757806387093eba14610a7c5780638da5cb5b14610a285780639ad91d4c14610977578063a06056f714610936578063ad3cb1cc146108d0578063bdeb442d14610846578063c0253023146107a7578063c1b0bed714610754578063c44956d114610716578063c4d66de8146102cd578063c879dbe414610284578063e33845cf14610226578063f2fde38b146101f7578063fddd4837146101d1578063fe18ab911461018d5763ffc33f7214610149575f80fd5b346101875760c0516003193601126101875760207f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054604051908152f35b60c05180fd5b346101875760c051600319360112610187576020600160ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b604051908152f35b346101875760c0516003193601126101875760206101ed612d3f565b6040519015158152f35b3461018757602060031936011261018757610220610213612b21565b61021b612f0e565b612c52565b60c05180f35b346101875760c0516003193601126101875760206040517fffffffff000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000168152f35b346101875760206003193601126101875760206101ed6004355f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b34610187576020600319360112610187576102e6612b21565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460ff8160401c16159167ffffffffffffffff82168015908161070e575b6001149081610704575b1590816106fb575b506106cf57818360017fffffffffffffffffffffffffffffffffffffffffffffffff000000000000000061039f9516177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005561067a575b5061039761327c565b61021b61327c565b6103a761327c565b6103af61327c565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90254680100000000000000008110156106495780600161043292017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b81549060031b905f197fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b06831b921b191617905560c0517f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055610492613de2565b507f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d260206040517fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b068152a16104e561327c565b7fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a2610579612d3f565b61061d576105875760c05180f35b7fffffffffffffffffffffffffffffffffffffffffffffff00ffffffffffffffff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054167ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00557fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2602060405160018152a1610220565b7f0b1d38a30000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526041600452602460c051fd5b7fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000001668010000000000000001177ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00558361038e565b7ff92ee8a90000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b90501584610337565b303b15915061032f565b849150610325565b346101875760c0516003193601126101875760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054604051908152f35b346101875760206003193601126101875760c0515060043560c051527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc016020526020604060c05120541515604051908152f35b34610187576020600319360112610187576004356107c3612f0e565b801561081a57807f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700557f902d68080c9f4bf7ed1c926758236afc2b4044487f6f8684352d38087244aee660c05160c051a260c05180f35b7f774d5de10000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b346101875760c051600319360112610187577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903545f19810190811161089f576108906020916130eb565b90549060031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526011600452602460c051fd5b346101875760c0516003193601126101875760408051610932916108f49082612b8d565b600581527f352e302e300000000000000000000000000000000000000000000000000000006020820152604051918291602083526020830190612c20565b0390f35b346101875760c05160031936011261018757602060ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416604051908152f35b34610187576020600319360112610187577f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054600435908110156109f7576020907f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0060c051528160c051200160c051505460c05160031b1c604051908152f35b7f4e487b710000000000000000000000000000000000000000000000000000000060c051526032600452602460c051fd5b346101875760c05160031936011261018757602073ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c1993005416604051908152f35b346101875760406003193601126101875767ffffffffffffffff6004351161018757606060031960043536030112610187576024358015158103610187575a6080527f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c61183b5760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610b10612f7a565b610b1e600480350180612fcd565b809291501561180f57610b3082613039565b610b38613156565b50604051610b4581612b44565b60c051815260c05160208201529260c05160a05260c0515b8181106112c9575050806020610ba5925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b3691612bcc565b856141a2565b909391936141dc565b602081519101519060c0515260205273ffffffffffffffffffffffffffffffffffffffff80604060c05120169116908082036112975750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a70054610c0d600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000610c6363ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152610caa606482612b8d565b60c051915b808310610f995750602080925060405191805191829101835e81019060c05182528060c05192039060025afa15610f5a5760c05151610cf860446004350160043560040161322b565b909281600411610187577fffffffff000000000000000000000000000000000000000000000000000000008435167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203610f6757505015610e7e575b50505060a051610e0b575b7f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d610ddc5a608051612c45565b7f6f1498310000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b610e1660a051613d32565b15610e4c577f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d2602060405160a0518152a1610d83565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c0515260a051600452602460c051fd5b73ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b1561018757610ef96040519485937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b927f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e60248401526044830152818060c0519403915afa8015610f5a57610f41575b8080610d78565b60c051610f4d91612b8d565b60c0516101875781610f3a565b6040513d60c051823e3d90fd5b7f78a2221c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b90610fb283610fac600480350180612fcd565b9061306a565b610fbc8180612fcd565b919050610ff163ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b1660208201526004815261102e602482612b8d565b9160c051905b808210611213575050602081019160206110f36004826110548787612fcd565b95905061108963ffffffff871662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519683889451918291018686015e83019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b9260c051915b8083106111915750505060019260208093611188936111526060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e8401908382019060c0518252519283915e010160c051815203601f198101835282612b8d565b92019190610caf565b909193602061120a604060019383806111b48b6111ae8b8d612fcd565b906131b8565b6111c86111c38683018361316e565b6142b4565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e010160c051838201520301601f198101835282612b8d565b940191906110f9565b9092602061128f606060019383806112358a61122f8b80612fcd565b906131a1565b6112446111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e010160c051838201520301601f198101835282612b8d565b930190611034565b7fe6d44b4c0000000000000000000000000000000000000000000000000000000060c05152600452602452604460c051fd5b6112db81610fac600480350180612fcd565b60c051909590866112ec8180612fcd565b90506112f781613039565b61130082613039565b9160c0515b81811061170d57505061131b6020840184612fcd565b92905061132783613039565b9161133184613039565b9360c051905b8082106114af575050926113ab7f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc32959361139d6113b99461138f608098604051998a990135895260a060208a015260a08901906131f8565b9087820360408901526131f8565b9085820360608701526131f8565b9083820360808501526131f8565b0390a1806114a6575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0873603011261018757604051906113fc82612b44565b6040870135825260208201606088013581526040519261141b84612b44565b5f84525f60208501526114318151835190613986565b1561146e578260019594926114539260206080965193015190519151926139e8565b6020830152815296013561146782866130d7565b5201610b5d565b604491604051917fb8a0e8a1000000000000000000000000000000000000000000000000000000008352516004830152516024820152fd5b60a052866113c2565b9192939495819750906111ae8260206114c9940190612fcd565b9560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154167f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900545f19811461089f57600181017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900559088359160c0515b82811061165257505090600192917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b146115f9575b50976020810135906115d66115cf604083016115c96115c3828661316e565b86613518565b8361316e565b8235613762565b356115e183896130d7565b526115ec82896130d7565b52018c9594939291611337565b61164761164061164c9261160c856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c05152602060c051200154809461415f565b928061415f565b61336c565b8f6115a4565b90926001908185166116d0576116c5907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c051528084602060c0512001557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90260c0515283602060c0512001549061415f565b935b811c9101611547565b611707907f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90160c0515283602060c05120015461415f565b936116c7565b909192938161122f8261171f93612fcd565b6040810135611758815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b156117e057506117688135613c7d565b156117b0579081602060019301359061178e6115cf606083016115c96115c3828661316e565b3561179983876130d7565b526117a482876130d7565b5201908a939291611305565b7f39a940c50000000000000000000000000000000000000000000000000000000060c0515235600452602460c051fd5b7ff9849ea30000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b7fcf1b093c0000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b7f3ee5aeb50000000000000000000000000000000000000000000000000000000060c05152600460c051fd5b34611cc4576020600319360112611cc45767ffffffffffffffff60043511611cc457606060031960043536030112611cc4577f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6124b25760017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6118eb612f7a565b6118f9600480350180612fcd565b8091501561248a5761190a81613039565b90611913613156565b5060405161192081612b44565b5f81525f6020820152915f915f5b818110611f60575050806020611960925160051b91012092610b9c610b96610b8f60246004350160043560040161322b565b60208151910151905f5260205273ffffffffffffffffffffffffffffffffffffffff8060405f2016911690808203611f325750507f3d00115d316bc70efe890550f490ccb6fcbb5768711f93a773ced4553de0a700546119c4600480350180612fcd565b9190507fffffffff00000000000000000000000000000000000000000000000000000000611a1a63ffffffff841662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b604051927f88df64fe233c97307dd518c1757bf6cfca1f17f7103b4069dd9e2848db9d84346020850152604084015260e01b16606082015260448152611a61606482612b8d565b905f905b808210611cf65750505f60208092604051918183925191829101835e8101838152039060025afa15611cb9575f51611aa760446004350160043560040161322b565b80600411611cc4577fffffffff000000000000000000000000000000000000000000000000000000008235167fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016808203611cc857505073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803b15611cc4575f92611ba192604051958694859384937fab750e7500000000000000000000000000000000000000000000000000000000855260606004860152606485019161372b565b907f5dc2615f3d14a517a25aadfe53a882394e602740514574f3201bbe735269058e6024840152604483015203915afa8015611cb957611ca5575b5080611c37575b507f862d83c6c5af275e697bfd4e27c8323c196b44bdd011dd9aaab6db0ec9943dce60c05160c051a260c0517f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d60c05180f35b611c4081613d32565b15611c765760207f0a2dc548ed950accb40d5d78541f3954c5e182a8ecf19e581a4f2263f61f59d291604051908152a181611be3565b7fdb788c2b0000000000000000000000000000000000000000000000000000000060c05152600452602460c051fd5b5f611caf91612b8d565b5f60c05282611bdc565b6040513d5f823e3d90fd5b5f80fd5b7f78a2221c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b9091611d0a83610fac600480350180612fcd565b611d148180612fcd565b919050611d4963ffffffff831662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b7fffffffff000000000000000000000000000000000000000000000000000000006040519160e01b16602082015260048152611d86602482612b8d565b915f905b808210611eb657505060208101916020611daa6004826110548787612fcd565b925f915b808310611e415750505060019260208093611e3993611e076060846040518094608083808401988051918291018a5e83019160408101358584015285810135604084015201358482015203016040810184520182612b8d565b6040519584879551918291018587015e840190838201905f8252519283915e01015f815203601f198101835282612b8d565b920190611a65565b9091936020611ead60406001938380611e5e8b6111ae8b8d612fcd565b611e6d6111c38683018361316e565b82865198868a9751918291018389015e860192803582850152013586830152805192839101606083015e01015f838201520301601f198101835282612b8d565b94019190611dae565b90926020611f2a60606001938380611ed28a61122f8b80612fcd565b611ee16111c38683018361316e565b6040805198868a9751918291018689015e8601928035858501528481013582850152013586830152805192839101608083015e01015f838201520301601f198101835282612b8d565b930190611d8a565b7fe6d44b4c000000000000000000000000000000000000000000000000000000005f5260045260245260445ffd5b611f7281610fac600480350180612fcd565b5f95611f7e8280612fcd565b979050611f8a88613039565b611f9389613039565b985f5b818110612387575050611fac6020850185612fcd565b999050611fb88a613039565b99611fc281613039565b905f905b8082106120da575050906120217f4ce7c1102060be4f28b229199140fdd5112d4214fe9541bc9b23541e4592cc3293926113ab61139d9d60808a01359e8f9561138f604051988998895260a060208a015260a08901906131f8565b0390a1806120d2575b5060407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc08336030112611cc4576040519161206483612b44565b6040810135835260606020840191013581526040519261208384612b44565b5f84525f60208501526120998151835190613986565b1561146e57916120b99160019594936020835193015190519151926139e8565b60208301528152956120cb82866130d7565b520161192e565b95508761202a565b9094506120ee856111ae60208a018a612fcd565b9460ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015416957f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90054965f19881461235a57878f986001017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90055908235915f5b8281106122765750509060019392917f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc900548560ff7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90154161b1461220f575b50976121fc836020840135936121f56115cf604083016115c96121ef828661316e565b89613518565b35926130d7565b5261220782866130d7565b520190611fc6565b61164761164061227092612222856132d3565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d431015493849061415f565b5f6121cc565b9092600190818516612303577fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f83018190557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025f527fc16ee73eec0ef4d2332a24ca3268ed9e51b774c2c5af5f5c59c25dbb3b74d4318301546122f89161415f565b935b811c910161216e565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015f527fc36adbe7d1fe63428efa33f52fcbd6115d89171225057b1e1f8e7e98617a479f830154612354919061415f565b936122fa565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b6123958161122f8880612fcd565b60408101356123ce815f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054151590565b1561245f575080356123df81613c7d565b15612434579061242d838e6001959461241d612417602087013596606081019061241261240c838361316e565b8a613518565b61316e565b82613762565b612427838a6130d7565b526130d7565b5201611f96565b7f39a940c5000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7ff9849ea3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7fcf1b093c000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b34611cc4575f600319360112611cc4576124f2612f0e565b5f73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300547fffffffffffffffffffffffff000000000000000000000000000000000000000081167f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e08280a3005b34611cc4575f600319360112611cc4576125ae612f0e565b6125b6612f7a565b6125be612f7a565b60017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff007fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416177fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a2586020604051338152a1005b34611cc4575f600319360112611cc457602060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f0330054166040519015158152f35b34611cc4575f600319360112611cc457602060405173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000168152f35b34611cc4575f600319360112611cc45760207f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354604051908152f35b34611cc4575f600319360112611cc45773ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001630036127975760206040517f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8152f35b7fe07c8dba000000000000000000000000000000000000000000000000000000005f5260045ffd5b6040600319360112611cc4576127d3612b21565b60243567ffffffffffffffff8111611cc4576127f3903690600401612c02565b9073ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016803014908115612a4d575b5061279757612843612f0e565b73ffffffffffffffffffffffffffffffffffffffff8116916040517f52d1902d000000000000000000000000000000000000000000000000000000008152602081600481875afa5f9181612a19575b506128c357837f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b807f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8592036129ee5750823b156129c357807fffffffffffffffffffffffff00000000000000000000000000000000000000007f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416177f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc557fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f80a28051156129925761299091613411565b005b50503461299b57005b7fb398979f000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f4c9c8ce3000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7faa1d49a4000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b9091506020813d602011612a45575b81612a3560209383612b8d565b81010312611cc457519085612892565b3d9150612a28565b905073ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416141583612836565b34611cc4575f600319360112611cc45760207f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054604051908152f35b34611cc4576020600319360112611cc45760206108906004356130eb565b34611cc4575f600319360112611cc457807f322e302e302d616c7068612e320000000000000000000000000000000000000060209252f35b6004359073ffffffffffffffffffffffffffffffffffffffff82168203611cc457565b6040810190811067ffffffffffffffff821117612b6057604052565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b90601f601f19910116810190811067ffffffffffffffff821117612b6057604052565b67ffffffffffffffff8111612b6057601f01601f191660200190565b929192612bd882612bb0565b91612be66040519384612b8d565b829481845281830111611cc4578281602093845f960137010152565b9080601f83011215611cc457816020612c1d93359101612bcc565b90565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b9190820391821161235a57565b73ffffffffffffffffffffffffffffffffffffffff168015612d135773ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054827fffffffffffffffffffffffff00000000000000000000000000000000000000008216177f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930055167f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e05f80a3565b7f1e4fbdf7000000000000000000000000000000000000000000000000000000005f525f60045260245ffd5b6040517f3cadf4490000000000000000000000000000000000000000000000000000000081527fffffffff000000000000000000000000000000000000000000000000000000007f000000000000000000000000000000000000000000000000000000000000000016600482015260208160248173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000165afa908115611cb9575f91612ebe575b50602073ffffffffffffffffffffffffffffffffffffffff916004604051809481937f5c975abb000000000000000000000000000000000000000000000000000000008352165afa908115611cb9575f91612e83575b508015612e5a5790565b5060ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300541690565b90506020813d602011612eb6575b81612e9e60209383612b8d565b81010312611cc457518015158103611cc4575f612e50565b3d9150612e91565b90506020813d602011612f06575b81612ed960209383612b8d565b81010312611cc4575173ffffffffffffffffffffffffffffffffffffffff81168103611cc4576020612dfa565b3d9150612ecc565b73ffffffffffffffffffffffffffffffffffffffff7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930054163303612f4e57565b7f118cdaa7000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b60ff7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005416612fa557565b7fd93c0665000000000000000000000000000000000000000000000000000000005f5260045ffd5b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918160051b36038313611cc457565b67ffffffffffffffff8111612b605760051b60200190565b9061304382613021565b6130506040519182612b8d565b828152601f196130608294613021565b0190602036910137565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6181360301821215611cc4570190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b80518210156130aa5760209160051b010190565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903548110156130aa577f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9035f5260205f2001905f90565b80548210156130aa575f5260205f2001905f90565b6040519061316382612b44565b5f6020838281520152565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8181360301821215611cc4570190565b908210156130aa57612c1d9160051b81019061316e565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa181360301821215611cc4570190565b90602080835192838152019201905f5b8181106132155750505090565b8251845260209384019390920191600101613208565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215611cc4570180359067ffffffffffffffff8211611cc457602001918136038313611cc457565b60ff7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005460401c16156132ab57565b7fd7e6bcf8000000000000000000000000000000000000000000000000000000005f5260045ffd5b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9015468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc901613141565b5f19829392549160031b92831b921b1916179055565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9025468010000000000000000811015612b605780600161335692017f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902557f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc902613141565b805468010000000000000000811015612b605761335691600182018155613141565b905f8091602081519101845af480806134c5575b156134455750506040513d81523d5f602083013e60203d82010160405290565b1561348c5773ffffffffffffffffffffffffffffffffffffffff907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b3d1561349d576040513d5f823e3d90fd5b7fd6bda275000000000000000000000000000000000000000000000000000000005f5260045ffd5b503d1515806134255750813b1515613425565b91908110156130aa5760051b810135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc181360301821215611cc4570190565b90604081016135278183612fcd565b9290505f5b83811061353a575050505050565b61355b6135518261354b8686612fcd565b906134d8565b602081019061322b565b8101606082820312611cc45781359173ffffffffffffffffffffffffffffffffffffffff8316809303611cc457602081013567ffffffffffffffff8111611cc457826135a8918301612c02565b91604082013567ffffffffffffffff8111611cc4576135c79201612c02565b90604051917f33a89203000000000000000000000000000000000000000000000000000000008352886004840152604060248401525f838061360c6044820186612c20565b038183885af1928315611cb9575f936136af575b50825160208401208151602083012003613674575060019392917fcddb327adb31fe5437df2a8c68301bb13a6baae432a804838caaf682506aadf19161366b60405192839283613f2d565b0390a20161352c565b90506136ab6040519283927fc504fada00000000000000000000000000000000000000000000000000000000845260048401613f2d565b0390fd5b9092503d805f833e6136c18183612b8d565b810190602081830312611cc45780519067ffffffffffffffff8211611cc4570181601f82011215611cc4578051906136f882612bb0565b926137066040519485612b8d565b82845260208383010111611cc457815f9260208093018386015e83010152915f613620565b601f8260209493601f1993818652868601375f8582860101520116010190565b604090612c1d94928152816020820152019161372b565b9061376d8180612fcd565b5f5b818110613917575050506137866020820182612fcd565b5f5b8181106138a85750505061379f6040820182612fcd565b5f5b818110613839575050508060606137b9920190612fcd565b90915f5b8281106137ca5750505050565b6137d58184866134d8565b35906002821015611cc45760018092146137f0575b016137bd565b827fa494dac4b7184843583f972e06783e2c3bb47f4f0137b8df52a860df07219f8c61382061355184888a6134d8565b90613831604051928392878461374b565b0390a26137ea565b6138448183856134d8565b35906002821015611cc457600180921461385f575b016137a1565b857f9c61b290f631097f56273cf4daf40df1ff9ccc33f101d464837da1f5ae18bd5961388f6135518487896134d8565b906138a0604051928392878461374b565b0390a2613859565b6138b38183856134d8565b35906002821015611cc45760018092146138ce575b01613788565b857f48243873b4752ddcb45e0d7b11c4c266583e5e099a0b798fdd9c1af7d49324f36138fe6135518487896134d8565b9061390f604051928392878461374b565b0390a26138c8565b6139228183856134d8565b35906002821015611cc457600180921461393d575b0161376f565b857f3a134d01c07803003c63301717ddc4612e6c47ae408eeea3222cded532d02ae661396d6135518487896134d8565b9061397e604051928392878461374b565b0390a2613937565b801580156139d8575b80156139d0575b80156139c0575b6139ba576401000003d01960078180938181800909089180091490565b50505f90565b506401000003d01982101561399d565b508115613996565b506401000003d01981101561398f565b90939290915f90808403613c615750506401000003d0195f918508613a1157505090505f905f90565b6401000003d0198060018180613a78818080613a689a81808f800996879281808080808f81818192099987096004099780095f09928009600309089181613a5b8183800882612c45565b81858009089d8e83612c45565b9008900993800960080983612c45565b900896096002099391905b8415158581613c50575b5080613c48575b15613bea5780946001906401000003d019918184925b613afe575050505080613ad15750906401000003d019809281808780098092099509900990565b807f4e487b7100000000000000000000000000000000000000000000000000000000602492526012600452fd5b929791928015613bbd57808904918094613b90576401000003d0199083096401000003d019036401000003d019811161235a576401000003d0199086940893988192828102928184041490151715613b635790613b5a91612c45565b90929080613aaa565b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526011600452fd5b6024867f4e487b710000000000000000000000000000000000000000000000000000000081526012600452fd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f496e76616c6964206e756d6265720000000000000000000000000000000000006044820152fd5b506001613a94565b6401000003d019915014155f613a8d565b6401000003d019929195613c7494613f52565b93909190613a83565b805f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2054155f14613d2d57613cda817f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc006133ef565b7f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0054905f527f5d2cc44bcf41d6324882f1c0d709f1b9ae20caeebcbf2358127a3d0a8c22cc0160205260405f2055600190565b505f90565b805f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2054155f14613d2d57613d8f817f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90354905f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc90460205260405f2055600190565b7fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e54613f2957613e997fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b067f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9036133ef565b7f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc903547fcc1d2f838445db7aec431df9ee8a871f40e7aa5e064fc056633ef8c60fab7b065f527f762a46a11c460b9bcb2bb98651da03b192a02e2a33ab26da9bf9ed53826bc9046020527f5deb946ebbf617e36331f9b8f582f11645232839ec35aa4ea6e3124c4262e96e55600190565b5f90565b9091613f44612c1d93604084526040840190612c20565b916020818403910152612c20565b9492909391851580614157575b61414c57801580614144575b61413c57604051608091613f7f8383612b8d565b823683378415613bbd5784600180098083529385856001099860208401998a52604084019286845287845160010993606086019485526040519a878c01958c871067ffffffffffffffff881117612b60578a80979581969482956040525190098d525190099460208b019586525190099860408901998a52519009606087019081528651885114801590614130575b156140d257849283808093816040519c8561402a8f9788612b8d565b368737518c5161403a9083612c45565b9008845251855161404b9083612c45565b90089860208301998a5281808b8180808089518a5190099360408a019485528185518b5190096060909a01998a5251800988516140889083612c45565b9008818087518551900960020961409f9083612c45565b90089c519351905190096140b38c83612c45565b900890099251905190096140c79083612c45565b900894510991929190565b60646040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f557365206a6163446f75626c652066756e6374696f6e20696e737465616400006044820152fd5b5081518151141561400e565b505050600190565b508115613f6b565b945092506001919050565b508415613f5f565b5f9060209260405190848201928352604082015260408152614182606082612b8d565b604051918291518091835e8101838152039060025afa15611cb9575f5190565b81519190604183036141d2576141cb9250602082015190606060408401519301515f1a90614516565b9192909190565b50505f9160029190565b600481101561428757806141ee575050565b6001810361421e577ff645eedf000000000000000000000000000000000000000000000000000000005f5260045ffd5b6002810361425257507ffce698f7000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b60031461425c5750565b7fd78bce0c000000000000000000000000000000000000000000000000000000005f5260045260245ffd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b6142be8180612fcd565b63ffffffff9150166142f29062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b6142fc8280612fcd565b614305916145a5565b9160208101906143158282612fcd565b63ffffffff9150166143499062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b916143549082612fcd565b61435d916145a5565b6040820161436b8184612fcd565b63ffffffff91501661439f9062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b906143aa9084612fcd565b6143b3916145a5565b9160608401936143c38582612fcd565b63ffffffff9150166143f79062ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b9461440191612fcd565b61440a916145a5565b9460405197889760e01b7fffffffff000000000000000000000000000000000000000000000000000000001660208901528051602081920160248a015e87019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016602482015281516020819301602883015e016024019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e016004019060e01b7fffffffff0000000000000000000000000000000000000000000000000000000016600482015281516020819301600883015e01600401600481015f905203600401601f1981018252612c1d9082612b8d565b91907f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0841161459a579160209360809260ff5f9560405194855216868401526040830152606082015282805260015afa15611cb9575f5173ffffffffffffffffffffffffffffffffffffffff81161561459057905f905f90565b505f906001905f90565b5050505f9160039190565b606092915f915b8183106145b857505050565b9091936145ff63ffffffff6145d16135518887876134d8565b905060021c1662ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b61460d6135518786866134d8565b61461b8887879594956134d8565b35906002821015611cc4576001946020947fffffffff0000000000000000000000000000000000000000000000000000000086846146df9760049796614684899862ff00ff63ff00ff008260081b169160081c161763ffffffff808260101b169160101c161790565b95856040519c898e9a5191829101888c015e89019360e01b1685840152602483013701019160e01b168382015203017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe4810184520182612b8d565b940191906145ac56fea164736f6c6343000824000a
+    /// ```
+    #[rustfmt::skip]
+    #[allow(clippy::all)]
+    pub static DEPLOYED_BYTECODE: alloy_sol_types::private::Bytes = alloy_sol_types::private::Bytes::from_static(
+        b"`\xE0\x80`@R`\x046\x10\x15a\0\x12W_\x80\xFD[_`\xC0R_5`\xE0\x1C\x90\x81c\r\x8En,\x14a*\xE9WP\x80c1\xEEbB\x14a*\xCBW\x80c@\xF3MB\x14a*\x8FW\x80cO\x1E\xF2\x86\x14a'\xBFW\x80cR\xD1\x90-\x14a' W\x80cY\xBA\x92X\x14a&\xE4W\x80c[fk\x1E\x14a&\x94W\x80c\\\x97Z\xBB\x14a&SW\x80cc\xA5\x99\xA4\x14a%\x96W\x80cqP\x18\xA6\x14a$\xDAW\x80cs\xAB\x99\x16\x14a\x18gW\x80c\x87\t>\xBA\x14a\n|W\x80c\x8D\xA5\xCB[\x14a\n(W\x80c\x9A\xD9\x1DL\x14a\twW\x80c\xA0`V\xF7\x14a\t6W\x80c\xAD<\xB1\xCC\x14a\x08\xD0W\x80c\xBD\xEBD-\x14a\x08FW\x80c\xC0%0#\x14a\x07\xA7W\x80c\xC1\xB0\xBE\xD7\x14a\x07TW\x80c\xC4IV\xD1\x14a\x07\x16W\x80c\xC4\xD6m\xE8\x14a\x02\xCDW\x80c\xC8y\xDB\xE4\x14a\x02\x84W\x80c\xE38E\xCF\x14a\x02&W\x80c\xF2\xFD\xE3\x8B\x14a\x01\xF7W\x80c\xFD\xDDH7\x14a\x01\xD1W\x80c\xFE\x18\xAB\x91\x14a\x01\x8DWc\xFF\xC3?r\x14a\x01IW_\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0T`@Q\x90\x81R\xF3[`\xC0Q\x80\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\x01`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B`@Q\x90\x81R\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` a\x01\xEDa-?V[`@Q\x90\x15\x15\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02 a\x02\x13a+!V[a\x02\x1Ba/\x0EV[a,RV[`\xC0Q\x80\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `@Q\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W` a\x01\xED`\x045_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87Wa\x02\xE6a+!V[\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`\xFF\x81`@\x1C\x16\x15\x91g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x80\x15\x90\x81a\x07\x0EW[`\x01\x14\x90\x81a\x07\x04W[\x15\x90\x81a\x06\xFBW[Pa\x06\xCFW\x81\x83`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0a\x03\x9F\x95\x16\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0Ua\x06zW[Pa\x03\x97a2|V[a\x02\x1Ba2|V[a\x03\xA7a2|V[a\x03\xAFa2|V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a\x06IW\x80`\x01a\x042\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x81T\x90`\x03\x1B\x90_\x19\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x83\x1B\x92\x1B\x19\x16\x17\x90U`\xC0Q\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0Ua\x04\x92a=\xE2V[P\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x81R\xA1a\x04\xE5a2|V[\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\xE3\xB0\xC4B\x98\xFC\x1C\x14\x9A\xFB\xF4\xC8\x99o\xB9$'\xAEA\xE4d\x9B\x93L\xA4\x95\x99\x1BxR\xB8U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2a\x05ya-?V[a\x06\x1DWa\x05\x87W`\xC0Q\x80\xF3[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T\x16\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x7F\xC7\xF5\x05\xB2\xF3q\xAE!u\xEEI\x13\xF4I\x9E\x1F&3\xA7\xB5\x93c!\xEE\xD1\xCD\xAE\xB6\x11Q\x81\xD2` `@Q`\x01\x81R\xA1a\x02 V[\x7F\x0B\x1D8\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`A`\x04R`$`\xC0Q\xFD[\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\x16h\x01\0\0\0\0\0\0\0\x01\x17\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0U\x83a\x03\x8EV[\x7F\xF9.\xE8\xA9\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x90P\x15\x84a\x037V[0;\x15\x91Pa\x03/V[\x84\x91Pa\x03%V[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\xC0QP`\x045`\xC0QR\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R` `@`\xC0Q T\x15\x15`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W`\x045a\x07\xC3a/\x0EV[\x80\x15a\x08\x1AW\x80\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0U\x7F\x90-h\x08\x0C\x9FK\xF7\xED\x1C\x92gX#j\xFC+@DH\x7Fo\x86\x845-8\x08rD\xAE\xE6`\xC0Q`\xC0Q\xA2`\xC0Q\x80\xF3[\x7FwM]\xE1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T_\x19\x81\x01\x90\x81\x11a\x08\x9FWa\x08\x90` \x91a0\xEBV[\x90T\x90`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x11`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W`@\x80Qa\t2\x91a\x08\xF4\x90\x82a+\x8DV[`\x05\x81R\x7F5.0.0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x82\x01R`@Q\x91\x82\x91` \x83R` \x83\x01\x90a, V[\x03\x90\xF3[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` `\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16`@Q\x90\x81R\xF3[4a\x01\x87W` `\x03\x196\x01\x12a\x01\x87W\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`\x045\x90\x81\x10\x15a\t\xF7W` \x90\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0`\xC0QR\x81`\xC0Q \x01`\xC0QPT`\xC0Q`\x03\x1B\x1C`@Q\x90\x81R\xF3[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`2`\x04R`$`\xC0Q\xFD[4a\x01\x87W`\xC0Q`\x03\x196\x01\x12a\x01\x87W` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x16`@Q\x90\x81R\xF3[4a\x01\x87W`@`\x03\x196\x01\x12a\x01\x87Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x01\x87W```\x03\x19`\x0456\x03\x01\x12a\x01\x87W`$5\x80\x15\x15\x81\x03a\x01\x87WZ`\x80R\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a\x18;W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x0B\x10a/zV[a\x0B\x1E`\x04\x805\x01\x80a/\xCDV[\x80\x92\x91P\x15a\x18\x0FWa\x0B0\x82a09V[a\x0B8a1VV[P`@Qa\x0BE\x81a+DV[`\xC0Q\x81R`\xC0Q` \x82\x01R\x92`\xC0Q`\xA0R`\xC0Q[\x81\x81\x10a\x12\xC9WPP\x80` a\x0B\xA5\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[6\x91a+\xCCV[\x85aA\xA2V[\x90\x93\x91\x93aA\xDCV[` \x81Q\x91\x01Q\x90`\xC0QR` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@`\xC0Q \x16\x91\x16\x90\x80\x82\x03a\x12\x97WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x0C\r`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x0Ccc\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x0C\xAA`d\x82a+\x8DV[`\xC0Q\x91[\x80\x83\x10a\x0F\x99WP` \x80\x92P`@Q\x91\x80Q\x91\x82\x91\x01\x83^\x81\x01\x90`\xC0Q\x82R\x80`\xC0Q\x92\x03\x90`\x02Z\xFA\x15a\x0FZW`\xC0QQa\x0C\xF8`D`\x045\x01`\x045`\x04\x01a2+V[\x90\x92\x81`\x04\x11a\x01\x87W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x845\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x0FgWPP\x15a\x0E~W[PPP`\xA0Qa\x0E\x0BW[\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\r\xDCZ`\x80Qa,EV[\x7Fo\x14\x981\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[a\x0E\x16`\xA0Qa=2V[\x15a\x0ELW\x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2` `@Q`\xA0Q\x81R\xA1a\r\x83V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\xA0Q`\x04R`$`\xC0Q\xFD[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x01\x87Wa\x0E\xF9`@Q\x94\x85\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x92\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x81\x80`\xC0Q\x94\x03\x91Z\xFA\x80\x15a\x0FZWa\x0FAW[\x80\x80a\rxV[`\xC0Qa\x0FM\x91a+\x8DV[`\xC0Qa\x01\x87W\x81a\x0F:V[`@Q=`\xC0Q\x82>=\x90\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[\x90a\x0F\xB2\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[\x90a0jV[a\x0F\xBC\x81\x80a/\xCDV[\x91\x90Pa\x0F\xF1c\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x10.`$\x82a+\x8DV[\x91`\xC0Q\x90[\x80\x82\x10a\x12\x13WPP` \x81\x01\x91` a\x10\xF3`\x04\x82a\x10T\x87\x87a/\xCDV[\x95\x90Pa\x10\x89c\xFF\xFF\xFF\xFF\x87\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x96\x83\x88\x94Q\x91\x82\x91\x01\x86\x86\x01^\x83\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x92`\xC0Q\x91[\x80\x83\x10a\x11\x91WPPP`\x01\x92` \x80\x93a\x11\x88\x93a\x11R``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90`\xC0Q\x82RQ\x92\x83\x91^\x01\x01`\xC0Q\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x91\x90a\x0C\xAFV[\x90\x91\x93` a\x12\n`@`\x01\x93\x83\x80a\x11\xB4\x8Ba\x11\xAE\x8B\x8Da/\xCDV[\x90a1\xB8V[a\x11\xC8a\x11\xC3\x86\x83\x01\x83a1nV[aB\xB4V[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x10\xF9V[\x90\x92` a\x12\x8F```\x01\x93\x83\x80a\x125\x8Aa\x12/\x8B\x80a/\xCDV[\x90a1\xA1V[a\x12Da\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01`\xC0Q\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x104V[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$R`D`\xC0Q\xFD[a\x12\xDB\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[`\xC0Q\x90\x95\x90\x86a\x12\xEC\x81\x80a/\xCDV[\x90Pa\x12\xF7\x81a09V[a\x13\0\x82a09V[\x91`\xC0Q[\x81\x81\x10a\x17\rWPPa\x13\x1B` \x84\x01\x84a/\xCDV[\x92\x90Pa\x13'\x83a09V[\x91a\x131\x84a09V[\x93`\xC0Q\x90[\x80\x82\x10a\x14\xAFWPP\x92a\x13\xAB\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x95\x93a\x13\x9Da\x13\xB9\x94a\x13\x8F`\x80\x98`@Q\x99\x8A\x99\x015\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x90\x87\x82\x03`@\x89\x01Ra1\xF8V[\x90\x85\x82\x03``\x87\x01Ra1\xF8V[\x90\x83\x82\x03`\x80\x85\x01Ra1\xF8V[\x03\x90\xA1\x80a\x14\xA6W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x876\x03\x01\x12a\x01\x87W`@Q\x90a\x13\xFC\x82a+DV[`@\x87\x015\x82R` \x82\x01``\x88\x015\x81R`@Q\x92a\x14\x1B\x84a+DV[_\x84R_` \x85\x01Ra\x141\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x82`\x01\x95\x94\x92a\x14S\x92` `\x80\x96Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x96\x015a\x14g\x82\x86a0\xD7V[R\x01a\x0B]V[`D\x91`@Q\x91\x7F\xB8\xA0\xE8\xA1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83RQ`\x04\x83\x01RQ`$\x82\x01R\xFD[`\xA0R\x86a\x13\xC2V[\x91\x92\x93\x94\x95\x81\x97P\x90a\x11\xAE\x82` a\x14\xC9\x94\x01\x90a/\xCDV[\x95`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T_\x19\x81\x14a\x08\x9FW`\x01\x81\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x885\x91`\xC0Q[\x82\x81\x10a\x16RWPP\x90`\x01\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x84`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\x15\xF9W[P\x97` \x81\x015\x90a\x15\xD6a\x15\xCF`@\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[\x86a5\x18V[\x83a1nV[\x825a7bV[5a\x15\xE1\x83\x89a0\xD7V[Ra\x15\xEC\x82\x89a0\xD7V[R\x01\x8C\x95\x94\x93\x92\x91a\x137V[a\x16Ga\x16@a\x16L\x92a\x16\x0C\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR` `\xC0Q \x01T\x80\x94aA_V[\x92\x80aA_V[a3lV[\x8Fa\x15\xA4V[\x90\x92`\x01\x90\x81\x85\x16a\x16\xD0Wa\x16\xC5\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x80\x84` `\xC0Q \x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02`\xC0QR\x83` `\xC0Q \x01T\x90aA_V[\x93[\x81\x1C\x91\x01a\x15GV[a\x17\x07\x90\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01`\xC0QR\x83` `\xC0Q \x01TaA_V[\x93a\x16\xC7V[\x90\x91\x92\x93\x81a\x12/\x82a\x17\x1F\x93a/\xCDV[`@\x81\x015a\x17X\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a\x17\xE0WPa\x17h\x815a<}V[\x15a\x17\xB0W\x90\x81` `\x01\x93\x015\x90a\x17\x8Ea\x15\xCF``\x83\x01a\x15\xC9a\x15\xC3\x82\x86a1nV[5a\x17\x99\x83\x87a0\xD7V[Ra\x17\xA4\x82\x87a0\xD7V[R\x01\x90\x8A\x93\x92\x91a\x13\x05V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR5`\x04R`$`\xC0Q\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04`\xC0Q\xFD[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4Wg\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF`\x045\x11a\x1C\xC4W```\x03\x19`\x0456\x03\x01\x12a\x1C\xC4W\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0\\a$\xB2W`\x01\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]a\x18\xEBa/zV[a\x18\xF9`\x04\x805\x01\x80a/\xCDV[\x80\x91P\x15a$\x8AWa\x19\n\x81a09V[\x90a\x19\x13a1VV[P`@Qa\x19 \x81a+DV[_\x81R_` \x82\x01R\x91_\x91_[\x81\x81\x10a\x1F`WPP\x80` a\x19`\x92Q`\x05\x1B\x91\x01 \x92a\x0B\x9Ca\x0B\x96a\x0B\x8F`$`\x045\x01`\x045`\x04\x01a2+V[` \x81Q\x91\x01Q\x90_R` Rs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x80`@_ \x16\x91\x16\x90\x80\x82\x03a\x1F2WPP\x7F=\0\x11]1k\xC7\x0E\xFE\x89\x05P\xF4\x90\xCC\xB6\xFC\xBBWhq\x1F\x93\xA7s\xCE\xD4U=\xE0\xA7\0Ta\x19\xC4`\x04\x805\x01\x80a/\xCDV[\x91\x90P\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a\x1A\x1Ac\xFF\xFF\xFF\xFF\x84\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[`@Q\x92\x7F\x88\xDFd\xFE#<\x970}\xD5\x18\xC1u{\xF6\xCF\xCA\x1F\x17\xF7\x10;@i\xDD\x9E(H\xDB\x9D\x844` \x85\x01R`@\x84\x01R`\xE0\x1B\x16``\x82\x01R`D\x81Ra\x1Aa`d\x82a+\x8DV[\x90_\x90[\x80\x82\x10a\x1C\xF6WPP_` \x80\x92`@Q\x91\x81\x83\x92Q\x91\x82\x91\x01\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Qa\x1A\xA7`D`\x045\x01`\x045`\x04\x01a2+V[\x80`\x04\x11a\x1C\xC4W\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x825\x16\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80\x82\x03a\x1C\xC8WPPs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x80;\x15a\x1C\xC4W_\x92a\x1B\xA1\x92`@Q\x95\x86\x94\x85\x93\x84\x93\x7F\xABu\x0Eu\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x85R```\x04\x86\x01R`d\x85\x01\x91a7+V[\x90\x7F]\xC2a_=\x14\xA5\x17\xA2Z\xAD\xFES\xA8\x829N`'@QEt\xF3 \x1B\xBEsRi\x05\x8E`$\x84\x01R`D\x83\x01R\x03\x91Z\xFA\x80\x15a\x1C\xB9Wa\x1C\xA5W[P\x80a\x1C7W[P\x7F\x86-\x83\xC6\xC5\xAF'^i{\xFDN'\xC82<\x19kD\xBD\xD0\x11\xDD\x9A\xAA\xB6\xDB\x0E\xC9\x94=\xCE`\xC0Q`\xC0Q\xA2`\xC0Q\x7F\x9Bw\x9B\x17B-\r\xF9\"#\x01\x8B2\xB4\xD1\xFAF\xE0qr=h\x17\xE2Hm\0;\xEC\xC5_\0]`\xC0Q\x80\xF3[a\x1C@\x81a=2V[\x15a\x1CvW` \x7F\n-\xC5H\xED\x95\n\xCC\xB4\r]xT\x1F9T\xC5\xE1\x82\xA8\xEC\xF1\x9EX\x1AO\"c\xF6\x1FY\xD2\x91`@Q\x90\x81R\xA1\x81a\x1B\xE3V[\x7F\xDBx\x8C+\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`\xC0QR`\x04R`$`\xC0Q\xFD[_a\x1C\xAF\x91a+\x8DV[_`\xC0R\x82a\x1B\xDCV[`@Q=_\x82>=\x90\xFD[_\x80\xFD[\x7Fx\xA2\"\x1C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[\x90\x91a\x1D\n\x83a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[a\x1D\x14\x81\x80a/\xCDV[\x91\x90Pa\x1DIc\xFF\xFF\xFF\xFF\x83\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`@Q\x91`\xE0\x1B\x16` \x82\x01R`\x04\x81Ra\x1D\x86`$\x82a+\x8DV[\x91_\x90[\x80\x82\x10a\x1E\xB6WPP` \x81\x01\x91` a\x1D\xAA`\x04\x82a\x10T\x87\x87a/\xCDV[\x92_\x91[\x80\x83\x10a\x1EAWPPP`\x01\x92` \x80\x93a\x1E9\x93a\x1E\x07``\x84`@Q\x80\x94`\x80\x83\x80\x84\x01\x98\x80Q\x91\x82\x91\x01\x8A^\x83\x01\x91`@\x81\x015\x85\x84\x01R\x85\x81\x015`@\x84\x01R\x015\x84\x82\x01R\x03\x01`@\x81\x01\x84R\x01\x82a+\x8DV[`@Q\x95\x84\x87\x95Q\x91\x82\x91\x01\x85\x87\x01^\x84\x01\x90\x83\x82\x01\x90_\x82RQ\x92\x83\x91^\x01\x01_\x81R\x03`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x92\x01\x90a\x1AeV[\x90\x91\x93` a\x1E\xAD`@`\x01\x93\x83\x80a\x1E^\x8Ba\x11\xAE\x8B\x8Da/\xCDV[a\x1Ema\x11\xC3\x86\x83\x01\x83a1nV[\x82\x86Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x83\x89\x01^\x86\x01\x92\x805\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01``\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x94\x01\x91\x90a\x1D\xAEV[\x90\x92` a\x1F*```\x01\x93\x83\x80a\x1E\xD2\x8Aa\x12/\x8B\x80a/\xCDV[a\x1E\xE1a\x11\xC3\x86\x83\x01\x83a1nV[`@\x80Q\x98\x86\x8A\x97Q\x91\x82\x91\x01\x86\x89\x01^\x86\x01\x92\x805\x85\x85\x01R\x84\x81\x015\x82\x85\x01R\x015\x86\x83\x01R\x80Q\x92\x83\x91\x01`\x80\x83\x01^\x01\x01_\x83\x82\x01R\x03\x01`\x1F\x19\x81\x01\x83R\x82a+\x8DV[\x93\x01\x90a\x1D\x8AV[\x7F\xE6\xD4KL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$R`D_\xFD[a\x1Fr\x81a\x0F\xAC`\x04\x805\x01\x80a/\xCDV[_\x95a\x1F~\x82\x80a/\xCDV[\x97\x90Pa\x1F\x8A\x88a09V[a\x1F\x93\x89a09V[\x98_[\x81\x81\x10a#\x87WPPa\x1F\xAC` \x85\x01\x85a/\xCDV[\x99\x90Pa\x1F\xB8\x8Aa09V[\x99a\x1F\xC2\x81a09V[\x90_\x90[\x80\x82\x10a \xDAWPP\x90a !\x7FL\xE7\xC1\x10 `\xBEO(\xB2)\x19\x91@\xFD\xD5\x11-B\x14\xFE\x95A\xBC\x9B#T\x1EE\x92\xCC2\x93\x92a\x13\xABa\x13\x9D\x9D`\x80\x8A\x015\x9E\x8F\x95a\x13\x8F`@Q\x98\x89\x98\x89R`\xA0` \x8A\x01R`\xA0\x89\x01\x90a1\xF8V[\x03\x90\xA1\x80a \xD2W[P`@\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC0\x836\x03\x01\x12a\x1C\xC4W`@Q\x91a d\x83a+DV[`@\x81\x015\x83R``` \x84\x01\x91\x015\x81R`@Q\x92a \x83\x84a+DV[_\x84R_` \x85\x01Ra \x99\x81Q\x83Q\x90a9\x86V[\x15a\x14nW\x91a \xB9\x91`\x01\x95\x94\x93` \x83Q\x93\x01Q\x90Q\x91Q\x92a9\xE8V[` \x83\x01R\x81R\x95a \xCB\x82\x86a0\xD7V[R\x01a\x19.V[\x95P\x87a *V[\x90\x94Pa \xEE\x85a\x11\xAE` \x8A\x01\x8Aa/\xCDV[\x94`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x95\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x96_\x19\x88\x14a#ZW\x87\x8F\x98`\x01\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0U\x90\x825\x91_[\x82\x81\x10a\"vWPP\x90`\x01\x93\x92\x91\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\0T\x85`\xFF\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01T\x16\x1B\x14a\"\x0FW[P\x97a!\xFC\x83` \x84\x015\x93a!\xF5a\x15\xCF`@\x83\x01a\x15\xC9a!\xEF\x82\x86a1nV[\x89a5\x18V[5\x92a0\xD7V[Ra\"\x07\x82\x86a0\xD7V[R\x01\x90a\x1F\xC6V[a\x16Ga\x16@a\"p\x92a\"\"\x85a2\xD3V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x01T\x93\x84\x90aA_V[_a!\xCCV[\x90\x92`\x01\x90\x81\x85\x16a#\x03W\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01\x81\x90U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02_R\x7F\xC1n\xE7>\xEC\x0E\xF4\xD23*$\xCA2h\xED\x9EQ\xB7t\xC2\xC5\xAF_\\Y\xC2]\xBB;t\xD41\x83\x01Ta\"\xF8\x91aA_V[\x93[\x81\x1C\x91\x01a!nV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01_R\x7F\xC3j\xDB\xE7\xD1\xFEcB\x8E\xFA3\xF5/\xCB\xD6\x11]\x89\x17\x12%\x05{\x1E\x1F\x8E~\x98azG\x9F\x83\x01Ta#T\x91\x90aA_V[\x93a\"\xFAV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x11`\x04R`$_\xFD[a#\x95\x81a\x12/\x88\x80a/\xCDV[`@\x81\x015a#\xCE\x81_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15\x15\x90V[\x15a$_WP\x805a#\xDF\x81a<}V[\x15a$4W\x90a$-\x83\x8E`\x01\x95\x94a$\x1Da$\x17` \x87\x015\x96``\x81\x01\x90a$\x12a$\x0C\x83\x83a1nV[\x8Aa5\x18V[a1nV[\x82a7bV[a$'\x83\x8Aa0\xD7V[Ra0\xD7V[R\x01a\x1F\x96V[\x7F9\xA9@\xC5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xF9\x84\x9E\xA3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xCF\x1B\t<\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7F>\xE5\xAE\xB5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa$\xF2a/\x0EV[_s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81\x16\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0\x82\x80\xA3\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Wa%\xAEa/\x0EV[a%\xB6a/zV[a%\xBEa/zV[`\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x17\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0U\x7Fb\xE7\x8C\xEA\x01\xBE\xE3 \xCDNB\x02p\xB5\xEAt\0\r\x11\xB0\xC9\xF7GT\xEB\xDB\xFCTK\x05\xA2X` `@Q3\x81R\xA1\0[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16`@Q\x90\x15\x15\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` `@Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T`@Q\x90\x81R\xF3[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x160\x03a'\x97W` `@Q\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x81R\xF3[\x7F\xE0|\x8D\xBA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`@`\x03\x196\x01\x12a\x1C\xC4Wa'\xD3a+!V[`$5g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa'\xF3\x906\x90`\x04\x01a,\x02V[\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16\x800\x14\x90\x81\x15a*MW[Pa'\x97Wa(Ca/\x0EV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x91`@Q\x7FR\xD1\x90-\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` \x81`\x04\x81\x87Z\xFA_\x91\x81a*\x19W[Pa(\xC3W\x83\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x80\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBC\x85\x92\x03a)\xEEWP\x82;\x15a)\xC3W\x80\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x17\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCU\x7F\xBC|\xD7Z \xEE'\xFD\x9A\xDE\xBA\xB3 A\xF7U!M\xBCk\xFF\xA9\x0C\xC0\"[9\xDA.\\-;_\x80\xA2\x80Q\x15a)\x92Wa)\x90\x91a4\x11V[\0[PP4a)\x9BW\0[\x7F\xB3\x98\x97\x9F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7FL\x9C\x8C\xE3\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7F\xAA\x1DI\xA4\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x90\x91P` \x81=` \x11a*EW[\x81a*5` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x90\x85a(\x92V[=\x91Pa*(V[\x90Ps\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F6\x08\x94\xA1;\xA1\xA3!\x06g\xC8(I-\xB9\x8D\xCA> v\xCC75\xA9 \xA3\xCAP]8+\xBCT\x16\x14\x15\x83a(6V[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W` \x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T`@Q\x90\x81R\xF3[4a\x1C\xC4W` `\x03\x196\x01\x12a\x1C\xC4W` a\x08\x90`\x045a0\xEBV[4a\x1C\xC4W_`\x03\x196\x01\x12a\x1C\xC4W\x80\x7F2.0.0-alpha.2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0` \x92R\xF3[`\x045\x90s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x16\x82\x03a\x1C\xC4WV[`@\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`A`\x04R`$_\xFD[\x90`\x1F`\x1F\x19\x91\x01\x16\x81\x01\x90\x81\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11\x17a+`W`@RV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x1F\x01`\x1F\x19\x16` \x01\x90V[\x92\x91\x92a+\xD8\x82a+\xB0V[\x91a+\xE6`@Q\x93\x84a+\x8DV[\x82\x94\x81\x84R\x81\x83\x01\x11a\x1C\xC4W\x82\x81` \x93\x84_\x96\x017\x01\x01RV[\x90\x80`\x1F\x83\x01\x12\x15a\x1C\xC4W\x81` a,\x1D\x935\x91\x01a+\xCCV[\x90V[\x90`\x1F\x19`\x1F` \x80\x94\x80Q\x91\x82\x91\x82\x87R\x01\x86\x86\x01^_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[\x91\x90\x82\x03\x91\x82\x11a#ZWV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x16\x80\x15a-\x13Ws\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x82\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x82\x16\x17\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0U\x16\x7F\x8B\xE0\x07\x9CS\x16Y\x14\x13D\xCD\x1F\xD0\xA4\xF2\x84\x19I\x7F\x97\"\xA3\xDA\xAF\xE3\xB4\x18okdW\xE0_\x80\xA3V[\x7F\x1EO\xBD\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R_`\x04R`$_\xFD[`@Q\x7F<\xAD\xF4I\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R` \x81`$\x81s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\xBEW[P` s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x91`\x04`@Q\x80\x94\x81\x93\x7F\\\x97Z\xBB\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x16Z\xFA\x90\x81\x15a\x1C\xB9W_\x91a.\x83W[P\x80\x15a.ZW\x90V[P`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16\x90V[\x90P` \x81=` \x11a.\xB6W[\x81a.\x9E` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQ\x80\x15\x15\x81\x03a\x1C\xC4W_a.PV[=\x91Pa.\x91V[\x90P` \x81=` \x11a/\x06W[\x81a.\xD9` \x93\x83a+\x8DV[\x81\x01\x03\x12a\x1C\xC4WQs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x81\x03a\x1C\xC4W` a-\xFAV[=\x91Pa.\xCCV[s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F\x90\x16\xD0\x9Dr\xD4\x0F\xDA\xE2\xFD\x8C\xEA\xC6\xB6#Lw\x06!O\xD3\x9C\x1C\xD1\xE6\t\xA0R\x8C\x19\x93\0T\x163\x03a/NWV[\x7F\x11\x8C\xDA\xA7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R3`\x04R`$_\xFD[`\xFF\x7F\xCD^\xD1\\n\x18~w\xE9\xAE\xE8\x81\x84\xC2\x1FO!\x82\xABX'\xCB;~\x07\xFB\xED\xCDc\xF03\0T\x16a/\xA5WV[\x7F\xD9<\x06e\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x81`\x05\x1B6\x03\x83\x13a\x1C\xC4WV[g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a+`W`\x05\x1B` \x01\x90V[\x90a0C\x82a0!V[a0P`@Q\x91\x82a+\x8DV[\x82\x81R`\x1F\x19a0`\x82\x94a0!V[\x01\x90` 6\x91\x017V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFFa\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`2`\x04R`$_\xFD[\x80Q\x82\x10\x15a0\xAAW` \x91`\x05\x1B\x01\x01\x90V[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x81\x10\x15a0\xAAW\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03_R` _ \x01\x90_\x90V[\x80T\x82\x10\x15a0\xAAW_R` _ \x01\x90_\x90V[`@Q\x90a1c\x82a+DV[_` \x83\x82\x81R\x01RV[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90\x82\x10\x15a0\xAAWa,\x1D\x91`\x05\x1B\x81\x01\x90a1nV[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xA1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90` \x80\x83Q\x92\x83\x81R\x01\x92\x01\x90_[\x81\x81\x10a2\x15WPPP\x90V[\x82Q\x84R` \x93\x84\x01\x93\x90\x92\x01\x91`\x01\x01a2\x08V[\x905\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x805\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W` \x01\x91\x816\x03\x83\x13a\x1C\xC4WV[`\xFF\x7F\xF0\xC5~\x16\x84\r\xF0@\xF1P\x88\xDC/\x81\xFE9\x1C9#\xBE\xC7>#\xA9f.\xFC\x9C\"\x9Cj\0T`@\x1C\x16\x15a2\xABWV[\x7F\xD7\xE6\xBC\xF8\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x01a1AV[_\x19\x82\x93\x92T\x91`\x03\x1B\x92\x83\x1B\x92\x1B\x19\x16\x17\x90UV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`W\x80`\x01a3V\x92\x01\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02U\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x02a1AV[\x80Th\x01\0\0\0\0\0\0\0\0\x81\x10\x15a+`Wa3V\x91`\x01\x82\x01\x81Ua1AV[\x90_\x80\x91` \x81Q\x91\x01\x84Z\xF4\x80\x80a4\xC5W[\x15a4EWPP`@Q=\x81R=_` \x83\x01>` =\x82\x01\x01`@R\x90V[\x15a4\x8CWs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x90\x7F\x99\x96\xB3\x15\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R\x16`\x04R`$_\xFD[=\x15a4\x9DW`@Q=_\x82>=\x90\xFD[\x7F\xD6\xBD\xA2u\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[P=\x15\x15\x80a4%WP\x81;\x15\x15a4%V[\x91\x90\x81\x10\x15a0\xAAW`\x05\x1B\x81\x015\x90\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xC1\x816\x03\x01\x82\x12\x15a\x1C\xC4W\x01\x90V[\x90`@\x81\x01a5'\x81\x83a/\xCDV[\x92\x90P_[\x83\x81\x10a5:WPPPPPV[a5[a5Q\x82a5K\x86\x86a/\xCDV[\x90a4\xD8V[` \x81\x01\x90a2+V[\x81\x01``\x82\x82\x03\x12a\x1C\xC4W\x815\x91s\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x83\x16\x80\x93\x03a\x1C\xC4W` \x81\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4W\x82a5\xA8\x91\x83\x01a,\x02V[\x91`@\x82\x015g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x11a\x1C\xC4Wa5\xC7\x92\x01a,\x02V[\x90`@Q\x91\x7F3\xA8\x92\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x83R\x88`\x04\x84\x01R`@`$\x84\x01R_\x83\x80a6\x0C`D\x82\x01\x86a, V[\x03\x81\x83\x88Z\xF1\x92\x83\x15a\x1C\xB9W_\x93a6\xAFW[P\x82Q` \x84\x01 \x81Q` \x83\x01 \x03a6tWP`\x01\x93\x92\x91\x7F\xCD\xDB2z\xDB1\xFET7\xDF*\x8Ch0\x1B\xB1:k\xAA\xE42\xA8\x04\x83\x8C\xAA\xF6\x82Pj\xAD\xF1\x91a6k`@Q\x92\x83\x92\x83a?-V[\x03\x90\xA2\x01a5,V[\x90Pa6\xAB`@Q\x92\x83\x92\x7F\xC5\x04\xFA\xDA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x84R`\x04\x84\x01a?-V[\x03\x90\xFD[\x90\x92P=\x80_\x83>a6\xC1\x81\x83a+\x8DV[\x81\x01\x90` \x81\x83\x03\x12a\x1C\xC4W\x80Q\x90g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x82\x11a\x1C\xC4W\x01\x81`\x1F\x82\x01\x12\x15a\x1C\xC4W\x80Q\x90a6\xF8\x82a+\xB0V[\x92a7\x06`@Q\x94\x85a+\x8DV[\x82\x84R` \x83\x83\x01\x01\x11a\x1C\xC4W\x81_\x92` \x80\x93\x01\x83\x86\x01^\x83\x01\x01R\x91_a6 V[`\x1F\x82` \x94\x93`\x1F\x19\x93\x81\x86R\x86\x86\x017_\x85\x82\x86\x01\x01R\x01\x16\x01\x01\x90V[`@\x90a,\x1D\x94\x92\x81R\x81` \x82\x01R\x01\x91a7+V[\x90a7m\x81\x80a/\xCDV[_[\x81\x81\x10a9\x17WPPPa7\x86` \x82\x01\x82a/\xCDV[_[\x81\x81\x10a8\xA8WPPPa7\x9F`@\x82\x01\x82a/\xCDV[_[\x81\x81\x10a89WPPP\x80``a7\xB9\x92\x01\x90a/\xCDV[\x90\x91_[\x82\x81\x10a7\xCAWPPPPV[a7\xD5\x81\x84\x86a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a7\xF0W[\x01a7\xBDV[\x82\x7F\xA4\x94\xDA\xC4\xB7\x18HCX?\x97.\x06x>,;\xB4\x7FO\x017\xB8\xDFR\xA8`\xDF\x07!\x9F\x8Ca8 a5Q\x84\x88\x8Aa4\xD8V[\x90a81`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a7\xEAV[a8D\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8_W[\x01a7\xA1V[\x85\x7F\x9Ca\xB2\x90\xF61\t\x7FV'<\xF4\xDA\xF4\r\xF1\xFF\x9C\xCC3\xF1\x01\xD4d\x83}\xA1\xF5\xAE\x18\xBDYa8\x8Fa5Q\x84\x87\x89a4\xD8V[\x90a8\xA0`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8YV[a8\xB3\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a8\xCEW[\x01a7\x88V[\x85\x7FH$8s\xB4u-\xDC\xB4^\r{\x11\xC4\xC2fX>^\t\x9A\x0By\x8F\xDD\x9C\x1A\xF7\xD4\x93$\xF3a8\xFEa5Q\x84\x87\x89a4\xD8V[\x90a9\x0F`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a8\xC8V[a9\"\x81\x83\x85a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x80\x92\x14a9=W[\x01a7oV[\x85\x7F:\x13M\x01\xC0x\x03\0<c0\x17\x17\xDD\xC4a.lG\xAE@\x8E\xEE\xA3\",\xDE\xD52\xD0*\xE6a9ma5Q\x84\x87\x89a4\xD8V[\x90a9~`@Q\x92\x83\x92\x87\x84a7KV[\x03\x90\xA2a97V[\x80\x15\x80\x15a9\xD8W[\x80\x15a9\xD0W[\x80\x15a9\xC0W[a9\xBAWd\x01\0\0\x03\xD0\x19`\x07\x81\x80\x93\x81\x81\x80\t\t\x08\x91\x80\t\x14\x90V[PP_\x90V[Pd\x01\0\0\x03\xD0\x19\x82\x10\x15a9\x9DV[P\x81\x15a9\x96V[Pd\x01\0\0\x03\xD0\x19\x81\x10\x15a9\x8FV[\x90\x93\x92\x90\x91_\x90\x80\x84\x03a<aWPPd\x01\0\0\x03\xD0\x19_\x91\x85\x08a:\x11WPP\x90P_\x90_\x90V[d\x01\0\0\x03\xD0\x19\x80`\x01\x81\x80a:x\x81\x80\x80a:h\x9A\x81\x80\x8F\x80\t\x96\x87\x92\x81\x80\x80\x80\x80\x8F\x81\x81\x81\x92\t\x99\x87\t`\x04\t\x97\x80\t_\t\x92\x80\t`\x03\t\x08\x91\x81a:[\x81\x83\x80\x08\x82a,EV[\x81\x85\x80\t\x08\x9D\x8E\x83a,EV[\x90\x08\x90\t\x93\x80\t`\x08\t\x83a,EV[\x90\x08\x96\t`\x02\t\x93\x91\x90[\x84\x15\x15\x85\x81a<PW[P\x80a<HW[\x15a;\xEAW\x80\x94`\x01\x90d\x01\0\0\x03\xD0\x19\x91\x81\x84\x92[a:\xFEWPPPP\x80a:\xD1WP\x90d\x01\0\0\x03\xD0\x19\x80\x92\x81\x80\x87\x80\t\x80\x92\t\x95\t\x90\t\x90V[\x80\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`$\x92R`\x12`\x04R\xFD[\x92\x97\x91\x92\x80\x15a;\xBDW\x80\x89\x04\x91\x80\x94a;\x90Wd\x01\0\0\x03\xD0\x19\x90\x83\td\x01\0\0\x03\xD0\x19\x03d\x01\0\0\x03\xD0\x19\x81\x11a#ZWd\x01\0\0\x03\xD0\x19\x90\x86\x94\x08\x93\x98\x81\x92\x82\x81\x02\x92\x81\x84\x04\x14\x90\x15\x17\x15a;cW\x90a;Z\x91a,EV[\x90\x92\x90\x80a:\xAAV[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x11`\x04R\xFD[`$\x86\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R`\x12`\x04R\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x12`\x04R`$_\xFD[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x0E`$\x82\x01R\x7FInvalid number\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0`D\x82\x01R\xFD[P`\x01a:\x94V[d\x01\0\0\x03\xD0\x19\x91P\x14\x15_a:\x8DV[d\x01\0\0\x03\xD0\x19\x92\x91\x95a<t\x94a?RV[\x93\x90\x91\x90a:\x83V[\x80_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ T\x15_\x14a=-Wa<\xDA\x81\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0a3\xEFV[\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\0T\x90_R\x7F],\xC4K\xCFA\xD62H\x82\xF1\xC0\xD7\t\xF1\xB9\xAE \xCA\xEE\xBC\xBF#X\x12z=\n\x8C\"\xCC\x01` R`@_ U`\x01\x90V[P_\x90V[\x80_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ T\x15_\x14a=-Wa=\x8F\x81\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x90_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R`@_ U`\x01\x90V[\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nTa?)Wa>\x99\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03a3\xEFV[\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x03T\x7F\xCC\x1D/\x83\x84E\xDBz\xECC\x1D\xF9\xEE\x8A\x87\x1F@\xE7\xAA^\x06O\xC0Vc>\xF8\xC6\x0F\xAB{\x06_R\x7Fv*F\xA1\x1CF\x0B\x9B\xCB+\xB9\x86Q\xDA\x03\xB1\x92\xA0.*3\xAB&\xDA\x9B\xF9\xEDS\x82k\xC9\x04` R\x7F]\xEB\x94n\xBB\xF6\x17\xE3c1\xF9\xB8\xF5\x82\xF1\x16E#(9\xEC5\xAAN\xA6\xE3\x12LBb\xE9nU`\x01\x90V[_\x90V[\x90\x91a?Da,\x1D\x93`@\x84R`@\x84\x01\x90a, V[\x91` \x81\x84\x03\x91\x01Ra, V[\x94\x92\x90\x93\x91\x85\x15\x80aAWW[aALW\x80\x15\x80aADW[aA<W`@Q`\x80\x91a?\x7F\x83\x83a+\x8DV[\x826\x837\x84\x15a;\xBDW\x84`\x01\x80\t\x80\x83R\x93\x85\x85`\x01\t\x98` \x84\x01\x99\x8AR`@\x84\x01\x92\x86\x84R\x87\x84Q`\x01\t\x93``\x86\x01\x94\x85R`@Q\x9A\x87\x8C\x01\x95\x8C\x87\x10g\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x88\x11\x17a+`W\x8A\x80\x97\x95\x81\x96\x94\x82\x95`@RQ\x90\t\x8DRQ\x90\t\x94` \x8B\x01\x95\x86RQ\x90\t\x98`@\x89\x01\x99\x8ARQ\x90\t``\x87\x01\x90\x81R\x86Q\x88Q\x14\x80\x15\x90aA0W[\x15a@\xD2W\x84\x92\x83\x80\x80\x93\x81`@Q\x9C\x85a@*\x8F\x97\x88a+\x8DV[6\x877Q\x8CQa@:\x90\x83a,EV[\x90\x08\x84RQ\x85Qa@K\x90\x83a,EV[\x90\x08\x98` \x83\x01\x99\x8AR\x81\x80\x8B\x81\x80\x80\x80\x89Q\x8AQ\x90\t\x93`@\x8A\x01\x94\x85R\x81\x85Q\x8BQ\x90\t``\x90\x9A\x01\x99\x8ARQ\x80\t\x88Qa@\x88\x90\x83a,EV[\x90\x08\x81\x80\x87Q\x85Q\x90\t`\x02\ta@\x9F\x90\x83a,EV[\x90\x08\x9CQ\x93Q\x90Q\x90\ta@\xB3\x8C\x83a,EV[\x90\x08\x90\t\x92Q\x90Q\x90\ta@\xC7\x90\x83a,EV[\x90\x08\x94Q\t\x91\x92\x91\x90V[`d`@Q\x7F\x08\xC3y\xA0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x81R` `\x04\x82\x01R`\x1E`$\x82\x01R\x7FUse jacDouble function instead\0\0`D\x82\x01R\xFD[P\x81Q\x81Q\x14\x15a@\x0EV[PPP`\x01\x90V[P\x81\x15a?kV[\x94P\x92P`\x01\x91\x90PV[P\x84\x15a?_V[_\x90` \x92`@Q\x90\x84\x82\x01\x92\x83R`@\x82\x01R`@\x81RaA\x82``\x82a+\x8DV[`@Q\x91\x82\x91Q\x80\x91\x83^\x81\x01\x83\x81R\x03\x90`\x02Z\xFA\x15a\x1C\xB9W_Q\x90V[\x81Q\x91\x90`A\x83\x03aA\xD2WaA\xCB\x92P` \x82\x01Q\x90```@\x84\x01Q\x93\x01Q_\x1A\x90aE\x16V[\x91\x92\x90\x91\x90V[PP_\x91`\x02\x91\x90V[`\x04\x81\x10\x15aB\x87W\x80aA\xEEWPPV[`\x01\x81\x03aB\x1EW\x7F\xF6E\xEE\xDF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04_\xFD[`\x02\x81\x03aBRWP\x7F\xFC\xE6\x98\xF7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[`\x03\x14aB\\WPV[\x7F\xD7\x8B\xCE\x0C\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`\x04R`$_\xFD[\x7FNH{q\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0_R`!`\x04R`$_\xFD[aB\xBE\x81\x80a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aB\xF2\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aB\xFC\x82\x80a/\xCDV[aC\x05\x91aE\xA5V[\x91` \x81\x01\x90aC\x15\x82\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aCI\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x91aCT\x90\x82a/\xCDV[aC]\x91aE\xA5V[`@\x82\x01aCk\x81\x84a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\x9F\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x90aC\xAA\x90\x84a/\xCDV[aC\xB3\x91aE\xA5V[\x91``\x84\x01\x93aC\xC3\x85\x82a/\xCDV[c\xFF\xFF\xFF\xFF\x91P\x16aC\xF7\x90b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x94aD\x01\x91a/\xCDV[aD\n\x91aE\xA5V[\x94`@Q\x97\x88\x97`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16` \x89\x01R\x80Q` \x81\x92\x01`$\x8A\x01^\x87\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`$\x82\x01R\x81Q` \x81\x93\x01`(\x83\x01^\x01`$\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01\x90`\xE0\x1B\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x16`\x04\x82\x01R\x81Q` \x81\x93\x01`\x08\x83\x01^\x01`\x04\x01`\x04\x81\x01_\x90R\x03`\x04\x01`\x1F\x19\x81\x01\x82Ra,\x1D\x90\x82a+\x8DV[\x91\x90\x7F\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF]WnsW\xA4P\x1D\xDF\xE9/Fh\x1B \xA0\x84\x11aE\x9AW\x91` \x93`\x80\x92`\xFF_\x95`@Q\x94\x85R\x16\x86\x84\x01R`@\x83\x01R``\x82\x01R\x82\x80R`\x01Z\xFA\x15a\x1C\xB9W_Qs\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x81\x16\x15aE\x90W\x90_\x90_\x90V[P_\x90`\x01\x90_\x90V[PPP_\x91`\x03\x91\x90V[``\x92\x91_\x91[\x81\x83\x10aE\xB8WPPPV[\x90\x91\x93aE\xFFc\xFF\xFF\xFF\xFFaE\xD1a5Q\x88\x87\x87a4\xD8V[\x90P`\x02\x1C\x16b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[aF\ra5Q\x87\x86\x86a4\xD8V[aF\x1B\x88\x87\x87\x95\x94\x95a4\xD8V[5\x90`\x02\x82\x10\x15a\x1C\xC4W`\x01\x94` \x94\x7F\xFF\xFF\xFF\xFF\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x86\x84aF\xDF\x97`\x04\x97\x96aF\x84\x89\x98b\xFF\0\xFFc\xFF\0\xFF\0\x82`\x08\x1B\x16\x91`\x08\x1C\x16\x17c\xFF\xFF\xFF\xFF\x80\x82`\x10\x1B\x16\x91`\x10\x1C\x16\x17\x90V[\x95\x85`@Q\x9C\x89\x8E\x9AQ\x91\x82\x91\x01\x88\x8C\x01^\x89\x01\x93`\xE0\x1B\x16\x85\x84\x01R`$\x83\x017\x01\x01\x91`\xE0\x1B\x16\x83\x82\x01R\x03\x01\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xE4\x81\x01\x84R\x01\x82a+\x8DV[\x94\x01\x91\x90aE\xACV\xFE\xA1dsolcC\0\x08$\0\n",
+    );
     #[derive(serde::Serialize, serde::Deserialize)]
     #[derive(Default, Debug, PartialEq, Eq, Hash)]
     /**Custom error with signature `AddressEmptyCode(address)` and selector `0x9996b315`.
@@ -5163,13 +5159,13 @@ error OwnableUnauthorizedAccount(address account);
     #[derive(Default, Debug, PartialEq, Eq, Hash)]
     /**Custom error with signature `PointNotOnCurve((uint256,uint256))` and selector `0xb8a0e8a1`.
 ```solidity
-error PointNotOnCurve(Delta.Point point);
+error PointNotOnCurve(Types.Delta point);
 ```*/
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct PointNotOnCurve {
         #[allow(missing_docs)]
-        pub point: <Delta::Point as alloy::sol_types::SolType>::RustType,
+        pub point: <Types::Delta as alloy::sol_types::SolType>::RustType,
     }
     #[allow(
         non_camel_case_types,
@@ -5181,10 +5177,10 @@ error PointNotOnCurve(Delta.Point point);
         use alloy::sol_types as alloy_sol_types;
         #[doc(hidden)]
         #[allow(dead_code)]
-        type UnderlyingSolTuple<'a> = (Delta::Point,);
+        type UnderlyingSolTuple<'a> = (Types::Delta,);
         #[doc(hidden)]
         type UnderlyingRustTuple<'a> = (
-            <Delta::Point as alloy::sol_types::SolType>::RustType,
+            <Types::Delta as alloy::sol_types::SolType>::RustType,
         );
         #[cfg(test)]
         #[allow(dead_code, unreachable_patterns)]
@@ -5227,7 +5223,7 @@ error PointNotOnCurve(Delta.Point point);
             }
             #[inline]
             fn tokenize(&self) -> Self::Token<'_> {
-                (<Delta::Point as alloy_sol_types::SolType>::tokenize(&self.point),)
+                (<Types::Delta as alloy_sol_types::SolType>::tokenize(&self.point),)
             }
             #[inline]
             fn abi_decode_raw_validate(data: &[u8]) -> alloy_sol_types::Result<Self> {
@@ -8897,13 +8893,13 @@ function emergencyStop() external;
     #[derive()]
     /**Function with signature `execute((((bytes32,bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(uint256,uint256),bytes32)[],bytes,bytes))` and selector `0x73ab9916`.
 ```solidity
-function execute(Transaction memory transaction) external;
+function execute(Types.Transaction memory transaction) external;
 ```*/
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct executeCall {
         #[allow(missing_docs)]
-        pub transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+        pub transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
     }
     ///Container type for the return parameters of the [`execute((((bytes32,bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(uint256,uint256),bytes32)[],bytes,bytes))`](executeCall) function.
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
@@ -8920,10 +8916,10 @@ function execute(Transaction memory transaction) external;
         {
             #[doc(hidden)]
             #[allow(dead_code)]
-            type UnderlyingSolTuple<'a> = (Transaction,);
+            type UnderlyingSolTuple<'a> = (Types::Transaction,);
             #[doc(hidden)]
             type UnderlyingRustTuple<'a> = (
-                <Transaction as alloy::sol_types::SolType>::RustType,
+                <Types::Transaction as alloy::sol_types::SolType>::RustType,
             );
             #[cfg(test)]
             #[allow(dead_code, unreachable_patterns)]
@@ -8992,7 +8988,7 @@ function execute(Transaction memory transaction) external;
         }
         #[automatically_derived]
         impl alloy_sol_types::SolCall for executeCall {
-            type Parameters<'a> = (Transaction,);
+            type Parameters<'a> = (Types::Transaction,);
             type Token<'a> = <Self::Parameters<
                 'a,
             > as alloy_sol_types::SolType>::Token<'a>;
@@ -9011,7 +9007,11 @@ function execute(Transaction memory transaction) external;
             }
             #[inline]
             fn tokenize(&self) -> Self::Token<'_> {
-                (<Transaction as alloy_sol_types::SolType>::tokenize(&self.transaction),)
+                (
+                    <Types::Transaction as alloy_sol_types::SolType>::tokenize(
+                        &self.transaction,
+                    ),
+                )
             }
             #[inline]
             fn tokenize_returns(ret: &Self::Return) -> Self::ReturnToken<'_> {
@@ -11424,13 +11424,13 @@ function setKindTableCommitment(bytes32 newKindTableCommitment) external;
     #[derive()]
     /**Function with signature `simulateExecute((((bytes32,bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(bytes32,bytes32,((uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[],(uint8,bytes)[]))[],(uint256,uint256),bytes32)[],bytes,bytes),bool)` and selector `0x87093eba`.
 ```solidity
-function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofVerification) external;
+function simulateExecute(Types.Transaction memory transaction, bool skipRiscZeroProofVerification) external;
 ```*/
     #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
     #[derive(Clone)]
     pub struct simulateExecuteCall {
         #[allow(missing_docs)]
-        pub transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+        pub transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
         #[allow(missing_docs)]
         pub skipRiscZeroProofVerification: bool,
     }
@@ -11450,12 +11450,12 @@ function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofV
             #[doc(hidden)]
             #[allow(dead_code)]
             type UnderlyingSolTuple<'a> = (
-                Transaction,
+                Types::Transaction,
                 alloy::sol_types::sol_data::Bool,
             );
             #[doc(hidden)]
             type UnderlyingRustTuple<'a> = (
-                <Transaction as alloy::sol_types::SolType>::RustType,
+                <Types::Transaction as alloy::sol_types::SolType>::RustType,
                 bool,
             );
             #[cfg(test)]
@@ -11530,7 +11530,7 @@ function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofV
         }
         #[automatically_derived]
         impl alloy_sol_types::SolCall for simulateExecuteCall {
-            type Parameters<'a> = (Transaction, alloy::sol_types::sol_data::Bool);
+            type Parameters<'a> = (Types::Transaction, alloy::sol_types::sol_data::Bool);
             type Token<'a> = <Self::Parameters<
                 'a,
             > as alloy_sol_types::SolType>::Token<'a>;
@@ -11550,7 +11550,7 @@ function simulateExecute(Transaction memory transaction, bool skipRiscZeroProofV
             #[inline]
             fn tokenize(&self) -> Self::Token<'_> {
                 (
-                    <Transaction as alloy_sol_types::SolType>::tokenize(
+                    <Types::Transaction as alloy_sol_types::SolType>::tokenize(
                         &self.transaction,
                     ),
                     <alloy::sol_types::sol_data::Bool as alloy_sol_types::SolType>::tokenize(
@@ -14996,7 +14996,7 @@ the bytecode concatenated with the constructor's ABI-encoded arguments.*/
         ///Creates a new call builder for the [`execute`] function.
         pub fn execute(
             &self,
-            transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+            transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
         ) -> alloy_contract::SolCallBuilder<&P, executeCall, N> {
             self.call_builder(&executeCall { transaction })
         }
@@ -15112,7 +15112,7 @@ the bytecode concatenated with the constructor's ABI-encoded arguments.*/
         ///Creates a new call builder for the [`simulateExecute`] function.
         pub fn simulateExecute(
             &self,
-            transaction: <Transaction as alloy::sol_types::SolType>::RustType,
+            transaction: <Types::Transaction as alloy::sol_types::SolType>::RustType,
             skipRiscZeroProofVerification: bool,
         ) -> alloy_contract::SolCallBuilder<&P, simulateExecuteCall, N> {
             self.call_builder(

--- a/crates/integration-test/src/envs/common/execute.rs
+++ b/crates/integration-test/src/envs/common/execute.rs
@@ -1,7 +1,7 @@
 use alloy::providers::DynProvider;
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionTrait;
-use anoma_pa_evm_bindings::generated::protocol_adapter::ProtocolAdapter as PaContract;
+use anoma_pa_evm_bindings::generated::protocol_adapter::{ProtocolAdapter as PaContract, Types};
 use anyhow::Context;
 
 pub(super) const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
@@ -9,7 +9,7 @@ pub(super) const PANIC_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
 
 pub(in crate::envs) async fn execute_on_pa(
     pa: &PaContract::ProtocolAdapterInstance<DynProvider>,
-    tx: PaContract::Transaction,
+    tx: Types::Transaction,
 ) -> anyhow::Result<alloy::rpc::types::TransactionReceipt> {
     preflight_check(pa, tx.clone()).await?;
 
@@ -42,7 +42,7 @@ pub(in crate::envs) async fn execute_on_pa(
 
 async fn preflight_check(
     pa: &PaContract::ProtocolAdapterInstance<DynProvider>,
-    tx: PaContract::Transaction,
+    tx: Types::Transaction,
 ) -> anyhow::Result<()> {
     match pa.execute(tx).call().await {
         Ok(_) => Ok(()),

--- a/crates/integration-test/src/envs/e2e/mod.rs
+++ b/crates/integration-test/src/envs/e2e/mod.rs
@@ -1,7 +1,7 @@
 use alloy::node_bindings::AnvilInstance;
 use alloy::primitives::B256;
 use alloy::providers::DynProvider;
-use anoma_pa_evm_bindings::generated::protocol_adapter::ProtocolAdapter as PaContract;
+use anoma_pa_evm_bindings::generated::protocol_adapter::{ProtocolAdapter as PaContract, Types};
 use anoma_pa_testkit::environment::CommitmentTree as CoreCommitmentTree;
 use anoma_pa_testkit::environment::Environment as CoreEnvironment;
 use anoma_pa_testkit::environment::ProtocolAdapter as CoreProtocolAdapter;
@@ -72,7 +72,7 @@ impl CoreProtocolAdapter for ProtocolAdapter {
 
         self.assert_root_consistency(&tx).await?;
 
-        let pa_tx: PaContract::Transaction = tx.into();
+        let pa_tx: Types::Transaction = tx.into();
 
         crate::envs::common::execute::execute_on_pa(&self.pa, pa_tx).await?;
 

--- a/crates/integration-test/src/envs/local/mod.rs
+++ b/crates/integration-test/src/envs/local/mod.rs
@@ -1,7 +1,7 @@
 use alloy::node_bindings::AnvilInstance;
 use alloy::primitives::B256;
 use alloy::providers::DynProvider;
-use anoma_pa_evm_bindings::generated::protocol_adapter::ProtocolAdapter as PaContract;
+use anoma_pa_evm_bindings::generated::protocol_adapter::{ProtocolAdapter as PaContract, Types};
 use anoma_pa_testkit::environment::CommitmentTree as CoreCommitmentTree;
 use anoma_pa_testkit::environment::Environment as CoreEnvironment;
 use anoma_pa_testkit::environment::ProtocolAdapter as CoreProtocolAdapter;
@@ -77,7 +77,7 @@ impl CoreProtocolAdapter for ProtocolAdapter {
 
         self.assert_root_consistency(&tx).await?;
 
-        let pa_tx: PaContract::Transaction = tx.into();
+        let pa_tx: Types::Transaction = tx.into();
 
         crate::envs::common::execute::execute_on_pa(&self.pa, pa_tx).await?;
 

--- a/crates/integration-test/tests/aggregation_instance.rs
+++ b/crates/integration-test/tests/aggregation_instance.rs
@@ -7,7 +7,7 @@
 mod common;
 
 use alloy::sol_types::SolError;
-use anoma_pa_evm_bindings::generated::protocol_adapter::ProtocolAdapter as PaContract;
+use anoma_pa_evm_bindings::generated::protocol_adapter::{ProtocolAdapter as PaContract, Types};
 use anoma_pa_evm_integration_test::deploy::pa::protocol_adapter;
 use anoma_pa_evm_integration_test::envs::local::Environment as EvmLocalEnv;
 use anoma_pa_evm_integration_test::state::actors::default_signer;
@@ -33,7 +33,7 @@ where
     let env = env.context("env setup failed")?;
     let proven = prove_trivial_tx(&env).await?;
 
-    let tx: PaContract::Transaction = proven.into_arm().into();
+    let tx: Types::Transaction = proven.into_arm().into();
 
     let provider = default_signer(&env)?;
     let pa = protocol_adapter(pa_address(&env)?, provider);

--- a/crates/integration-test/tests/conversion.rs
+++ b/crates/integration-test/tests/conversion.rs
@@ -3,7 +3,7 @@
 //! themselves live in the testkit; this asserts the EVM conversion seam, which
 //! needs the bindings.)
 
-use anoma_pa_evm_bindings::generated::protocol_adapter::ProtocolAdapter as PaContract;
+use anoma_pa_evm_bindings::generated::protocol_adapter::Types;
 use anoma_pa_testkit::environment::Prover;
 use anoma_pa_testkit::fixtures::trivial;
 use anoma_pa_testkit::prover::LocalProver;
@@ -15,7 +15,7 @@ async fn proven_transaction_into_pa_transaction_yields_actions_and_delta_proof()
     let tx = LocalProver.prove(&actions).await.unwrap();
     let arm_tx: ArmTxn = tx.into_arm();
 
-    let pa_tx: PaContract::Transaction = arm_tx.into();
+    let pa_tx: Types::Transaction = arm_tx.into();
     assert!(!pa_tx.actions.is_empty());
     assert!(!pa_tx.deltaProof.is_empty());
 }


### PR DESCRIPTION
Move `Delta.Point` there as `Types.Delta`. The selectors are unchanged, but forge-bind moves the generated Rust structs into a `Types` module.