### PR TITLE
test(contracts): exclude congruent verifying keys from the mismatch fuzz

### DIFF
--- a/contracts/test/proofs/DeltaProof.t.sol
+++ b/contracts/test/proofs/DeltaProof.t.sol
@@ -140,7 +140,7 @@ contract DeltaProofTest is Test {
     ) public {
         kind = bound(kind, 1, DeltaGen.SECP256K1_ORDER - 1);
         valueCommitmentRandomness = bound(valueCommitmentRandomness, 1, DeltaGen.SECP256K1_ORDER - 1);
-        vm.assume(verifyingKey1 != verifyingKey2);
+        vm.assume(uint256(verifyingKey1).modOrder() != uint256(verifyingKey2).modOrder());
 
         DeltaGen.InstanceInputs memory deltaInputs = DeltaGen.InstanceInputs({
             kind: kind, quantity: 0, consumed: consumed, valueCommitmentRandomness: valueCommitmentRandomness


### PR DESCRIPTION
ECDSA reduces the message modulo the curve order before signing and recovery, so two verifying keys that differ by exactly the order are the same message and the signature over one verifies against the other. The fuzzer found such a pair (2^256 - 1 and its reduction), for which no DeltaMismatch revert can happen. Assume the keys apart modulo the order, as the randomness-mismatch test already does for its scalars.